### PR TITLE
feat: auto-delete draft after sending

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -92,7 +92,7 @@ Always pass `--config ~/.mcporter/mcporter.json` unless a local `config/mcporter
 | `ofw_list_message_folders` | Get folder IDs (inbox, sent, etc.) — call this first |
 | `ofw_list_messages(folderId)` | List messages in a folder |
 | `ofw_get_message(messageId)` | Read a message. ⚠️ Marks unread messages as read. |
-| `ofw_send_message(subject, body, recipientIds[])` | Send a message. Get `recipientIds` from `ofw_get_profile`. |
+| `ofw_send_message(subject, body, recipientIds[], draftId?)` | Send a message. Pass `draftId` to auto-delete the draft after sending. |
 | `ofw_list_drafts` | List saved drafts |
 | `ofw_save_draft(subject, body, recipientIds?, messageId?, replyToId?)` | Create or update a draft |
 | `ofw_delete_draft(messageId)` | Delete a draft |
@@ -131,7 +131,7 @@ Always pass `--config ~/.mcporter/mcporter.json` unless a local `config/mcporter
 
 **Draft before sending (sensitive messages):**
 1. `ofw_save_draft(subject, body)` → review with user
-2. `ofw_send_message(...)` after approval, then `ofw_delete_draft(draftId)`
+2. `ofw_send_message(..., draftId)` after approval — draft is auto-deleted on send
 
 **Check what's coming up:**
 - `ofw_get_notifications` for a quick summary

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -36,7 +36,7 @@ export const toolDefinitions: Tool[] = [
   },
   {
     name: 'ofw_send_message',
-    description: 'Send a message via OurFamilyWizard',
+    description: 'Send a message via OurFamilyWizard. If sending from a draft, pass draftId to automatically delete the draft after sending.',
     annotations: { destructiveHint: true },
     inputSchema: {
       type: 'object',
@@ -47,6 +47,10 @@ export const toolDefinitions: Tool[] = [
           type: 'array',
           items: { type: 'number' },
           description: 'Array of recipient user IDs (get from ofw_get_profile)',
+        },
+        draftId: {
+          type: 'number',
+          description: 'ID of the draft to delete after sending (omit if not sending from a draft)',
         },
       },
       required: ['subject', 'body', 'recipientIds'],
@@ -131,10 +135,11 @@ export async function handleTool(
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
     }
     case 'ofw_send_message': {
-      const { subject, body, recipientIds } = args as {
+      const { subject, body, recipientIds, draftId } = args as {
         subject: string;
         body: string;
         recipientIds: number[];
+        draftId?: number;
       };
       const data = await client.request('POST', '/pub/v3/messages', {
         subject, body, recipientIds,
@@ -142,6 +147,11 @@ export async function handleTool(
         draft: false,
         includeOriginal: false,
       });
+      if (draftId !== undefined) {
+        const form = new FormData();
+        form.append('messageIds', String(draftId));
+        await client.request('DELETE', '/pub/v1/messages', form);
+      }
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
     }
     case 'ofw_list_drafts': {

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -87,6 +87,47 @@ describe('ofw_send_message', () => {
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe('text');
   });
+
+  it('does not delete a draft when draftId is not provided', async () => {
+    const client = makeClient({ id: 200, status: 'sent' });
+
+    await handleTool('ofw_send_message', {
+      subject: 'Hello',
+      body: 'World',
+      recipientIds: [123],
+    }, client);
+
+    expect(client.request).toHaveBeenCalledTimes(1);
+    expect(client.request).not.toHaveBeenCalledWith('DELETE', expect.anything(), expect.anything());
+  });
+
+  it('deletes the draft after sending when draftId is provided', async () => {
+    const c = new OFWClient();
+    const spy = vi.spyOn(c, 'request')
+      .mockResolvedValueOnce({ id: 200, status: 'sent' })
+      .mockResolvedValueOnce({});
+
+    const result = await handleTool('ofw_send_message', {
+      subject: 'Hello',
+      body: 'World',
+      recipientIds: [123],
+      draftId: 42,
+    }, c);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(1, 'POST', '/pub/v3/messages', {
+      subject: 'Hello',
+      body: 'World',
+      recipientIds: [123],
+      attachments: { myFileIDs: [] },
+      draft: false,
+      includeOriginal: false,
+    });
+    expect(spy).toHaveBeenNthCalledWith(2, 'DELETE', '/pub/v1/messages', expect.any(FormData));
+    const deleteForm = spy.mock.calls[1][2] as FormData;
+    expect(deleteForm.get('messageIds')).toBe('42');
+    expect(JSON.parse(result.content[0].text)).toEqual({ id: 200, status: 'sent' });
+  });
 });
 
 describe('ofw_list_drafts', () => {


### PR DESCRIPTION
## Summary

- Adds optional `draftId` parameter to `ofw_send_message`
- When provided, the draft is deleted immediately after a successful send
- Replaces the prior two-step workflow of calling `ofw_send_message` then `ofw_delete_draft` separately
- Two new tests cover both branches: no-delete when `draftId` omitted, delete with correct FormData when provided

## Test plan

- [ ] `ofw_send_message` without `draftId` → single request, no DELETE call
- [ ] `ofw_send_message` with `draftId` → POST send fires first, DELETE draft fires second with correct `messageIds`
- [ ] Full suite: `npm test` (51 tests, all passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)