### PR TITLE
Refactor HTTP client and response handling; add inline attachment support

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -31962,12 +31962,13 @@ ${text}` : text;
     }, null, 2) }] };
   });
   server2.registerTool("ofw_download_attachment", {
-    description: "Download an OFW message attachment by fileId. Bytes are saved to disk; the tool returns the absolute path, mime type, and size so the caller can then read/analyze the file. fileId comes from the attachments array on ofw_get_message. Saves under ~/Downloads/ofw-mcp/ by default \u2014 a user-accessible location so sandboxed MCP hosts (e.g. Claude Desktop) can read the file back. Override with OFW_ATTACHMENTS_DIR or the saveTo argument. Re-downloading is a no-op if the file is already on disk.",
+    description: "Download an OFW message attachment by fileId. By default, bytes are saved to disk (~/Downloads/ofw-mcp/) and the response carries the absolute path, mime type, and size for the caller to read back. Pass inline:true to skip disk entirely and return the bytes as MCP content blocks \u2014 images come back as ImageContent (the model sees them directly); other files come back as an EmbeddedResource blob. Use inline for small files where you want the model to read content immediately and the host is sandboxed; use disk for large files or when you want a persistent local copy. fileId comes from attachments[].fileId on ofw_get_message. Override disk destination with OFW_ATTACHMENTS_DIR or saveTo. Re-downloading to the same path is a no-op (disk mode only).",
     annotations: { readOnlyHint: false },
     inputSchema: {
       fileId: external_exports.number().describe("Attachment file id (from ofw_get_message \u2192 attachments[].fileId)"),
-      saveTo: external_exports.string().describe("Absolute path or directory to write to. If a directory, the OFW filename is used. Default: ~/Downloads/ofw-mcp/<fileId>-<filename>").optional(),
-      force: external_exports.boolean().describe("Re-download even if already on disk. Default false.").optional()
+      inline: external_exports.boolean().describe("If true, return bytes inline as MCP content (image for image/*, embedded resource blob otherwise) and skip the disk write. Default false (writes to disk).").optional(),
+      saveTo: external_exports.string().describe("Absolute path or directory to write to. If a directory, the OFW filename is used. Default: ~/Downloads/ofw-mcp/<fileId>-<filename>. Ignored when inline:true.").optional(),
+      force: external_exports.boolean().describe("Re-download even if already on disk. Default false. Ignored when inline:true (inline always fetches fresh bytes, or reuses an on-disk copy if present).").optional()
     }
   }, async (args) => {
     const fileId = args.fileId;
@@ -31986,6 +31987,44 @@ ${text}` : text;
       });
       cached2 = getAttachment(fileId);
       if (!cached2) throw new Error(`failed to fetch metadata for fileId ${fileId}`);
+    }
+    if (args.inline) {
+      let bytes;
+      let mimeType;
+      let fileName;
+      if (cached2.downloadedPath) {
+        try {
+          bytes = readFileSync(cached2.downloadedPath);
+          mimeType = cached2.mimeType;
+          fileName = cached2.fileName;
+        } catch {
+          const response2 = await client2.requestBinary("GET", `/pub/v1/myfiles/${fileId}/data`);
+          bytes = response2.body;
+          mimeType = response2.contentType ?? cached2.mimeType;
+          fileName = response2.suggestedFileName ?? cached2.fileName;
+        }
+      } else {
+        const response2 = await client2.requestBinary("GET", `/pub/v1/myfiles/${fileId}/data`);
+        bytes = response2.body;
+        mimeType = response2.contentType ?? cached2.mimeType;
+        fileName = response2.suggestedFileName ?? cached2.fileName;
+      }
+      const base643 = bytes.toString("base64");
+      const metaBlock = { type: "text", text: JSON.stringify({
+        fileId,
+        fileName,
+        mimeType,
+        sizeBytes: bytes.length,
+        mode: "inline"
+      }, null, 2) };
+      if (mimeType.startsWith("image/")) {
+        return { content: [metaBlock, { type: "image", data: base643, mimeType }] };
+      }
+      return { content: [metaBlock, { type: "resource", resource: {
+        uri: `ofw://attachment/${fileId}/${encodeURIComponent(fileName)}`,
+        mimeType,
+        blob: base643
+      } }] };
     }
     let dest;
     if (args.saveTo) {

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -31072,6 +31072,11 @@ function getAttachmentsDir() {
   if (override && override.trim().length > 0) return override.trim();
   return join2(homedir(), "Downloads", "ofw-mcp");
 }
+function getDefaultInlineAttachments() {
+  const raw = process.env.OFW_INLINE_ATTACHMENTS;
+  if (typeof raw !== "string") return false;
+  return ["1", "true", "yes", "on"].includes(raw.trim().toLowerCase());
+}
 
 // src/cache.ts
 var instance = null;
@@ -31962,16 +31967,17 @@ ${text}` : text;
     }, null, 2) }] };
   });
   server2.registerTool("ofw_download_attachment", {
-    description: "Download an OFW message attachment by fileId. By default, bytes are saved to disk (~/Downloads/ofw-mcp/) and the response carries the absolute path, mime type, and size for the caller to read back. Pass inline:true to skip disk entirely and return the bytes as MCP content blocks \u2014 images come back as ImageContent (the model sees them directly); other files come back as an EmbeddedResource blob. Use inline for small files where you want the model to read content immediately and the host is sandboxed; use disk for large files or when you want a persistent local copy. fileId comes from attachments[].fileId on ofw_get_message. Override disk destination with OFW_ATTACHMENTS_DIR or saveTo. Re-downloading to the same path is a no-op (disk mode only).",
+    description: 'Download an OFW message attachment by fileId. By default, bytes are saved to disk (~/Downloads/ofw-mcp/) and the response carries the absolute path, mime type, and size for the caller to read back. Pass inline:true to skip disk entirely and return the bytes as MCP content blocks \u2014 images come back as ImageContent (the model sees them directly); other files come back as an EmbeddedResource blob. Use inline for small files where you want the model to read content immediately and the host is sandboxed; use disk for large files or when you want a persistent local copy. The default for `inline` can be flipped server-side via the OFW_INLINE_ATTACHMENTS env var (set to "true" to make inline the default). fileId comes from attachments[].fileId on ofw_get_message. Override disk destination with OFW_ATTACHMENTS_DIR or saveTo. Re-downloading to the same path is a no-op (disk mode only).',
     annotations: { readOnlyHint: false },
     inputSchema: {
       fileId: external_exports.number().describe("Attachment file id (from ofw_get_message \u2192 attachments[].fileId)"),
-      inline: external_exports.boolean().describe("If true, return bytes inline as MCP content (image for image/*, embedded resource blob otherwise) and skip the disk write. Default false (writes to disk).").optional(),
+      inline: external_exports.boolean().describe("If true, return bytes inline as MCP content (image for image/*, embedded resource blob otherwise) and skip the disk write. If false, write to disk and return the path. If omitted, falls back to the OFW_INLINE_ATTACHMENTS env var (default: false = disk).").optional(),
       saveTo: external_exports.string().describe("Absolute path or directory to write to. If a directory, the OFW filename is used. Default: ~/Downloads/ofw-mcp/<fileId>-<filename>. Ignored when inline:true.").optional(),
       force: external_exports.boolean().describe("Re-download even if already on disk. Default false. Ignored when inline:true (inline always fetches fresh bytes, or reuses an on-disk copy if present).").optional()
     }
   }, async (args) => {
     const fileId = args.fileId;
+    const inline = args.inline ?? getDefaultInlineAttachments();
     let cached2 = getAttachment(fileId);
     if (!cached2) {
       const meta3 = await client2.request("GET", `/pub/v1/myfiles/${fileId}`);
@@ -31988,7 +31994,7 @@ ${text}` : text;
       cached2 = getAttachment(fileId);
       if (!cached2) throw new Error(`failed to fetch metadata for fileId ${fileId}`);
     }
-    if (args.inline) {
+    if (inline) {
       let bytes;
       let mimeType;
       let fileName;

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -31070,9 +31070,7 @@ function getCacheDbPath() {
 function getAttachmentsDir() {
   const override = process.env.OFW_ATTACHMENTS_DIR;
   if (override && override.trim().length > 0) return override.trim();
-  const username = readUsername();
-  const hash2 = createHash("sha256").update(username).digest("hex").slice(0, 16);
-  return join2(getCacheDir(), "attachments", hash2);
+  return join2(homedir(), "Downloads", "ofw-mcp");
 }
 
 // src/cache.ts
@@ -31964,11 +31962,11 @@ ${text}` : text;
     }, null, 2) }] };
   });
   server2.registerTool("ofw_download_attachment", {
-    description: "Download an OFW message attachment by fileId. Bytes are saved to disk; the tool returns the absolute path, mime type, and size so the caller can then read/analyze the file. fileId comes from the attachments array on ofw_get_message. Saves under ~/.cache/ofw-mcp/attachments/<hash>/ by default (override via OFW_ATTACHMENTS_DIR or the saveTo argument). Re-downloading is a no-op if the file is already on disk.",
+    description: "Download an OFW message attachment by fileId. Bytes are saved to disk; the tool returns the absolute path, mime type, and size so the caller can then read/analyze the file. fileId comes from the attachments array on ofw_get_message. Saves under ~/Downloads/ofw-mcp/ by default \u2014 a user-accessible location so sandboxed MCP hosts (e.g. Claude Desktop) can read the file back. Override with OFW_ATTACHMENTS_DIR or the saveTo argument. Re-downloading is a no-op if the file is already on disk.",
     annotations: { readOnlyHint: false },
     inputSchema: {
       fileId: external_exports.number().describe("Attachment file id (from ofw_get_message \u2192 attachments[].fileId)"),
-      saveTo: external_exports.string().describe("Absolute path or directory to write to. If a directory, the OFW filename is used. Default: ~/.cache/ofw-mcp/attachments/<hash>/<fileId>-<filename>").optional(),
+      saveTo: external_exports.string().describe("Absolute path or directory to write to. If a directory, the OFW filename is used. Default: ~/Downloads/ofw-mcp/<fileId>-<filename>").optional(),
       force: external_exports.boolean().describe("Re-download even if already on disk. Default false.").optional()
     }
   }, async (args) => {

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -30880,74 +30880,53 @@ function readVar(key) {
   return trimmed;
 }
 var BASE_URL = "https://ofw.ourfamilywizard.com";
-var STATIC_HEADERS = {
+var OFW_PROTOCOL_HEADERS = {
   "ofw-client": "WebApplication",
-  "ofw-version": "1.0.0",
-  Accept: "application/json",
-  "Content-Type": "application/json"
+  "ofw-version": "1.0.0"
 };
+function parseContentDispositionFilename(cd) {
+  const extMatch = /filename\*=(?:UTF-8'')?([^;]+)/i.exec(cd);
+  if (extMatch) {
+    const raw = extMatch[1].trim().replace(/^"|"$/g, "");
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      return raw;
+    }
+  }
+  const m = /filename="?([^";]+)"?/i.exec(cd);
+  return m ? m[1] : null;
+}
 var OFWClient = class {
   token = null;
   tokenExpiry = null;
   async request(method, path, body) {
     await this.ensureAuthenticated();
-    return this.doRequest(method, path, body, false);
+    const response = await this.fetchWithRetry(method, path, body, "application/json", false);
+    const text = await response.text();
+    return text ? JSON.parse(text) : null;
   }
   /** Like `request`, but returns the raw bytes plus Content-Type/-Disposition metadata. */
   async requestBinary(method, path) {
     await this.ensureAuthenticated();
-    return this.doRequestBinary(method, path, false);
-  }
-  async doRequestBinary(method, path, isRetry) {
-    const headers = {
-      "ofw-client": "WebApplication",
-      "ofw-version": "1.0.0",
-      Accept: "application/octet-stream",
-      Authorization: `Bearer ${this.token}`
-    };
-    const response = await fetch(`${BASE_URL}${path}`, { method, headers });
-    if (response.status === 401 && !isRetry) {
-      this.token = null;
-      this.tokenExpiry = null;
-      await this.ensureAuthenticated();
-      return this.doRequestBinary(method, path, true);
-    }
-    if (response.status === 429 && !isRetry) {
-      await new Promise((r) => setTimeout(r, 2e3));
-      return this.doRequestBinary(method, path, true);
-    }
-    if (!response.ok) {
-      throw new Error(`OFW API error: ${response.status} ${response.statusText} for ${method} ${path}`);
-    }
-    const buf = Buffer.from(await response.arrayBuffer());
-    const cd = response.headers.get("content-disposition") ?? "";
-    let suggestedFileName = null;
-    const extMatch = /filename\*=(?:UTF-8'')?([^;]+)/i.exec(cd);
-    if (extMatch) {
-      try {
-        suggestedFileName = decodeURIComponent(extMatch[1].trim().replace(/^"|"$/g, ""));
-      } catch {
-        suggestedFileName = extMatch[1];
-      }
-    } else {
-      const m = /filename="?([^";]+)"?/i.exec(cd);
-      if (m) suggestedFileName = m[1];
-    }
+    const response = await this.fetchWithRetry(method, path, void 0, "application/octet-stream", false);
     return {
-      body: buf,
+      body: Buffer.from(await response.arrayBuffer()),
       contentType: response.headers.get("content-type"),
-      suggestedFileName
+      suggestedFileName: parseContentDispositionFilename(response.headers.get("content-disposition") ?? "")
     };
   }
-  async doRequest(method, path, body, isRetry) {
+  // Single fetch+retry scaffold for both JSON and binary callers. Handles
+  // 401 (re-auth and replay once), 429 (wait 2s and replay once), and
+  // turns any other non-2xx into a thrown Error.
+  async fetchWithRetry(method, path, body, accept, isRetry) {
     const isFormData = body instanceof FormData;
     const headers = {
-      "ofw-client": "WebApplication",
-      "ofw-version": "1.0.0",
-      Accept: "application/json",
+      ...OFW_PROTOCOL_HEADERS,
+      Accept: accept,
       Authorization: `Bearer ${this.token}`
     };
-    if (!isFormData) headers["Content-Type"] = "application/json";
+    if (body !== void 0 && !isFormData) headers["Content-Type"] = "application/json";
     const response = await fetch(`${BASE_URL}${path}`, {
       method,
       headers,
@@ -30957,22 +30936,19 @@ var OFWClient = class {
       this.token = null;
       this.tokenExpiry = null;
       await this.ensureAuthenticated();
-      return this.doRequest(method, path, body, true);
+      return this.fetchWithRetry(method, path, body, accept, true);
     }
     if (response.status === 429) {
       if (!isRetry) {
         await new Promise((r) => setTimeout(r, 2e3));
-        return this.doRequest(method, path, body, true);
+        return this.fetchWithRetry(method, path, body, accept, true);
       }
       throw new Error("Rate limited by OFW API");
     }
     if (!response.ok) {
-      throw new Error(
-        `OFW API error: ${response.status} ${response.statusText} for ${method} ${path}`
-      );
+      throw new Error(`OFW API error: ${response.status} ${response.statusText} for ${method} ${path}`);
     }
-    const text = await response.text();
-    return text ? JSON.parse(text) : null;
+    return response;
   }
   async ensureAuthenticated() {
     if (!this.isTokenExpiredSoon()) return;
@@ -30985,7 +30961,7 @@ var OFWClient = class {
       throw new Error("OFW_USERNAME and OFW_PASSWORD must be set");
     }
     const initResponse = await fetch(`${BASE_URL}/ofw/login.form`, {
-      headers: { "ofw-client": "WebApplication", "ofw-version": "1.0.0" },
+      headers: { ...OFW_PROTOCOL_HEADERS },
       redirect: "manual"
     });
     const setCookie = initResponse.headers.get("set-cookie") ?? "";
@@ -30993,7 +30969,8 @@ var OFWClient = class {
     const response = await fetch(`${BASE_URL}/ofw/login`, {
       method: "POST",
       headers: {
-        ...STATIC_HEADERS,
+        ...OFW_PROTOCOL_HEADERS,
+        Accept: "application/json",
         "Content-Type": "application/x-www-form-urlencoded",
         ...sessionCookie ? { Cookie: sessionCookie } : {}
       },
@@ -31023,6 +31000,26 @@ var OFWClient = class {
 };
 var client = new OFWClient();
 
+// src/tools/_shared.ts
+import { isAbsolute, join as join2, resolve } from "node:path";
+function jsonResponse(payload) {
+  return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+}
+function textResponse(text) {
+  return { content: [{ type: "text", text }] };
+}
+function mapRecipients(items) {
+  return (items ?? []).map((r) => ({
+    userId: r.user?.id ?? 0,
+    name: r.user?.name ?? "",
+    viewedAt: r.viewed?.dateTime ?? null
+  }));
+}
+function expandPath(p) {
+  const expanded = p.startsWith("~/") ? join2(process.env.HOME ?? "", p.slice(2)) : p;
+  return isAbsolute(expanded) ? expanded : resolve(expanded);
+}
+
 // src/tools/user.ts
 function registerUserTools(server2, client2) {
   server2.registerTool("ofw_get_profile", {
@@ -31030,14 +31027,14 @@ function registerUserTools(server2, client2) {
     annotations: { readOnlyHint: true }
   }, async () => {
     const data = await client2.request("GET", "/pub/v2/profiles");
-    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
   server2.registerTool("ofw_get_notifications", {
     description: "Get OurFamilyWizard dashboard summary: unread message count, upcoming events, outstanding expenses. Note: updates your last-seen status.",
     annotations: { readOnlyHint: false }
   }, async () => {
     const data = await client2.request("GET", "/pub/v1/users/useraccountstatus");
-    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 }
 
@@ -31049,7 +31046,7 @@ import { dirname as dirname2 } from "node:path";
 // src/config.ts
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
-import { join as join2 } from "node:path";
+import { join as join3 } from "node:path";
 function readUsername() {
   const raw = process.env.OFW_USERNAME;
   if (typeof raw !== "string" || raw.trim().length === 0) {
@@ -31060,17 +31057,17 @@ function readUsername() {
 function getCacheDir() {
   const override = process.env.OFW_CACHE_DIR;
   if (override && override.trim().length > 0) return override.trim();
-  return join2(homedir(), ".cache", "ofw-mcp");
+  return join3(homedir(), ".cache", "ofw-mcp");
 }
 function getCacheDbPath() {
   const username = readUsername();
   const hash2 = createHash("sha256").update(username).digest("hex").slice(0, 16);
-  return join2(getCacheDir(), `${hash2}.db`);
+  return join3(getCacheDir(), `${hash2}.db`);
 }
 function getAttachmentsDir() {
   const override = process.env.OFW_ATTACHMENTS_DIR;
   if (override && override.trim().length > 0) return override.trim();
-  return join2(homedir(), "Downloads", "ofw-mcp");
+  return join3(homedir(), "Downloads", "ofw-mcp");
 }
 function getDefaultInlineAttachments() {
   const raw = process.env.OFW_INLINE_ATTACHMENTS;
@@ -31212,9 +31209,7 @@ function getMessage(id) {
   const r = db.prepare("SELECT * FROM messages WHERE id = ?").get(id);
   return r ? rowFromDb(r) : null;
 }
-function listMessages(opts) {
-  const { db } = openCache();
-  const offset = (opts.page - 1) * opts.size;
+function buildMessageFilter(opts) {
   const wheres = [];
   const params = [];
   if (opts.folder !== void 0) {
@@ -31234,37 +31229,25 @@ function listMessages(opts) {
     wheres.push("(subject LIKE ? OR body LIKE ?)");
     params.push(pattern, pattern);
   }
-  const where = wheres.length > 0 ? `WHERE ${wheres.join(" AND ")}` : "";
-  params.push(opts.size, offset);
+  return {
+    where: wheres.length > 0 ? `WHERE ${wheres.join(" AND ")}` : "",
+    params
+  };
+}
+function listMessages(opts) {
+  const { db } = openCache();
+  const { where, params } = buildMessageFilter(opts);
+  const offset = (opts.page - 1) * opts.size;
   const rows = db.prepare(
     `SELECT * FROM messages ${where}
      ORDER BY sent_at DESC, id DESC
      LIMIT ? OFFSET ?`
-  ).all(...params);
+  ).all(...params, opts.size, offset);
   return rows.map(rowFromDb);
 }
 function countMessages(opts) {
   const { db } = openCache();
-  const wheres = [];
-  const params = [];
-  if (opts.folder !== void 0) {
-    wheres.push("folder = ?");
-    params.push(opts.folder);
-  }
-  if (opts.since !== void 0) {
-    wheres.push("sent_at >= ?");
-    params.push(opts.since);
-  }
-  if (opts.until !== void 0) {
-    wheres.push("sent_at < ?");
-    params.push(opts.until);
-  }
-  if (opts.q !== void 0 && opts.q.length > 0) {
-    const pattern = `%${opts.q}%`;
-    wheres.push("(subject LIKE ? OR body LIKE ?)");
-    params.push(pattern, pattern);
-  }
-  const where = wheres.length > 0 ? `WHERE ${wheres.join(" AND ")}` : "";
+  const { where, params } = buildMessageFilter(opts);
   const r = db.prepare(`SELECT COUNT(*) as n FROM messages ${where}`).get(...params);
   return r?.n ?? 0;
 }
@@ -31423,24 +31406,24 @@ function markAttachmentDownloaded(fileId, path) {
 }
 
 // src/sync.ts
-async function fetchAndCacheAttachmentMeta(client2, fileId, messageId) {
-  try {
-    const meta3 = await client2.request("GET", `/pub/v1/myfiles/${fileId}`);
-    upsertAttachmentForMessage({
-      fileId: meta3.fileId ?? fileId,
-      fileName: meta3.fileName ?? `file-${fileId}`,
-      label: meta3.label ?? meta3.fileName ?? `file-${fileId}`,
-      mimeType: meta3.fileType ?? "application/octet-stream",
-      sizeBytes: typeof meta3.fileSize === "number" ? meta3.fileSize : null,
-      metadata: meta3,
-      messageId
-    });
-  } catch {
-  }
+async function fetchAttachmentMeta(client2, fileId, messageId) {
+  const meta3 = await client2.request("GET", `/pub/v1/myfiles/${fileId}`);
+  upsertAttachmentForMessage({
+    fileId: meta3.fileId ?? fileId,
+    fileName: meta3.fileName ?? `file-${fileId}`,
+    label: meta3.label ?? meta3.fileName ?? `file-${fileId}`,
+    mimeType: meta3.fileType ?? "application/octet-stream",
+    sizeBytes: typeof meta3.fileSize === "number" ? meta3.fileSize : null,
+    metadata: meta3,
+    messageId
+  });
 }
 async function fetchAttachmentMetaForMessage(client2, messageId, fileIds) {
   for (const fid of fileIds) {
-    await fetchAndCacheAttachmentMeta(client2, fid, messageId);
+    try {
+      await fetchAttachmentMeta(client2, fid, messageId);
+    } catch {
+    }
   }
 }
 async function resolveFolderIds(client2) {
@@ -31461,13 +31444,6 @@ async function resolveFolderIds(client2) {
   };
   setMeta("drafts_folder_id", ids.drafts);
   return ids;
-}
-function recipientsFromList(item) {
-  return (item.recipients ?? []).map((r) => ({
-    userId: r.user.id,
-    name: r.user.name,
-    viewedAt: r.viewed?.dateTime ?? null
-  }));
 }
 async function syncMessageFolder(client2, folder, folderId, opts) {
   let page = 1;
@@ -31511,7 +31487,7 @@ async function syncMessageFolder(client2, folder, folderId, opts) {
         subject: item.subject ?? "(no subject)",
         fromUser: item.from?.name ?? "",
         sentAt: item.date?.dateTime ?? (/* @__PURE__ */ new Date()).toISOString(),
-        recipients: recipientsFromList(item),
+        recipients: mapRecipients(item.recipients),
         body,
         fetchedBodyAt,
         replyToId: null,
@@ -31551,11 +31527,7 @@ async function syncDrafts(client2, draftsFolderId) {
       id: item.id,
       subject: detail.subject ?? item.subject ?? "(no subject)",
       body: detail.body ?? "",
-      recipients: (item.recipients ?? []).map((r) => ({
-        userId: r.user?.id ?? 0,
-        name: r.user?.name ?? "",
-        viewedAt: r.viewed?.dateTime ?? null
-      })),
+      recipients: mapRecipients(item.recipients),
       replyToId: item.replyToId ?? null,
       modifiedAt,
       listData: item
@@ -31598,7 +31570,7 @@ async function syncAll(client2, opts) {
 
 // src/tools/messages.ts
 import { mkdirSync as mkdirSync2, readFileSync, statSync, writeFileSync } from "node:fs";
-import { basename, dirname as dirname3, extname, join as join3, isAbsolute, resolve } from "node:path";
+import { basename, dirname as dirname3, extname, join as join4 } from "node:path";
 var MIME_BY_EXT = {
   ".pdf": "application/pdf",
   ".png": "image/png",
@@ -31639,7 +31611,7 @@ function registerMessageTools(server2, client2) {
     annotations: { readOnlyHint: true }
   }, async () => {
     const data = await client2.request("GET", "/pub/v1/messageFolders?includeFolderCounts=true");
-    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
   server2.registerTool("ofw_list_messages", {
     description: "List messages from the local OurFamilyWizard cache. Supports filtering by folder, date range, and a substring query on subject+body. Pagination is offset-based but if you know what you want (a date range, a topic), prefer the filters over walking pages \u2014 the cache may have 1000+ messages. Call ofw_sync_messages first if the cache is empty or stale.",
@@ -31661,15 +31633,10 @@ function registerMessageTools(server2, client2) {
     else if (folderArg === "sent") folder = "sent";
     else if (folderArg === "both") folder = void 0;
     else {
-      return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({
-            messages: [],
-            note: 'folderId must be "inbox", "sent", or "both". Numeric OFW folder IDs are not supported by the cache.'
-          }, null, 2)
-        }]
-      };
+      return jsonResponse({
+        messages: [],
+        note: 'folderId must be "inbox", "sent", or "both". Numeric OFW folder IDs are not supported by the cache.'
+      });
     }
     const filter = { folder, since: args.since, until: args.until, q: args.q };
     const total = countMessages(filter);
@@ -31680,7 +31647,7 @@ function registerMessageTools(server2, client2) {
     } else if (page * size < total) {
       payload.note = `Showing ${(page - 1) * size + 1}\u2013${(page - 1) * size + messages.length} of ${total}. Increase 'page' to see more, or narrow with since/until/q.`;
     }
-    return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+    return jsonResponse(payload);
   });
   server2.registerTool("ofw_get_message", {
     description: "Get a single OurFamilyWizard message by ID. Reads from local cache when available; otherwise fetches from OFW (which will mark unread inbox messages as read on OFW).",
@@ -31703,14 +31670,9 @@ function registerMessageTools(server2, client2) {
         } catch {
         }
       }
-      return { content: [{ type: "text", text: JSON.stringify({ ...cached2, attachments: attachments2 }, null, 2) }] };
+      return jsonResponse({ ...cached2, attachments: attachments2 });
     }
     const detail = await client2.request("GET", `/pub/v3/messages/${encodeURIComponent(args.messageId)}`);
-    const recipients = (detail.recipients ?? []).map((r) => ({
-      userId: r.user.id,
-      name: r.user.name,
-      viewedAt: r.viewed?.dateTime ?? null
-    }));
     const folder = cached2?.folder ?? "inbox";
     const row = {
       id: detail.id,
@@ -31718,7 +31680,7 @@ function registerMessageTools(server2, client2) {
       subject: detail.subject,
       fromUser: detail.from?.name ?? "",
       sentAt: detail.date?.dateTime ?? (/* @__PURE__ */ new Date()).toISOString(),
-      recipients,
+      recipients: mapRecipients(detail.recipients),
       body: detail.body ?? "",
       fetchedBodyAt: (/* @__PURE__ */ new Date()).toISOString(),
       replyToId: cached2?.replyToId ?? null,
@@ -31730,7 +31692,7 @@ function registerMessageTools(server2, client2) {
       await fetchAttachmentMetaForMessage(client2, detail.id, detail.files);
     }
     const attachments = listAttachmentsForMessage(detail.id);
-    return { content: [{ type: "text", text: JSON.stringify({ ...row, attachments }, null, 2) }] };
+    return jsonResponse({ ...row, attachments });
   });
   server2.registerTool("ofw_send_message", {
     description: "Send a message via OurFamilyWizard. If sending from a draft, pass draftId to delete the draft after sending. If replyToId is provided, the cache may rewrite it to the latest reply in the same thread (a note is included in the response when this happens). Attach files by passing their fileIds (from ofw_upload_attachment) in myFileIDs.",
@@ -31767,18 +31729,13 @@ function registerMessageTools(server2, client2) {
       replyToId: resolvedReplyTo
     });
     if (data && typeof data.id === "number") {
-      const recipients = (data.recipients ?? []).map((r) => ({
-        userId: r.user.id,
-        name: r.user.name,
-        viewedAt: r.viewed?.dateTime ?? null
-      }));
       const row = {
         id: data.id,
         folder: "sent",
         subject: data.subject ?? args.subject,
         fromUser: data.from?.name ?? "",
         sentAt: data.date?.dateTime ?? (/* @__PURE__ */ new Date()).toISOString(),
-        recipients,
+        recipients: mapRecipients(data.recipients),
         body: data.body ?? args.body,
         fetchedBodyAt: (/* @__PURE__ */ new Date()).toISOString(),
         replyToId: resolvedReplyTo,
@@ -31800,16 +31757,13 @@ function registerMessageTools(server2, client2) {
       }
     }
     if (args.draftId !== void 0) {
-      const form = new FormData();
-      form.append("messageIds", String(args.draftId));
-      await client2.request("DELETE", "/pub/v1/messages", form);
+      await deleteOFWMessages(client2, [args.draftId]);
       deleteDraft(args.draftId);
     }
     const text = data ? JSON.stringify(data, null, 2) : "Message sent successfully.";
-    const finalText = rewriteNote ? `${rewriteNote}
+    return textResponse(rewriteNote ? `${rewriteNote}
 
-${text}` : text;
-    return { content: [{ type: "text", text: finalText }] };
+${text}` : text);
   });
   server2.registerTool("ofw_list_drafts", {
     description: "List draft messages from the local OurFamilyWizard cache. Call ofw_sync_messages first if the cache is empty.",
@@ -31823,7 +31777,7 @@ ${text}` : text;
     const size = args.size ?? 50;
     const drafts = listDrafts({ page, size });
     const payload = drafts.length === 0 ? { drafts: [], note: "Cache empty. Call ofw_sync_messages to populate." } : { drafts };
-    return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+    return jsonResponse(payload);
   });
   server2.registerTool("ofw_save_draft", {
     description: "Save a message as a draft in OurFamilyWizard. Recipients are optional. To update an existing draft, provide its messageId. If replyToId is provided, the cache may rewrite it to the latest reply in the thread (note included in response). Attach files by passing their fileIds (from ofw_upload_attachment) in myFileIDs.",
@@ -31863,11 +31817,7 @@ ${text}` : text;
         id: data.id,
         subject: data.subject ?? args.subject,
         body: data.body ?? args.body,
-        recipients: (data.recipients ?? []).map((r) => ({
-          userId: r.user.id,
-          name: r.user.name,
-          viewedAt: r.viewed?.dateTime ?? null
-        })),
+        recipients: mapRecipients(data.recipients),
         replyToId: data.replyToId ?? resolvedReplyTo,
         modifiedAt: data.date?.dateTime ?? (/* @__PURE__ */ new Date()).toISOString(),
         listData: data
@@ -31875,10 +31825,9 @@ ${text}` : text;
       upsertDraft(draft);
     }
     const text = data ? JSON.stringify(data, null, 2) : "Draft saved.";
-    const finalText = rewriteNote ? `${rewriteNote}
+    return textResponse(rewriteNote ? `${rewriteNote}
 
-${text}` : text;
-    return { content: [{ type: "text", text: finalText }] };
+${text}` : text);
   });
   server2.registerTool("ofw_delete_draft", {
     description: "Delete a draft message from OurFamilyWizard. Also removes the draft from the local cache.",
@@ -31887,11 +31836,9 @@ ${text}` : text;
       messageId: external_exports.number().describe("Draft message ID to delete")
     }
   }, async (args) => {
-    const form = new FormData();
-    form.append("messageIds", String(args.messageId));
-    const data = await client2.request("DELETE", "/pub/v1/messages", form);
+    const data = await deleteOFWMessages(client2, [args.messageId]);
     deleteDraft(args.messageId);
-    return { content: [{ type: "text", text: data ? JSON.stringify(data, null, 2) : "Draft deleted." }] };
+    return data ? jsonResponse(data) : textResponse("Draft deleted.");
   });
   server2.registerTool("ofw_get_unread_sent", {
     description: "List sent messages that have not been read by one or more recipients. Reads from local cache; call ofw_sync_messages first if cache is stale.",
@@ -31905,9 +31852,7 @@ ${text}` : text;
     const size = args.size ?? 50;
     const sent = listMessages({ folder: "sent", page, size });
     if (sent.length === 0) {
-      return { content: [{ type: "text", text: JSON.stringify({
-        note: "Sent cache is empty. Call ofw_sync_messages to populate."
-      }, null, 2) }] };
+      return jsonResponse({ note: "Sent cache is empty. Call ofw_sync_messages to populate." });
     }
     const unread = [];
     for (const msg of sent) {
@@ -31917,11 +31862,9 @@ ${text}` : text;
       }
     }
     if (unread.length === 0) {
-      return { content: [{ type: "text", text: JSON.stringify({
-        message: "All scanned sent messages have been read."
-      }, null, 2) }] };
+      return jsonResponse({ message: "All scanned sent messages have been read." });
     }
-    return { content: [{ type: "text", text: JSON.stringify(unread, null, 2) }] };
+    return jsonResponse(unread);
   });
   server2.registerTool("ofw_upload_attachment", {
     description: `Upload a local file to OurFamilyWizard's "My Files" so it can be attached to a message. Returns the fileId \u2014 pass that to ofw_send_message or ofw_save_draft in myFileIDs to attach it. The file is uploaded as PRIVATE (visible only to you) by default; pass shareClass:"SHARED" to share with co-parents directly via the My Files area.`,
@@ -31933,8 +31876,7 @@ ${text}` : text;
       description: external_exports.string().describe("Description shown in OFW My Files (default: filename)").optional()
     }
   }, async (args) => {
-    const expanded = args.path.startsWith("~/") ? join3(process.env.HOME ?? "", args.path.slice(2)) : args.path;
-    const abs = isAbsolute(expanded) ? expanded : resolve(expanded);
+    const abs = expandPath(args.path);
     const stat = statSync(abs);
     if (!stat.isFile()) throw new Error(`Not a file: ${abs}`);
     const buf = readFileSync(abs);
@@ -31957,14 +31899,14 @@ ${text}` : text;
       metadata: meta3,
       messageId: 0
     });
-    return { content: [{ type: "text", text: JSON.stringify({
+    return jsonResponse({
       fileId: meta3.fileId,
       fileName: meta3.fileName ?? fileName,
       mimeType: meta3.fileType ?? mime,
       sizeBytes: meta3.sizeInBytes ?? buf.length,
       shareClass: meta3.shareClass ?? args.shareClass ?? "PRIVATE",
       note: "Pass this fileId to ofw_send_message or ofw_save_draft in myFileIDs to attach it."
-    }, null, 2) }] };
+    });
   });
   server2.registerTool("ofw_download_attachment", {
     description: 'Download an OFW message attachment by fileId. By default, bytes are saved to disk (~/Downloads/ofw-mcp/) and the response carries the absolute path, mime type, and size for the caller to read back. Pass inline:true to skip disk entirely and return the bytes as MCP content blocks \u2014 images come back as ImageContent (the model sees them directly); other files come back as an EmbeddedResource blob. Use inline for small files where you want the model to read content immediately and the host is sandboxed; use disk for large files or when you want a persistent local copy. The default for `inline` can be flipped server-side via the OFW_INLINE_ATTACHMENTS env var (set to "true" to make inline the default). fileId comes from attachments[].fileId on ofw_get_message. Override disk destination with OFW_ATTACHMENTS_DIR or saveTo. Re-downloading to the same path is a no-op (disk mode only).',
@@ -31980,36 +31922,21 @@ ${text}` : text;
     const inline = args.inline ?? getDefaultInlineAttachments();
     let cached2 = getAttachment(fileId);
     if (!cached2) {
-      const meta3 = await client2.request("GET", `/pub/v1/myfiles/${fileId}`);
-      upsertAttachmentForMessage({
-        fileId: meta3.fileId ?? fileId,
-        fileName: meta3.fileName ?? `file-${fileId}`,
-        label: meta3.label ?? meta3.fileName ?? `file-${fileId}`,
-        mimeType: meta3.fileType ?? "application/octet-stream",
-        sizeBytes: typeof meta3.fileSize === "number" ? meta3.fileSize : null,
-        metadata: meta3,
-        messageId: 0
-        // placeholder; will be cleaned up if a real message references it
-      });
+      await fetchAttachmentMeta(client2, fileId, 0);
       cached2 = getAttachment(fileId);
       if (!cached2) throw new Error(`failed to fetch metadata for fileId ${fileId}`);
     }
     if (inline) {
-      let bytes;
-      let mimeType;
-      let fileName;
+      let bytes = null;
+      let mimeType = cached2.mimeType;
+      let fileName = cached2.fileName;
       if (cached2.downloadedPath) {
         try {
           bytes = readFileSync(cached2.downloadedPath);
-          mimeType = cached2.mimeType;
-          fileName = cached2.fileName;
         } catch {
-          const response2 = await client2.requestBinary("GET", `/pub/v1/myfiles/${fileId}/data`);
-          bytes = response2.body;
-          mimeType = response2.contentType ?? cached2.mimeType;
-          fileName = response2.suggestedFileName ?? cached2.fileName;
         }
-      } else {
+      }
+      if (bytes === null) {
         const response2 = await client2.requestBinary("GET", `/pub/v1/myfiles/${fileId}/data`);
         bytes = response2.body;
         mimeType = response2.contentType ?? cached2.mimeType;
@@ -32034,34 +31961,33 @@ ${text}` : text;
     }
     let dest;
     if (args.saveTo) {
-      const expanded = args.saveTo.startsWith("~/") ? join3(process.env.HOME ?? "", args.saveTo.slice(2)) : args.saveTo;
-      const abs = isAbsolute(expanded) ? expanded : resolve(expanded);
-      const isDirArg = expanded.endsWith("/") || expanded.endsWith("\\");
-      dest = isDirArg ? join3(abs, `${fileId}-${cached2.fileName}`) : abs;
+      const isDirArg = args.saveTo.endsWith("/") || args.saveTo.endsWith("\\");
+      const abs = expandPath(args.saveTo);
+      dest = isDirArg ? join4(abs, `${fileId}-${cached2.fileName}`) : abs;
     } else {
-      dest = join3(getAttachmentsDir(), `${fileId}-${cached2.fileName}`);
+      dest = join4(getAttachmentsDir(), `${fileId}-${cached2.fileName}`);
     }
     if (!args.force && cached2.downloadedPath === dest) {
-      return { content: [{ type: "text", text: JSON.stringify({
+      return jsonResponse({
         fileId,
         path: dest,
         mimeType: cached2.mimeType,
         sizeBytes: cached2.sizeBytes,
         fileName: cached2.fileName,
         note: "already downloaded"
-      }, null, 2) }] };
+      });
     }
     const response = await client2.requestBinary("GET", `/pub/v1/myfiles/${fileId}/data`);
     mkdirSync2(dirname3(dest), { recursive: true });
     writeFileSync(dest, response.body);
     markAttachmentDownloaded(fileId, dest);
-    return { content: [{ type: "text", text: JSON.stringify({
+    return jsonResponse({
       fileId,
       path: dest,
       mimeType: response.contentType ?? cached2.mimeType,
       sizeBytes: response.body.length,
       fileName: response.suggestedFileName ?? cached2.fileName
-    }, null, 2) }] };
+    });
   });
   server2.registerTool("ofw_sync_messages", {
     description: "Sync messages from OurFamilyWizard into the local cache. Returns counts per folder and a list of unread inbox messages whose bodies were NOT fetched (to avoid mark-as-read on OFW). Call ofw_get_message(id) on those to read them. Pass deep:true to walk all OFW pages instead of stopping at the first all-cached page (use to backfill suspected gaps).",
@@ -32077,8 +32003,13 @@ ${text}` : text;
       fetchUnreadBodies: args.fetchUnreadBodies,
       deep: args.deep
     });
-    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    return jsonResponse(result);
   });
+}
+async function deleteOFWMessages(client2, ids) {
+  const form = new FormData();
+  for (const id of ids) form.append("messageIds", String(id));
+  return client2.request("DELETE", "/pub/v1/messages", form);
 }
 
 // src/tools/calendar.ts
@@ -32097,7 +32028,7 @@ function registerCalendarTools(server2, client2) {
       "GET",
       `/pub/v1/calendar/${variant}?startDate=${encodeURIComponent(args.startDate)}&endDate=${encodeURIComponent(args.endDate)}`
     );
-    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
   server2.registerTool("ofw_create_event", {
     description: "Create a calendar event in OurFamilyWizard",
@@ -32117,7 +32048,7 @@ function registerCalendarTools(server2, client2) {
     }
   }, async (args) => {
     const data = await client2.request("POST", "/pub/v1/calendar/events", args);
-    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
   server2.registerTool("ofw_update_event", {
     description: "Update an existing OurFamilyWizard calendar event",
@@ -32135,7 +32066,7 @@ function registerCalendarTools(server2, client2) {
   }, async (args) => {
     const { eventId, ...updateData } = args;
     const data = await client2.request("PUT", `/pub/v1/calendar/events/${encodeURIComponent(eventId)}`, updateData);
-    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
   server2.registerTool("ofw_delete_event", {
     description: "Delete an OurFamilyWizard calendar event",
@@ -32145,7 +32076,7 @@ function registerCalendarTools(server2, client2) {
     }
   }, async (args) => {
     await client2.request("DELETE", `/pub/v1/calendar/events/${encodeURIComponent(args.eventId)}`);
-    return { content: [{ type: "text", text: `Event ${args.eventId} deleted` }] };
+    return textResponse(`Event ${args.eventId} deleted`);
   });
 }
 
@@ -32156,7 +32087,7 @@ function registerExpenseTools(server2, client2) {
     annotations: { readOnlyHint: true }
   }, async () => {
     const data = await client2.request("GET", "/pub/v2/expense/expenses/totals");
-    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
   server2.registerTool("ofw_list_expenses", {
     description: "List OurFamilyWizard expenses with pagination",
@@ -32169,7 +32100,7 @@ function registerExpenseTools(server2, client2) {
     const start = args.start ?? 0;
     const max = args.max ?? 20;
     const data = await client2.request("GET", `/pub/v2/expense/expenses?start=${start}&max=${max}`);
-    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
   server2.registerTool("ofw_create_expense", {
     description: "Log a new expense in OurFamilyWizard",
@@ -32180,7 +32111,7 @@ function registerExpenseTools(server2, client2) {
     }
   }, async (args) => {
     const data = await client2.request("POST", "/pub/v2/expense/expenses", args);
-    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 }
 
@@ -32197,7 +32128,7 @@ function registerJournalTools(server2, client2) {
     const start = args.start ?? 1;
     const max = args.max ?? 10;
     const data = await client2.request("GET", `/pub/v1/journals?start=${start}&max=${max}`);
-    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
   server2.registerTool("ofw_create_journal_entry", {
     description: "Create a new journal entry in OurFamilyWizard",
@@ -32208,7 +32139,7 @@ function registerJournalTools(server2, client2) {
     }
   }, async (args) => {
     const data = await client2.request("POST", "/pub/v1/journals", args);
-    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "ofw-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^25.5.2",
-        "@vitest/coverage-v8": "^4.1.2",
+        "@types/node": "^25.8.0",
+        "@vitest/coverage-v8": "^4.1.6",
         "esbuild": "^0.28.0",
         "typescript": "^6.0.2",
-        "vitest": "^4.1.2"
+        "vitest": "^4.1.6"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -659,9 +659,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -669,9 +669,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
       "cpu": [
         "arm64"
       ],
@@ -686,9 +686,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
       "cpu": [
         "arm64"
       ],
@@ -703,9 +703,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
       "cpu": [
         "x64"
       ],
@@ -720,9 +720,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
       "cpu": [
         "x64"
       ],
@@ -737,9 +737,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
       "cpu": [
         "arm"
       ],
@@ -754,9 +754,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
       "cpu": [
         "arm64"
       ],
@@ -771,9 +771,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "cpu": [
         "arm64"
       ],
@@ -788,9 +788,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
       "cpu": [
         "ppc64"
       ],
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "cpu": [
         "s390x"
       ],
@@ -822,9 +822,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
       "cpu": [
         "x64"
       ],
@@ -839,9 +839,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "cpu": [
         "x64"
       ],
@@ -856,9 +856,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
       "cpu": [
         "arm64"
       ],
@@ -873,9 +873,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
       "cpu": [
         "wasm32"
       ],
@@ -892,9 +892,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
       "cpu": [
         "arm64"
       ],
@@ -909,9 +909,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
       "cpu": [
         "x64"
       ],
@@ -926,9 +926,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -940,9 +940,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -976,24 +976,24 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
-      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.6",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1007,8 +1007,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.5",
-        "vitest": "4.1.5"
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1017,16 +1017,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1035,13 +1035,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1062,9 +1062,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1075,13 +1075,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.6",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1089,14 +1089,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1105,9 +1105,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1115,13 +1115,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1443,9 +1443,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2322,9 +2322,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -2467,9 +2467,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -2557,14 +2557,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -2573,21 +2573,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
       }
     },
     "node_modules/router": {
@@ -2830,9 +2830,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2912,9 +2912,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2937,16 +2937,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -2963,7 +2963,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -3015,19 +3015,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -3055,12 +3055,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "zod": "^4.4.2"
   },
   "devDependencies": {
-    "@types/node": "^25.5.2",
-    "@vitest/coverage-v8": "^4.1.2",
+    "@types/node": "^25.8.0",
+    "@vitest/coverage-v8": "^4.1.6",
     "esbuild": "^0.28.0",
     "typescript": "^6.0.2",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.6"
   }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -206,9 +206,11 @@ export interface ListMessagesOptions {
   q?: string;                  // substring match on subject and body (case-insensitive)
 }
 
-export function listMessages(opts: ListMessagesOptions): MessageRow[] {
-  const { db } = openCache();
-  const offset = (opts.page - 1) * opts.size;
+type MessageFilter = Omit<ListMessagesOptions, 'page' | 'size'>;
+
+// Build the WHERE clause + bound params for message queries. listMessages and
+// countMessages share this so the filter semantics can't drift.
+function buildMessageFilter(opts: MessageFilter): { where: string; params: unknown[] } {
   const wheres: string[] = [];
   const params: unknown[] = [];
   if (opts.folder !== undefined) {
@@ -228,38 +230,27 @@ export function listMessages(opts: ListMessagesOptions): MessageRow[] {
     wheres.push('(subject LIKE ? OR body LIKE ?)');
     params.push(pattern, pattern);
   }
-  const where = wheres.length > 0 ? `WHERE ${wheres.join(' AND ')}` : '';
-  params.push(opts.size, offset);
+  return {
+    where: wheres.length > 0 ? `WHERE ${wheres.join(' AND ')}` : '',
+    params,
+  };
+}
+
+export function listMessages(opts: ListMessagesOptions): MessageRow[] {
+  const { db } = openCache();
+  const { where, params } = buildMessageFilter(opts);
+  const offset = (opts.page - 1) * opts.size;
   const rows = db.prepare(
     `SELECT * FROM messages ${where}
      ORDER BY sent_at DESC, id DESC
      LIMIT ? OFFSET ?`
-  ).all(...params as never[]) as unknown as MessageDbRow[];
+  ).all(...params as never[], opts.size, offset) as unknown as MessageDbRow[];
   return rows.map(rowFromDb);
 }
 
-export function countMessages(opts: Omit<ListMessagesOptions, 'page' | 'size'>): number {
+export function countMessages(opts: MessageFilter): number {
   const { db } = openCache();
-  const wheres: string[] = [];
-  const params: unknown[] = [];
-  if (opts.folder !== undefined) {
-    wheres.push('folder = ?');
-    params.push(opts.folder);
-  }
-  if (opts.since !== undefined) {
-    wheres.push('sent_at >= ?');
-    params.push(opts.since);
-  }
-  if (opts.until !== undefined) {
-    wheres.push('sent_at < ?');
-    params.push(opts.until);
-  }
-  if (opts.q !== undefined && opts.q.length > 0) {
-    const pattern = `%${opts.q}%`;
-    wheres.push('(subject LIKE ? OR body LIKE ?)');
-    params.push(pattern, pattern);
-  }
-  const where = wheres.length > 0 ? `WHERE ${wheres.join(' AND ')}` : '';
+  const { where, params } = buildMessageFilter(opts);
   const r = db.prepare(`SELECT COUNT(*) as n FROM messages ${where}`)
     .get(...params as never[]) as { n: number } | undefined;
   return r?.n ?? 0;

--- a/src/client.ts
+++ b/src/client.ts
@@ -27,11 +27,9 @@ function readVar(key: string): string | undefined {
 
 const BASE_URL = 'https://ofw.ourfamilywizard.com';
 
-const STATIC_HEADERS = {
+const OFW_PROTOCOL_HEADERS = {
   'ofw-client': 'WebApplication',
   'ofw-version': '1.0.0',
-  Accept: 'application/json',
-  'Content-Type': 'application/json',
 } as const;
 
 interface LoginResponse {
@@ -46,74 +44,57 @@ export interface BinaryResponse {
   suggestedFileName: string | null;
 }
 
+// Parse a Content-Disposition header for a filename. Prefers RFC 6266
+// `filename*=UTF-8''…` (percent-decoded) and falls back to `filename="…"`.
+function parseContentDispositionFilename(cd: string): string | null {
+  const extMatch = /filename\*=(?:UTF-8'')?([^;]+)/i.exec(cd);
+  if (extMatch) {
+    const raw = extMatch[1].trim().replace(/^"|"$/g, '');
+    try { return decodeURIComponent(raw); } catch { return raw; }
+  }
+  const m = /filename="?([^";]+)"?/i.exec(cd);
+  return m ? m[1] : null;
+}
+
 export class OFWClient {
   private token: string | null = null;
   private tokenExpiry: Date | null = null;
 
   async request<T>(method: string, path: string, body?: unknown): Promise<T> {
     await this.ensureAuthenticated();
-    return this.doRequest<T>(method, path, body, false);
+    const response = await this.fetchWithRetry(method, path, body, 'application/json', false);
+    const text = await response.text();
+    return (text ? JSON.parse(text) : null) as T;
   }
 
   /** Like `request`, but returns the raw bytes plus Content-Type/-Disposition metadata. */
   async requestBinary(method: string, path: string): Promise<BinaryResponse> {
     await this.ensureAuthenticated();
-    return this.doRequestBinary(method, path, false);
-  }
-
-  private async doRequestBinary(method: string, path: string, isRetry: boolean): Promise<BinaryResponse> {
-    const headers: Record<string, string> = {
-      'ofw-client': 'WebApplication',
-      'ofw-version': '1.0.0',
-      Accept: 'application/octet-stream',
-      Authorization: `Bearer ${this.token!}`,
-    };
-    const response = await fetch(`${BASE_URL}${path}`, { method, headers });
-    if (response.status === 401 && !isRetry) {
-      this.token = null;
-      this.tokenExpiry = null;
-      await this.ensureAuthenticated();
-      return this.doRequestBinary(method, path, true);
-    }
-    if (response.status === 429 && !isRetry) {
-      await new Promise<void>((r) => setTimeout(r, 2000));
-      return this.doRequestBinary(method, path, true);
-    }
-    if (!response.ok) {
-      throw new Error(`OFW API error: ${response.status} ${response.statusText} for ${method} ${path}`);
-    }
-    const buf = Buffer.from(await response.arrayBuffer());
-    const cd = response.headers.get('content-disposition') ?? '';
-    // RFC 6266: filename*=UTF-8''… takes priority; fall back to filename="…"
-    let suggestedFileName: string | null = null;
-    const extMatch = /filename\*=(?:UTF-8'')?([^;]+)/i.exec(cd);
-    if (extMatch) {
-      try { suggestedFileName = decodeURIComponent(extMatch[1].trim().replace(/^"|"$/g, '')); } catch { suggestedFileName = extMatch[1]; }
-    } else {
-      const m = /filename="?([^";]+)"?/i.exec(cd);
-      if (m) suggestedFileName = m[1];
-    }
+    const response = await this.fetchWithRetry(method, path, undefined, 'application/octet-stream', false);
     return {
-      body: buf,
+      body: Buffer.from(await response.arrayBuffer()),
       contentType: response.headers.get('content-type'),
-      suggestedFileName,
+      suggestedFileName: parseContentDispositionFilename(response.headers.get('content-disposition') ?? ''),
     };
   }
 
-  private async doRequest<T>(
+  // Single fetch+retry scaffold for both JSON and binary callers. Handles
+  // 401 (re-auth and replay once), 429 (wait 2s and replay once), and
+  // turns any other non-2xx into a thrown Error.
+  private async fetchWithRetry(
     method: string,
     path: string,
     body: unknown,
-    isRetry: boolean
-  ): Promise<T> {
+    accept: string,
+    isRetry: boolean,
+  ): Promise<Response> {
     const isFormData = body instanceof FormData;
     const headers: Record<string, string> = {
-      'ofw-client': 'WebApplication',
-      'ofw-version': '1.0.0',
-      Accept: 'application/json',
+      ...OFW_PROTOCOL_HEADERS,
+      Accept: accept,
       Authorization: `Bearer ${this.token!}`,
     };
-    if (!isFormData) headers['Content-Type'] = 'application/json';
+    if (body !== undefined && !isFormData) headers['Content-Type'] = 'application/json';
 
     const response = await fetch(`${BASE_URL}${path}`, {
       method,
@@ -125,25 +106,19 @@ export class OFWClient {
       this.token = null;
       this.tokenExpiry = null;
       await this.ensureAuthenticated();
-      return this.doRequest<T>(method, path, body, true);
+      return this.fetchWithRetry(method, path, body, accept, true);
     }
-
     if (response.status === 429) {
       if (!isRetry) {
         await new Promise<void>((r) => setTimeout(r, 2000));
-        return this.doRequest<T>(method, path, body, true);
+        return this.fetchWithRetry(method, path, body, accept, true);
       }
       throw new Error('Rate limited by OFW API');
     }
-
     if (!response.ok) {
-      throw new Error(
-        `OFW API error: ${response.status} ${response.statusText} for ${method} ${path}`
-      );
+      throw new Error(`OFW API error: ${response.status} ${response.statusText} for ${method} ${path}`);
     }
-
-    const text = await response.text();
-    return (text ? JSON.parse(text) : null) as T;
+    return response;
   }
 
   private async ensureAuthenticated(): Promise<void> {
@@ -161,24 +136,25 @@ export class OFWClient {
     // Spring Security requires a SESSION cookie before accepting the login POST.
     // GET /ofw/login.form with redirect:manual to capture the Set-Cookie from the 303 response.
     const initResponse = await fetch(`${BASE_URL}/ofw/login.form`, {
-      headers: { 'ofw-client': 'WebApplication', 'ofw-version': '1.0.0' },
+      headers: { ...OFW_PROTOCOL_HEADERS },
       redirect: 'manual',
     });
     // Extract just the SESSION=value part (strip attributes like Path, Secure, etc.)
     const setCookie = initResponse.headers.get('set-cookie') ?? '';
-    const sessionCookie = setCookie.split(';')[0]; // split always returns a string; empty string is falsy
+    const sessionCookie = setCookie.split(';')[0];
 
     const response = await fetch(`${BASE_URL}/ofw/login`, {
       method: 'POST',
       headers: {
-        ...STATIC_HEADERS,
+        ...OFW_PROTOCOL_HEADERS,
+        Accept: 'application/json',
         'Content-Type': 'application/x-www-form-urlencoded',
         ...(sessionCookie ? { Cookie: sessionCookie } : {}),
       },
       body: new URLSearchParams({
         submit: 'Sign In',
         _eventId: 'submit',
-        username: username,
+        username,
         password,
       }).toString(),
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,8 +25,10 @@ export function getCacheDbPath(): string {
 export function getAttachmentsDir(): string {
   const override = process.env.OFW_ATTACHMENTS_DIR;
   if (override && override.trim().length > 0) return override.trim();
-  // Sibling to the cache db: ~/.cache/ofw-mcp/attachments/<hash>/
-  const username = readUsername();
-  const hash = createHash('sha256').update(username).digest('hex').slice(0, 16);
-  return join(getCacheDir(), 'attachments', hash);
+  // Default to ~/Downloads/ofw-mcp/ — the cache dir (~/.cache/...) is hidden and
+  // typically outside the filesystem allowlist of sandboxed MCP hosts like
+  // Claude Desktop, so files written there are unreadable to the model that
+  // just downloaded them. Downloads is the standard "user-accessible files"
+  // location across macOS/Linux/Windows.
+  return join(homedir(), 'Downloads', 'ofw-mcp');
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,3 +32,14 @@ export function getAttachmentsDir(): string {
   // location across macOS/Linux/Windows.
   return join(homedir(), 'Downloads', 'ofw-mcp');
 }
+
+// Default for ofw_download_attachment's `inline` arg when the caller doesn't
+// pass one. Set OFW_INLINE_ATTACHMENTS=true to have attachments returned as
+// MCP content blocks by default (skipping disk) — useful on sandboxed MCP
+// hosts where filesystem reads back to the model aren't available.
+// Accepts: "1", "true", "yes", "on" (case-insensitive) → true; anything else → false.
+export function getDefaultInlineAttachments(): boolean {
+  const raw = process.env.OFW_INLINE_ATTACHMENTS;
+  if (typeof raw !== 'string') return false;
+  return ['1', 'true', 'yes', 'on'].includes(raw.trim().toLowerCase());
+}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -4,10 +4,10 @@ import {
   upsertMessage, getMessage, setSyncState,
   upsertDraft, getDraft, deleteDraft, listDraftIds,
   upsertAttachmentForMessage,
-  type MessageRow, type Recipient, type DraftRow, type FolderName,
+  type MessageRow, type DraftRow, type FolderName,
 } from './cache.js';
+import { mapRecipients } from './tools/_shared.js';
 
-// ─── Attachment metadata ──────────────────────────────────────────────────────
 // Each OFW message detail returns `files: [fileId, ...]`. We fetch the metadata
 // for each file id (cheap JSON call) so the model can see filenames/mime types
 // without downloading bytes. Bytes are pulled lazily by ofw_download_attachment.
@@ -23,36 +23,37 @@ interface FileMetaResponse {
   lastUpdateDate?: { dateTime?: string };
 }
 
-export async function fetchAndCacheAttachmentMeta(
+// Fetches OFW attachment metadata for one file id and writes it to the cache.
+// Throws on network/HTTP errors — callers in bulk-sync paths wrap this in the
+// best-effort helper below; callers that need the result (download tool) let
+// the throw propagate.
+export async function fetchAttachmentMeta(
   client: OFWClient,
   fileId: number,
-  messageId: number
+  messageId: number,
 ): Promise<void> {
-  try {
-    const meta = await client.request<FileMetaResponse>('GET', `/pub/v1/myfiles/${fileId}`);
-    upsertAttachmentForMessage({
-      fileId: meta.fileId ?? fileId,
-      fileName: meta.fileName ?? `file-${fileId}`,
-      label: meta.label ?? meta.fileName ?? `file-${fileId}`,
-      mimeType: meta.fileType ?? 'application/octet-stream',
-      sizeBytes: typeof meta.fileSize === 'number' ? meta.fileSize : null,
-      metadata: meta,
-      messageId,
-    });
-  } catch {
-    // Attachment metadata failures shouldn't break the surrounding sync.
-    // The file ids stay in the message's listData; the model can retry later
-    // via ofw_download_attachment, which will surface the actual error.
-  }
+  const meta = await client.request<FileMetaResponse>('GET', `/pub/v1/myfiles/${fileId}`);
+  upsertAttachmentForMessage({
+    fileId: meta.fileId ?? fileId,
+    fileName: meta.fileName ?? `file-${fileId}`,
+    label: meta.label ?? meta.fileName ?? `file-${fileId}`,
+    mimeType: meta.fileType ?? 'application/octet-stream',
+    sizeBytes: typeof meta.fileSize === 'number' ? meta.fileSize : null,
+    metadata: meta,
+    messageId,
+  });
 }
 
 export async function fetchAttachmentMetaForMessage(
   client: OFWClient,
   messageId: number,
-  fileIds: number[]
+  fileIds: number[],
 ): Promise<void> {
   for (const fid of fileIds) {
-    await fetchAndCacheAttachmentMeta(client, fid, messageId);
+    // Best-effort: a single bad attachment shouldn't break the surrounding
+    // sync. The file id stays in the message's listData; the model can
+    // retry later via ofw_download_attachment, which surfaces the real error.
+    try { await fetchAttachmentMeta(client, fid, messageId); } catch { /* swallow */ }
   }
 }
 
@@ -111,14 +112,6 @@ export interface MessageSyncResult {
   unread: UnreadHint[];
 }
 
-function recipientsFromList(item: ListItem): Recipient[] {
-  return (item.recipients ?? []).map((r) => ({
-    userId: r.user.id,
-    name: r.user.name,
-    viewedAt: r.viewed?.dateTime ?? null,
-  }));
-}
-
 export async function syncMessageFolder(
   client: OFWClient,
   folder: 'inbox' | 'sent',
@@ -171,7 +164,7 @@ export async function syncMessageFolder(
         subject: item.subject ?? '(no subject)',
         fromUser: item.from?.name ?? '',
         sentAt: item.date?.dateTime ?? new Date().toISOString(),
-        recipients: recipientsFromList(item),
+        recipients: mapRecipients(item.recipients),
         body,
         fetchedBodyAt,
         replyToId: null,
@@ -237,11 +230,7 @@ export async function syncDrafts(client: OFWClient, draftsFolderId: string): Pro
       id: item.id,
       subject: detail.subject ?? item.subject ?? '(no subject)',
       body: detail.body ?? '',
-      recipients: (item.recipients ?? []).map((r) => ({
-        userId: r.user?.id ?? 0,
-        name: r.user?.name ?? '',
-        viewedAt: r.viewed?.dateTime ?? null,
-      })),
+      recipients: mapRecipients(item.recipients),
       replyToId: item.replyToId ?? null,
       modifiedAt,
       listData: item,

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -1,0 +1,32 @@
+import { isAbsolute, join, resolve } from 'node:path';
+import type { Recipient } from '../cache.js';
+
+export function jsonResponse(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }] };
+}
+
+export function textResponse(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+interface ApiRecipient {
+  user?: { id?: number; name?: string };
+  viewed?: { dateTime: string } | null;
+}
+
+// Translates OFW API recipient shape into the cache's normalized Recipient.
+// Used wherever we surface or persist recipients (sync, get_message, send,
+// save_draft) — all five call sites had near-identical inline mappings.
+export function mapRecipients(items: ApiRecipient[] | undefined | null): Recipient[] {
+  return (items ?? []).map((r) => ({
+    userId: r.user?.id ?? 0,
+    name: r.user?.name ?? '',
+    viewedAt: r.viewed?.dateTime ?? null,
+  }));
+}
+
+// Expand a user-provided path: ~ → $HOME, relative → absolute.
+export function expandPath(p: string): string {
+  const expanded = p.startsWith('~/') ? join(process.env.HOME ?? '', p.slice(2)) : p;
+  return isAbsolute(expanded) ? expanded : resolve(expanded);
+}

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { OFWClient } from '../client.js';
+import { jsonResponse, textResponse } from './_shared.js';
 
 export function registerCalendarTools(server: McpServer, client: OFWClient): void {
   server.registerTool('ofw_list_events', {
@@ -17,7 +18,7 @@ export function registerCalendarTools(server: McpServer, client: OFWClient): voi
       'GET',
       `/pub/v1/calendar/${variant}?startDate=${encodeURIComponent(args.startDate)}&endDate=${encodeURIComponent(args.endDate)}`
     );
-    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 
   server.registerTool('ofw_create_event', {
@@ -38,7 +39,7 @@ export function registerCalendarTools(server: McpServer, client: OFWClient): voi
     },
   }, async (args) => {
     const data = await client.request('POST', '/pub/v1/calendar/events', args);
-    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 
   server.registerTool('ofw_update_event', {
@@ -57,7 +58,7 @@ export function registerCalendarTools(server: McpServer, client: OFWClient): voi
   }, async (args) => {
     const { eventId, ...updateData } = args;
     const data = await client.request('PUT', `/pub/v1/calendar/events/${encodeURIComponent(eventId)}`, updateData);
-    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 
   server.registerTool('ofw_delete_event', {
@@ -68,6 +69,6 @@ export function registerCalendarTools(server: McpServer, client: OFWClient): voi
     },
   }, async (args) => {
     await client.request('DELETE', `/pub/v1/calendar/events/${encodeURIComponent(args.eventId)}`);
-    return { content: [{ type: 'text' as const, text: `Event ${args.eventId} deleted` }] };
+    return textResponse(`Event ${args.eventId} deleted`);
   });
 }

--- a/src/tools/expenses.ts
+++ b/src/tools/expenses.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { OFWClient } from '../client.js';
+import { jsonResponse } from './_shared.js';
 
 export function registerExpenseTools(server: McpServer, client: OFWClient): void {
   server.registerTool('ofw_get_expense_totals', {
@@ -8,7 +9,7 @@ export function registerExpenseTools(server: McpServer, client: OFWClient): void
     annotations: { readOnlyHint: true },
   }, async () => {
     const data = await client.request('GET', '/pub/v2/expense/expenses/totals');
-    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 
   server.registerTool('ofw_list_expenses', {
@@ -22,7 +23,7 @@ export function registerExpenseTools(server: McpServer, client: OFWClient): void
     const start = args.start ?? 0;
     const max = args.max ?? 20;
     const data = await client.request('GET', `/pub/v2/expense/expenses?start=${start}&max=${max}`);
-    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 
   server.registerTool('ofw_create_expense', {
@@ -34,6 +35,6 @@ export function registerExpenseTools(server: McpServer, client: OFWClient): void
     },
   }, async (args) => {
     const data = await client.request('POST', '/pub/v2/expense/expenses', args);
-    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 }

--- a/src/tools/journal.ts
+++ b/src/tools/journal.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { OFWClient } from '../client.js';
+import { jsonResponse } from './_shared.js';
 
 export function registerJournalTools(server: McpServer, client: OFWClient): void {
   server.registerTool('ofw_list_journal_entries', {
@@ -15,7 +16,7 @@ export function registerJournalTools(server: McpServer, client: OFWClient): void
     const start = args.start ?? 1;
     const max = args.max ?? 10;
     const data = await client.request('GET', `/pub/v1/journals?start=${start}&max=${max}`);
-    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 
   server.registerTool('ofw_create_journal_entry', {
@@ -27,6 +28,6 @@ export function registerJournalTools(server: McpServer, client: OFWClient): void
     },
   }, async (args) => {
     const data = await client.request('POST', '/pub/v1/journals', args);
-    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 }

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -1,16 +1,17 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { OFWClient } from '../client.js';
-import { syncAll, fetchAttachmentMetaForMessage } from '../sync.js';
+import { syncAll, fetchAttachmentMeta, fetchAttachmentMetaForMessage } from '../sync.js';
 import {
   listMessages, countMessages, listDrafts, getMessage, upsertMessage,
   upsertDraft, deleteDraft, findLatestReplyTip,
   listAttachmentsForMessage, getAttachment, upsertAttachmentForMessage, markAttachmentDownloaded,
-  type MessageRow, type DraftRow, type Recipient,
+  type MessageRow, type DraftRow,
 } from '../cache.js';
 import { getAttachmentsDir, getDefaultInlineAttachments } from '../config.js';
 import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { basename, dirname, extname, join, isAbsolute, resolve } from 'node:path';
+import { basename, dirname, extname, join } from 'node:path';
+import { expandPath, jsonResponse, mapRecipients, textResponse } from './_shared.js';
 
 // Lightweight mime sniff from extension. OFW re-derives mime from the filename
 // server-side anyway, so this is just a polite Content-Type for the Blob.
@@ -58,7 +59,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     annotations: { readOnlyHint: true },
   }, async () => {
     const data = await client.request('GET', '/pub/v1/messageFolders?includeFolderCounts=true');
-    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 
   server.registerTool('ofw_list_messages', {
@@ -82,15 +83,10 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     else if (folderArg === 'sent') folder = 'sent';
     else if (folderArg === 'both') folder = undefined;
     else {
-      return {
-        content: [{
-          type: 'text' as const,
-          text: JSON.stringify({
-            messages: [],
-            note: 'folderId must be "inbox", "sent", or "both". Numeric OFW folder IDs are not supported by the cache.',
-          }, null, 2),
-        }],
-      };
+      return jsonResponse({
+        messages: [],
+        note: 'folderId must be "inbox", "sent", or "both". Numeric OFW folder IDs are not supported by the cache.',
+      });
     }
 
     const filter = { folder, since: args.since, until: args.until, q: args.q };
@@ -104,7 +100,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       payload.note = `Showing ${(page - 1) * size + 1}–${(page - 1) * size + messages.length} of ${total}. Increase 'page' to see more, or narrow with since/until/q.`;
     }
 
-    return { content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }] };
+    return jsonResponse(payload);
   });
 
   server.registerTool('ofw_get_message', {
@@ -136,7 +132,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
           // Backfill is best-effort. Fall through with whatever we have.
         }
       }
-      return { content: [{ type: 'text' as const, text: JSON.stringify({ ...cached, attachments }, null, 2) }] };
+      return jsonResponse({ ...cached, attachments });
     }
 
     const detail = await client.request<{
@@ -146,10 +142,6 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       recipients?: Array<{ user: { id: number; name: string }; viewed?: { dateTime: string } | null }>;
     }>('GET', `/pub/v3/messages/${encodeURIComponent(args.messageId)}`);
 
-    const recipients: Recipient[] = (detail.recipients ?? []).map((r) => ({
-      userId: r.user.id, name: r.user.name, viewedAt: r.viewed?.dateTime ?? null,
-    }));
-
     const folder: 'inbox' | 'sent' = cached?.folder ?? 'inbox';
     const row: MessageRow = {
       id: detail.id,
@@ -157,7 +149,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       subject: detail.subject,
       fromUser: detail.from?.name ?? '',
       sentAt: detail.date?.dateTime ?? new Date().toISOString(),
-      recipients,
+      recipients: mapRecipients(detail.recipients),
       body: detail.body ?? '',
       fetchedBodyAt: new Date().toISOString(),
       replyToId: cached?.replyToId ?? null,
@@ -169,7 +161,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       await fetchAttachmentMetaForMessage(client, detail.id, detail.files);
     }
     const attachments = listAttachmentsForMessage(detail.id);
-    return { content: [{ type: 'text' as const, text: JSON.stringify({ ...row, attachments }, null, 2) }] };
+    return jsonResponse({ ...row, attachments });
   });
 
   server.registerTool('ofw_send_message', {
@@ -214,16 +206,13 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     });
 
     if (data && typeof data.id === 'number') {
-      const recipients: Recipient[] = (data.recipients ?? []).map((r) => ({
-        userId: r.user.id, name: r.user.name, viewedAt: r.viewed?.dateTime ?? null,
-      }));
       const row: MessageRow = {
         id: data.id,
         folder: 'sent',
         subject: data.subject ?? args.subject,
         fromUser: data.from?.name ?? '',
         sentAt: data.date?.dateTime ?? new Date().toISOString(),
-        recipients,
+        recipients: mapRecipients(data.recipients),
         body: data.body ?? args.body,
         fetchedBodyAt: new Date().toISOString(),
         replyToId: resolvedReplyTo,
@@ -249,15 +238,12 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     }
 
     if (args.draftId !== undefined) {
-      const form = new FormData();
-      form.append('messageIds', String(args.draftId));
-      await client.request('DELETE', '/pub/v1/messages', form);
+      await deleteOFWMessages(client, [args.draftId]);
       deleteDraft(args.draftId);
     }
 
     const text = data ? JSON.stringify(data, null, 2) : 'Message sent successfully.';
-    const finalText = rewriteNote ? `${rewriteNote}\n\n${text}` : text;
-    return { content: [{ type: 'text' as const, text: finalText }] };
+    return textResponse(rewriteNote ? `${rewriteNote}\n\n${text}` : text);
   });
 
   server.registerTool('ofw_list_drafts', {
@@ -274,7 +260,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     const payload = drafts.length === 0
       ? { drafts: [], note: 'Cache empty. Call ofw_sync_messages to populate.' }
       : { drafts };
-    return { content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }] };
+    return jsonResponse(payload);
   });
 
   server.registerTool('ofw_save_draft', {
@@ -324,9 +310,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
         id: data.id,
         subject: data.subject ?? args.subject,
         body: data.body ?? args.body,
-        recipients: (data.recipients ?? []).map((r) => ({
-          userId: r.user.id, name: r.user.name, viewedAt: r.viewed?.dateTime ?? null,
-        })),
+        recipients: mapRecipients(data.recipients),
         replyToId: data.replyToId ?? resolvedReplyTo,
         modifiedAt: data.date?.dateTime ?? new Date().toISOString(),
         listData: data,
@@ -335,8 +319,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     }
 
     const text = data ? JSON.stringify(data, null, 2) : 'Draft saved.';
-    const finalText = rewriteNote ? `${rewriteNote}\n\n${text}` : text;
-    return { content: [{ type: 'text' as const, text: finalText }] };
+    return textResponse(rewriteNote ? `${rewriteNote}\n\n${text}` : text);
   });
 
   server.registerTool('ofw_delete_draft', {
@@ -346,11 +329,9 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       messageId: z.number().describe('Draft message ID to delete'),
     },
   }, async (args) => {
-    const form = new FormData();
-    form.append('messageIds', String(args.messageId));
-    const data = await client.request('DELETE', '/pub/v1/messages', form);
+    const data = await deleteOFWMessages(client, [args.messageId]);
     deleteDraft(args.messageId);
-    return { content: [{ type: 'text' as const, text: data ? JSON.stringify(data, null, 2) : 'Draft deleted.' }] };
+    return data ? jsonResponse(data) : textResponse('Draft deleted.');
   });
 
   server.registerTool('ofw_get_unread_sent', {
@@ -366,9 +347,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     const sent = listMessages({ folder: 'sent', page, size });
 
     if (sent.length === 0) {
-      return { content: [{ type: 'text' as const, text: JSON.stringify({
-        note: 'Sent cache is empty. Call ofw_sync_messages to populate.',
-      }, null, 2) }] };
+      return jsonResponse({ note: 'Sent cache is empty. Call ofw_sync_messages to populate.' });
     }
 
     const unread: Array<{ id: number; subject: string; sentAt: string; unreadBy: string[] }> = [];
@@ -380,11 +359,9 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     }
 
     if (unread.length === 0) {
-      return { content: [{ type: 'text' as const, text: JSON.stringify({
-        message: 'All scanned sent messages have been read.',
-      }, null, 2) }] };
+      return jsonResponse({ message: 'All scanned sent messages have been read.' });
     }
-    return { content: [{ type: 'text' as const, text: JSON.stringify(unread, null, 2) }] };
+    return jsonResponse(unread);
   });
 
   server.registerTool('ofw_upload_attachment', {
@@ -397,18 +374,14 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       description: z.string().describe('Description shown in OFW My Files (default: filename)').optional(),
     },
   }, async (args) => {
-    // Resolve and read the local file
-    const expanded = args.path.startsWith('~/')
-      ? join(process.env.HOME ?? '', args.path.slice(2))
-      : args.path;
-    const abs = isAbsolute(expanded) ? expanded : resolve(expanded);
+    const abs = expandPath(args.path);
     const stat = statSync(abs); // throws if missing
     if (!stat.isFile()) throw new Error(`Not a file: ${abs}`);
     const buf = readFileSync(abs);
     const fileName = basename(abs);
     const mime = mimeFromName(fileName);
 
-    // Build the multipart payload matching the OFW web UI's request shape
+    // Build the multipart payload matching the OFW web UI's request shape.
     const form = new FormData();
     form.append('file', new Blob([new Uint8Array(buf)], { type: mime }), fileName);
     form.append('source', 'message');
@@ -422,10 +395,9 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       fileType?: string; sizeInBytes?: number; shareClass?: string;
     }>('POST', '/pub/v3/myfiles/multipart', form);
 
-    // Cache the metadata so subsequent ofw_get_message calls can surface it
-    // and ofw_download_attachment short-circuits if asked. messageId is 0
-    // because no message references this yet — it'll be linked once a
-    // message is sent with this fileId in its attachments.
+    // Cache metadata so subsequent ofw_get_message calls can surface it and
+    // ofw_download_attachment can short-circuit. messageId is 0 (the
+    // not-yet-linked sentinel) until a message actually references this file.
     upsertAttachmentForMessage({
       fileId: meta.fileId,
       fileName: meta.fileName ?? fileName,
@@ -436,14 +408,14 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       messageId: 0,
     });
 
-    return { content: [{ type: 'text' as const, text: JSON.stringify({
+    return jsonResponse({
       fileId: meta.fileId,
       fileName: meta.fileName ?? fileName,
       mimeType: meta.fileType ?? mime,
       sizeBytes: meta.sizeInBytes ?? buf.length,
       shareClass: meta.shareClass ?? args.shareClass ?? 'PRIVATE',
       note: 'Pass this fileId to ofw_send_message or ofw_save_draft in myFileIDs to attach it.',
-    }, null, 2) }] };
+    });
   });
 
   server.registerTool('ofw_download_attachment', {
@@ -460,44 +432,22 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     const inline = args.inline ?? getDefaultInlineAttachments();
     let cached = getAttachment(fileId);
     if (!cached) {
-      // Metadata not in cache — fetch on the fly.
-      const meta = await client.request<{
-        fileId: number; label?: string; fileName?: string; fileType?: string; fileSize?: number;
-      }>('GET', `/pub/v1/myfiles/${fileId}`);
-      // Store with a sentinel "metadata-only, no message link" — we don't know which message asked.
-      // We'll re-link if a message later references it during sync.
-      upsertAttachmentForMessage({
-        fileId: meta.fileId ?? fileId,
-        fileName: meta.fileName ?? `file-${fileId}`,
-        label: meta.label ?? meta.fileName ?? `file-${fileId}`,
-        mimeType: meta.fileType ?? 'application/octet-stream',
-        sizeBytes: typeof meta.fileSize === 'number' ? meta.fileSize : null,
-        metadata: meta,
-        messageId: 0, // placeholder; will be cleaned up if a real message references it
-      });
+      // Not in cache. Fetch metadata and store under the messageId=0
+      // sentinel — gets re-linked if a message later references this file.
+      await fetchAttachmentMeta(client, fileId, 0);
       cached = getAttachment(fileId);
       if (!cached) throw new Error(`failed to fetch metadata for fileId ${fileId}`);
     }
 
-    // Inline mode: return bytes as MCP content, no disk write.
     if (inline) {
-      // Reuse on-disk bytes if we already have them, otherwise fetch fresh.
-      let bytes: Buffer;
-      let mimeType: string;
-      let fileName: string;
+      // Reuse on-disk bytes if we already have them; otherwise fetch fresh.
+      let bytes: Buffer | null = null;
+      let mimeType = cached.mimeType;
+      let fileName = cached.fileName;
       if (cached.downloadedPath) {
-        try {
-          bytes = readFileSync(cached.downloadedPath);
-          mimeType = cached.mimeType;
-          fileName = cached.fileName;
-        } catch {
-          // On-disk copy went missing — fall through to a network fetch.
-          const response = await client.requestBinary('GET', `/pub/v1/myfiles/${fileId}/data`);
-          bytes = response.body;
-          mimeType = response.contentType ?? cached.mimeType;
-          fileName = response.suggestedFileName ?? cached.fileName;
-        }
-      } else {
+        try { bytes = readFileSync(cached.downloadedPath); } catch { /* on-disk copy missing; fall through */ }
+      }
+      if (bytes === null) {
         const response = await client.requestBinary('GET', `/pub/v1/myfiles/${fileId}/data`);
         bytes = response.body;
         mimeType = response.contentType ?? cached.mimeType;
@@ -517,41 +467,35 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       } }] };
     }
 
-    // Decide destination path
     let dest: string;
     if (args.saveTo) {
-      const expanded = args.saveTo.startsWith('~/')
-        ? join(process.env.HOME ?? '', args.saveTo.slice(2))
-        : args.saveTo;
-      const abs = isAbsolute(expanded) ? expanded : resolve(expanded);
-      // If it looks like a directory (ends with /) OR is an existing directory, treat as dir.
-      const isDirArg = expanded.endsWith('/') || expanded.endsWith('\\');
+      // Treat saveTo as a directory if it ends with a separator; otherwise as a full path.
+      const isDirArg = args.saveTo.endsWith('/') || args.saveTo.endsWith('\\');
+      const abs = expandPath(args.saveTo);
       dest = isDirArg ? join(abs, `${fileId}-${cached.fileName}`) : abs;
     } else {
       dest = join(getAttachmentsDir(), `${fileId}-${cached.fileName}`);
     }
 
-    // Short-circuit if already downloaded to this path
     if (!args.force && cached.downloadedPath === dest) {
-      return { content: [{ type: 'text' as const, text: JSON.stringify({
+      return jsonResponse({
         fileId, path: dest, mimeType: cached.mimeType, sizeBytes: cached.sizeBytes,
         fileName: cached.fileName, note: 'already downloaded',
-      }, null, 2) }] };
+      });
     }
 
-    // Fetch bytes
     const response = await client.requestBinary('GET', `/pub/v1/myfiles/${fileId}/data`);
     mkdirSync(dirname(dest), { recursive: true });
     writeFileSync(dest, response.body);
     markAttachmentDownloaded(fileId, dest);
 
-    return { content: [{ type: 'text' as const, text: JSON.stringify({
+    return jsonResponse({
       fileId,
       path: dest,
       mimeType: response.contentType ?? cached.mimeType,
       sizeBytes: response.body.length,
       fileName: response.suggestedFileName ?? cached.fileName,
-    }, null, 2) }] };
+    });
   });
 
   server.registerTool('ofw_sync_messages', {
@@ -568,6 +512,14 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       fetchUnreadBodies: args.fetchUnreadBodies,
       deep: args.deep,
     });
-    return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    return jsonResponse(result);
   });
+}
+
+// OFW's bulk-delete endpoint takes a multipart form with `messageIds`.
+// Used by both ofw_delete_draft and ofw_send_message (draft cleanup).
+async function deleteOFWMessages(client: OFWClient, ids: number[]): Promise<unknown> {
+  const form = new FormData();
+  for (const id of ids) form.append('messageIds', String(id));
+  return client.request('DELETE', '/pub/v1/messages', form);
 }

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -447,11 +447,11 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
   });
 
   server.registerTool('ofw_download_attachment', {
-    description: 'Download an OFW message attachment by fileId. Bytes are saved to disk; the tool returns the absolute path, mime type, and size so the caller can then read/analyze the file. fileId comes from the attachments array on ofw_get_message. Saves under ~/.cache/ofw-mcp/attachments/<hash>/ by default (override via OFW_ATTACHMENTS_DIR or the saveTo argument). Re-downloading is a no-op if the file is already on disk.',
+    description: 'Download an OFW message attachment by fileId. Bytes are saved to disk; the tool returns the absolute path, mime type, and size so the caller can then read/analyze the file. fileId comes from the attachments array on ofw_get_message. Saves under ~/Downloads/ofw-mcp/ by default — a user-accessible location so sandboxed MCP hosts (e.g. Claude Desktop) can read the file back. Override with OFW_ATTACHMENTS_DIR or the saveTo argument. Re-downloading is a no-op if the file is already on disk.',
     annotations: { readOnlyHint: false },
     inputSchema: {
       fileId: z.number().describe('Attachment file id (from ofw_get_message → attachments[].fileId)'),
-      saveTo: z.string().describe('Absolute path or directory to write to. If a directory, the OFW filename is used. Default: ~/.cache/ofw-mcp/attachments/<hash>/<fileId>-<filename>').optional(),
+      saveTo: z.string().describe('Absolute path or directory to write to. If a directory, the OFW filename is used. Default: ~/Downloads/ofw-mcp/<fileId>-<filename>').optional(),
       force: z.boolean().describe('Re-download even if already on disk. Default false.').optional(),
     },
   }, async (args) => {

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -8,7 +8,7 @@ import {
   listAttachmentsForMessage, getAttachment, upsertAttachmentForMessage, markAttachmentDownloaded,
   type MessageRow, type DraftRow, type Recipient,
 } from '../cache.js';
-import { getAttachmentsDir } from '../config.js';
+import { getAttachmentsDir, getDefaultInlineAttachments } from '../config.js';
 import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, extname, join, isAbsolute, resolve } from 'node:path';
 
@@ -447,16 +447,17 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
   });
 
   server.registerTool('ofw_download_attachment', {
-    description: 'Download an OFW message attachment by fileId. By default, bytes are saved to disk (~/Downloads/ofw-mcp/) and the response carries the absolute path, mime type, and size for the caller to read back. Pass inline:true to skip disk entirely and return the bytes as MCP content blocks — images come back as ImageContent (the model sees them directly); other files come back as an EmbeddedResource blob. Use inline for small files where you want the model to read content immediately and the host is sandboxed; use disk for large files or when you want a persistent local copy. fileId comes from attachments[].fileId on ofw_get_message. Override disk destination with OFW_ATTACHMENTS_DIR or saveTo. Re-downloading to the same path is a no-op (disk mode only).',
+    description: 'Download an OFW message attachment by fileId. By default, bytes are saved to disk (~/Downloads/ofw-mcp/) and the response carries the absolute path, mime type, and size for the caller to read back. Pass inline:true to skip disk entirely and return the bytes as MCP content blocks — images come back as ImageContent (the model sees them directly); other files come back as an EmbeddedResource blob. Use inline for small files where you want the model to read content immediately and the host is sandboxed; use disk for large files or when you want a persistent local copy. The default for `inline` can be flipped server-side via the OFW_INLINE_ATTACHMENTS env var (set to "true" to make inline the default). fileId comes from attachments[].fileId on ofw_get_message. Override disk destination with OFW_ATTACHMENTS_DIR or saveTo. Re-downloading to the same path is a no-op (disk mode only).',
     annotations: { readOnlyHint: false },
     inputSchema: {
       fileId: z.number().describe('Attachment file id (from ofw_get_message → attachments[].fileId)'),
-      inline: z.boolean().describe('If true, return bytes inline as MCP content (image for image/*, embedded resource blob otherwise) and skip the disk write. Default false (writes to disk).').optional(),
+      inline: z.boolean().describe('If true, return bytes inline as MCP content (image for image/*, embedded resource blob otherwise) and skip the disk write. If false, write to disk and return the path. If omitted, falls back to the OFW_INLINE_ATTACHMENTS env var (default: false = disk).').optional(),
       saveTo: z.string().describe('Absolute path or directory to write to. If a directory, the OFW filename is used. Default: ~/Downloads/ofw-mcp/<fileId>-<filename>. Ignored when inline:true.').optional(),
       force: z.boolean().describe('Re-download even if already on disk. Default false. Ignored when inline:true (inline always fetches fresh bytes, or reuses an on-disk copy if present).').optional(),
     },
   }, async (args) => {
     const fileId = args.fileId;
+    const inline = args.inline ?? getDefaultInlineAttachments();
     let cached = getAttachment(fileId);
     if (!cached) {
       // Metadata not in cache — fetch on the fly.
@@ -479,7 +480,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     }
 
     // Inline mode: return bytes as MCP content, no disk write.
-    if (args.inline) {
+    if (inline) {
       // Reuse on-disk bytes if we already have them, otherwise fetch fresh.
       let bytes: Buffer;
       let mimeType: string;

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -447,12 +447,13 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
   });
 
   server.registerTool('ofw_download_attachment', {
-    description: 'Download an OFW message attachment by fileId. Bytes are saved to disk; the tool returns the absolute path, mime type, and size so the caller can then read/analyze the file. fileId comes from the attachments array on ofw_get_message. Saves under ~/Downloads/ofw-mcp/ by default — a user-accessible location so sandboxed MCP hosts (e.g. Claude Desktop) can read the file back. Override with OFW_ATTACHMENTS_DIR or the saveTo argument. Re-downloading is a no-op if the file is already on disk.',
+    description: 'Download an OFW message attachment by fileId. By default, bytes are saved to disk (~/Downloads/ofw-mcp/) and the response carries the absolute path, mime type, and size for the caller to read back. Pass inline:true to skip disk entirely and return the bytes as MCP content blocks — images come back as ImageContent (the model sees them directly); other files come back as an EmbeddedResource blob. Use inline for small files where you want the model to read content immediately and the host is sandboxed; use disk for large files or when you want a persistent local copy. fileId comes from attachments[].fileId on ofw_get_message. Override disk destination with OFW_ATTACHMENTS_DIR or saveTo. Re-downloading to the same path is a no-op (disk mode only).',
     annotations: { readOnlyHint: false },
     inputSchema: {
       fileId: z.number().describe('Attachment file id (from ofw_get_message → attachments[].fileId)'),
-      saveTo: z.string().describe('Absolute path or directory to write to. If a directory, the OFW filename is used. Default: ~/Downloads/ofw-mcp/<fileId>-<filename>').optional(),
-      force: z.boolean().describe('Re-download even if already on disk. Default false.').optional(),
+      inline: z.boolean().describe('If true, return bytes inline as MCP content (image for image/*, embedded resource blob otherwise) and skip the disk write. Default false (writes to disk).').optional(),
+      saveTo: z.string().describe('Absolute path or directory to write to. If a directory, the OFW filename is used. Default: ~/Downloads/ofw-mcp/<fileId>-<filename>. Ignored when inline:true.').optional(),
+      force: z.boolean().describe('Re-download even if already on disk. Default false. Ignored when inline:true (inline always fetches fresh bytes, or reuses an on-disk copy if present).').optional(),
     },
   }, async (args) => {
     const fileId = args.fileId;
@@ -475,6 +476,44 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       });
       cached = getAttachment(fileId);
       if (!cached) throw new Error(`failed to fetch metadata for fileId ${fileId}`);
+    }
+
+    // Inline mode: return bytes as MCP content, no disk write.
+    if (args.inline) {
+      // Reuse on-disk bytes if we already have them, otherwise fetch fresh.
+      let bytes: Buffer;
+      let mimeType: string;
+      let fileName: string;
+      if (cached.downloadedPath) {
+        try {
+          bytes = readFileSync(cached.downloadedPath);
+          mimeType = cached.mimeType;
+          fileName = cached.fileName;
+        } catch {
+          // On-disk copy went missing — fall through to a network fetch.
+          const response = await client.requestBinary('GET', `/pub/v1/myfiles/${fileId}/data`);
+          bytes = response.body;
+          mimeType = response.contentType ?? cached.mimeType;
+          fileName = response.suggestedFileName ?? cached.fileName;
+        }
+      } else {
+        const response = await client.requestBinary('GET', `/pub/v1/myfiles/${fileId}/data`);
+        bytes = response.body;
+        mimeType = response.contentType ?? cached.mimeType;
+        fileName = response.suggestedFileName ?? cached.fileName;
+      }
+      const base64 = bytes.toString('base64');
+      const metaBlock = { type: 'text' as const, text: JSON.stringify({
+        fileId, fileName, mimeType, sizeBytes: bytes.length, mode: 'inline',
+      }, null, 2) };
+      if (mimeType.startsWith('image/')) {
+        return { content: [metaBlock, { type: 'image' as const, data: base64, mimeType }] };
+      }
+      return { content: [metaBlock, { type: 'resource' as const, resource: {
+        uri: `ofw://attachment/${fileId}/${encodeURIComponent(fileName)}`,
+        mimeType,
+        blob: base64,
+      } }] };
     }
 
     // Decide destination path

--- a/src/tools/user.ts
+++ b/src/tools/user.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { OFWClient } from '../client.js';
+import { jsonResponse } from './_shared.js';
 
 export function registerUserTools(server: McpServer, client: OFWClient): void {
   server.registerTool('ofw_get_profile', {
@@ -7,7 +8,7 @@ export function registerUserTools(server: McpServer, client: OFWClient): void {
     annotations: { readOnlyHint: true },
   }, async () => {
     const data = await client.request('GET', '/pub/v2/profiles');
-    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 
   server.registerTool('ofw_get_notifications', {
@@ -16,6 +17,6 @@ export function registerUserTools(server: McpServer, client: OFWClient): void {
     annotations: { readOnlyHint: false },
   }, async () => {
     const data = await client.request('GET', '/pub/v1/users/useraccountstatus');
-    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    return jsonResponse(data);
   });
 }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -6,6 +6,7 @@ const MOCK_TOKEN = 'test-token-abc';
 interface MockResponse {
   status: number;
   body?: unknown;
+  bytes?: Uint8Array;
   headers?: Record<string, string>;
 }
 
@@ -21,6 +22,7 @@ function mockFetch(responses: MockResponse[]) {
       headers: { get: (key: string) => headerMap[key.toLowerCase()] ?? null },
       json: async () => r.body,
       text: async () => JSON.stringify(r.body),
+      arrayBuffer: async () => (r.bytes ?? new Uint8Array()).buffer,
     } as unknown as Response;
   });
 }
@@ -260,5 +262,183 @@ describe('OFWClient', () => {
     const h = init.headers as Record<string, string>;
     expect(h['ofw-client']).toBe('WebApplication');
     expect(h['ofw-version']).toBe('1.0.0');
+  });
+});
+
+describe('OFWClient.requestBinary', () => {
+  beforeEach(() => {
+    process.env.OFW_USERNAME = 'test@example.com';
+    process.env.OFW_PASSWORD = 'testpass';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+  it('returns body as Buffer with content-type and parsed filename', async () => {
+    mockFetch([
+      LOGIN_INIT,
+      LOGIN_SUCCESS,
+      { status: 200, bytes: PNG_BYTES, headers: {
+        'content-type': 'image/png',
+        'content-disposition': 'attachment; filename="kid.png"',
+      } },
+    ]);
+
+    const client = new OFWClient();
+    const r = await client.requestBinary('GET', '/pub/v1/myfiles/1/data');
+
+    expect(Buffer.isBuffer(r.body)).toBe(true);
+    expect(r.body.equals(Buffer.from(PNG_BYTES))).toBe(true);
+    expect(r.contentType).toBe('image/png');
+    expect(r.suggestedFileName).toBe('kid.png');
+  });
+
+  it('sends Authorization, ofw-* headers, and Accept: application/octet-stream', async () => {
+    const spy = mockFetch([
+      LOGIN_INIT,
+      LOGIN_SUCCESS,
+      { status: 200, bytes: PNG_BYTES },
+    ]);
+
+    const client = new OFWClient();
+    await client.requestBinary('GET', '/pub/v1/myfiles/1/data');
+
+    const init = spy.mock.calls[2][1] as RequestInit;
+    const h = init.headers as Record<string, string>;
+    expect(h['Authorization']).toBe(`Bearer ${MOCK_TOKEN}`);
+    expect(h['Accept']).toBe('application/octet-stream');
+    expect(h['ofw-client']).toBe('WebApplication');
+    expect(h['ofw-version']).toBe('1.0.0');
+    expect(h['Content-Type']).toBeUndefined();
+  });
+
+  it('re-logs in and retries on 401', async () => {
+    const spy = mockFetch([
+      LOGIN_INIT,
+      LOGIN_SUCCESS,
+      { status: 401, body: {} },
+      LOGIN_INIT,
+      { ...LOGIN_SUCCESS, body: { auth: 'new-token', redirectUrl: '/' } },
+      { status: 200, bytes: PNG_BYTES },
+    ]);
+
+    const client = new OFWClient();
+    const r = await client.requestBinary('GET', '/pub/v1/myfiles/1/data');
+    expect(r.body.length).toBe(PNG_BYTES.length);
+    expect(spy).toHaveBeenCalledTimes(6);
+  });
+
+  it('throws on a second 401', async () => {
+    mockFetch([
+      LOGIN_INIT,
+      LOGIN_SUCCESS,
+      { status: 401, body: {} },
+      LOGIN_INIT,
+      LOGIN_SUCCESS,
+      { status: 401, body: {} },
+    ]);
+
+    const client = new OFWClient();
+    await expect(client.requestBinary('GET', '/pub/v1/myfiles/1/data')).rejects.toThrow('401');
+  });
+
+  it('waits 2s and retries on 429', async () => {
+    vi.useFakeTimers();
+    const spy = mockFetch([
+      LOGIN_INIT,
+      LOGIN_SUCCESS,
+      { status: 429, body: {} },
+      { status: 200, bytes: PNG_BYTES },
+    ]);
+
+    const client = new OFWClient();
+    const promise = client.requestBinary('GET', '/pub/v1/myfiles/1/data');
+    await vi.advanceTimersByTimeAsync(2000);
+    const r = await promise;
+
+    expect(r.body.length).toBe(PNG_BYTES.length);
+    expect(spy).toHaveBeenCalledTimes(4);
+    vi.useRealTimers();
+  });
+
+  it('throws "Rate limited" on a second 429 (matches request() behavior)', async () => {
+    vi.useFakeTimers();
+    mockFetch([
+      LOGIN_INIT,
+      LOGIN_SUCCESS,
+      { status: 429, body: {} },
+      { status: 429, body: {} },
+    ]);
+
+    const client = new OFWClient();
+    const promise = client.requestBinary('GET', '/pub/v1/myfiles/1/data');
+    promise.catch(() => {});
+    await vi.advanceTimersByTimeAsync(2000);
+    await expect(promise).rejects.toThrow('Rate limited');
+    vi.useRealTimers();
+  });
+
+  it('throws on non-2xx response', async () => {
+    mockFetch([
+      LOGIN_INIT,
+      LOGIN_SUCCESS,
+      { status: 500, body: {} },
+    ]);
+
+    const client = new OFWClient();
+    await expect(client.requestBinary('GET', '/pub/v1/myfiles/1/data')).rejects.toThrow('500');
+  });
+
+  describe('Content-Disposition filename parsing', () => {
+    async function downloadWithCD(cd: string | undefined): Promise<string | null> {
+      const headers: Record<string, string> = { 'content-type': 'application/octet-stream' };
+      if (cd !== undefined) headers['content-disposition'] = cd;
+      mockFetch([
+        LOGIN_INIT,
+        LOGIN_SUCCESS,
+        { status: 200, bytes: new Uint8Array([1, 2, 3]), headers },
+      ]);
+      const client = new OFWClient();
+      const r = await client.requestBinary('GET', '/pub/v1/myfiles/1/data');
+      return r.suggestedFileName;
+    }
+
+    it('decodes RFC 6266 filename*=UTF-8\'\'percent-encoded', async () => {
+      expect(await downloadWithCD("attachment; filename*=UTF-8''Hello%20World.pdf")).toBe('Hello World.pdf');
+    });
+
+    it('decodes filename*= without the UTF-8\'\' prefix', async () => {
+      expect(await downloadWithCD('attachment; filename*=Hello%20World.pdf')).toBe('Hello World.pdf');
+    });
+
+    it('prefers filename*= over legacy filename=', async () => {
+      expect(await downloadWithCD(
+        'attachment; filename="legacy.pdf"; filename*=UTF-8\'\'fancy%20name.pdf',
+      )).toBe('fancy name.pdf');
+    });
+
+    it('matches legacy quoted filename', async () => {
+      expect(await downloadWithCD('attachment; filename="legacy file.pdf"')).toBe('legacy file.pdf');
+    });
+
+    it('matches legacy unquoted filename', async () => {
+      expect(await downloadWithCD('attachment; filename=legacy.pdf')).toBe('legacy.pdf');
+    });
+
+    it('falls back to the raw value when filename*= has broken percent-encoding', async () => {
+      // %ZZ is invalid → decodeURIComponent throws → we keep the raw token.
+      expect(await downloadWithCD("attachment; filename*=UTF-8''bad%ZZname.pdf")).toBe('bad%ZZname.pdf');
+    });
+
+    it('returns null when there is no Content-Disposition header', async () => {
+      expect(await downloadWithCD(undefined)).toBeNull();
+    });
+
+    it('returns null when Content-Disposition has no filename', async () => {
+      expect(await downloadWithCD('attachment')).toBeNull();
+    });
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { getCacheDbPath } from '../src/config.js';
+import { getAttachmentsDir, getCacheDbPath } from '../src/config.js';
 
 describe('getCacheDbPath', () => {
   let tmp: string;
@@ -46,5 +46,28 @@ describe('getCacheDbPath', () => {
   it('throws if OFW_USERNAME is not set', () => {
     delete process.env.OFW_USERNAME;
     expect(() => getCacheDbPath()).toThrow(/OFW_USERNAME/);
+  });
+});
+
+describe('getAttachmentsDir', () => {
+  let originalAttachmentsDir: string | undefined;
+
+  beforeEach(() => {
+    originalAttachmentsDir = process.env.OFW_ATTACHMENTS_DIR;
+    delete process.env.OFW_ATTACHMENTS_DIR;
+  });
+
+  afterEach(() => {
+    if (originalAttachmentsDir === undefined) delete process.env.OFW_ATTACHMENTS_DIR;
+    else process.env.OFW_ATTACHMENTS_DIR = originalAttachmentsDir;
+  });
+
+  it('defaults to ~/Downloads/ofw-mcp so sandboxed MCP hosts can read the file', () => {
+    expect(getAttachmentsDir()).toBe(join(homedir(), 'Downloads', 'ofw-mcp'));
+  });
+
+  it('honors OFW_ATTACHMENTS_DIR override', () => {
+    process.env.OFW_ATTACHMENTS_DIR = '/custom/attachments';
+    expect(getAttachmentsDir()).toBe('/custom/attachments');
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { getAttachmentsDir, getCacheDbPath } from '../src/config.js';
+import { getAttachmentsDir, getCacheDbPath, getDefaultInlineAttachments } from '../src/config.js';
 
 describe('getCacheDbPath', () => {
   let tmp: string;
@@ -69,5 +69,33 @@ describe('getAttachmentsDir', () => {
   it('honors OFW_ATTACHMENTS_DIR override', () => {
     process.env.OFW_ATTACHMENTS_DIR = '/custom/attachments';
     expect(getAttachmentsDir()).toBe('/custom/attachments');
+  });
+});
+
+describe('getDefaultInlineAttachments', () => {
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env.OFW_INLINE_ATTACHMENTS;
+    delete process.env.OFW_INLINE_ATTACHMENTS;
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.OFW_INLINE_ATTACHMENTS;
+    else process.env.OFW_INLINE_ATTACHMENTS = original;
+  });
+
+  it('defaults to false when unset', () => {
+    expect(getDefaultInlineAttachments()).toBe(false);
+  });
+
+  it.each(['true', 'TRUE', 'True', '1', 'yes', 'on', ' true '])('treats %j as true', (val) => {
+    process.env.OFW_INLINE_ATTACHMENTS = val;
+    expect(getDefaultInlineAttachments()).toBe(true);
+  });
+
+  it.each(['false', '0', 'no', 'off', '', 'maybe'])('treats %j as false', (val) => {
+    process.env.OFW_INLINE_ATTACHMENTS = val;
+    expect(getDefaultInlineAttachments()).toBe(false);
   });
 });

--- a/tests/tools/_shared.test.ts
+++ b/tests/tools/_shared.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { isAbsolute } from 'node:path';
+import { expandPath, jsonResponse, mapRecipients, textResponse } from '../../src/tools/_shared.js';
+
+describe('jsonResponse', () => {
+  it('wraps a payload as a single text content block with pretty-printed JSON', () => {
+    const result = jsonResponse({ foo: 'bar', n: 1 });
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toBe('{\n  "foo": "bar",\n  "n": 1\n}');
+  });
+
+  it('serializes arrays and nested objects', () => {
+    const result = jsonResponse([{ a: 1 }, { a: 2 }]);
+    expect(JSON.parse(result.content[0].text)).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+});
+
+describe('textResponse', () => {
+  it('wraps a string as a single text content block (no JSON-encoding)', () => {
+    const result = textResponse('plain message');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({ type: 'text', text: 'plain message' });
+  });
+});
+
+describe('mapRecipients', () => {
+  it('returns [] for null / undefined / empty input', () => {
+    expect(mapRecipients(null)).toEqual([]);
+    expect(mapRecipients(undefined)).toEqual([]);
+    expect(mapRecipients([])).toEqual([]);
+  });
+
+  it('maps the standard OFW recipient shape into the cache Recipient shape', () => {
+    expect(mapRecipients([
+      { user: { id: 1, name: 'Alice' }, viewed: { dateTime: '2026-05-01T00:00:00Z' } },
+      { user: { id: 2, name: 'Bob' }, viewed: null },
+    ])).toEqual([
+      { userId: 1, name: 'Alice', viewedAt: '2026-05-01T00:00:00Z' },
+      { userId: 2, name: 'Bob', viewedAt: null },
+    ]);
+  });
+
+  it('defaults userId to 0 and name to empty string when user is missing (defensive)', () => {
+    // OFW occasionally returns recipients with a partial or missing user — the
+    // null-safe fallbacks here exist to keep cache writes from blowing up.
+    expect(mapRecipients([
+      { user: undefined, viewed: { dateTime: '2026-05-01T00:00:00Z' } },
+      { user: { id: undefined, name: undefined } },
+      {},
+    ])).toEqual([
+      { userId: 0, name: '', viewedAt: '2026-05-01T00:00:00Z' },
+      { userId: 0, name: '', viewedAt: null },
+      { userId: 0, name: '', viewedAt: null },
+    ]);
+  });
+});
+
+describe('expandPath', () => {
+  let originalHome: string | undefined;
+
+  beforeEach(() => { originalHome = process.env.HOME; });
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+  });
+
+  it('expands ~/ to $HOME', () => {
+    process.env.HOME = '/home/alice';
+    expect(expandPath('~/Downloads/file.pdf')).toBe('/home/alice/Downloads/file.pdf');
+  });
+
+  it('treats absolute paths as-is', () => {
+    expect(expandPath('/tmp/foo/bar.txt')).toBe('/tmp/foo/bar.txt');
+  });
+
+  it('resolves relative paths against cwd to an absolute path', () => {
+    const result = expandPath('relative/path.txt');
+    expect(isAbsolute(result)).toBe(true);
+    expect(result.endsWith('/relative/path.txt')).toBe(true);
+  });
+
+  it('does not strip the leading slash when HOME is unset (regression guard)', () => {
+    delete process.env.HOME;
+    // With HOME unset the join collapses to an absolute path starting at /
+    // — the path stays absolute rather than becoming a relative one.
+    expect(isAbsolute(expandPath('~/foo'))).toBe(true);
+  });
+});

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -859,6 +859,63 @@ describe('ofw_download_attachment', () => {
     expect(Buffer.from(res.resource.blob, 'base64').equals(pdfBytes)).toBe(true);
   });
 
+  it('OFW_INLINE_ATTACHMENTS=true makes inline the default when arg is omitted', async () => {
+    const prev = process.env.OFW_INLINE_ATTACHMENTS;
+    process.env.OFW_INLINE_ATTACHMENTS = 'true';
+    try {
+      const client = new OFWClient();
+      const bytes = Buffer.from('env-flipped', 'utf8');
+      vi.spyOn(client, 'request').mockResolvedValueOnce({
+        fileId: 11, fileName: 'memo.txt', label: 'memo.txt',
+        fileType: 'text/plain', fileSize: bytes.length,
+      });
+      vi.spyOn(client, 'requestBinary').mockResolvedValueOnce({
+        body: bytes, contentType: 'text/plain', suggestedFileName: 'memo.txt',
+      });
+      setup(client);
+
+      // No inline arg — should default to inline because of the env var.
+      const result = await handlers.get('ofw_download_attachment')!({ fileId: 11 });
+      expect(result.content).toHaveLength(2);
+      const meta = JSON.parse(result.content[0].text);
+      expect(meta.mode).toBe('inline');
+      const res = result.content[1];
+      expect(res.type).toBe('resource');
+      expect(Buffer.from(res.resource.blob, 'base64').equals(bytes)).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.OFW_INLINE_ATTACHMENTS;
+      else process.env.OFW_INLINE_ATTACHMENTS = prev;
+    }
+  });
+
+  it('explicit inline:false overrides OFW_INLINE_ATTACHMENTS=true', async () => {
+    const prev = process.env.OFW_INLINE_ATTACHMENTS;
+    process.env.OFW_INLINE_ATTACHMENTS = 'true';
+    try {
+      const client = new OFWClient();
+      vi.spyOn(client, 'request').mockResolvedValueOnce({
+        fileId: 12, fileName: 'memo.txt', label: 'memo.txt',
+        fileType: 'text/plain', fileSize: 4,
+      });
+      vi.spyOn(client, 'requestBinary').mockResolvedValueOnce({
+        body: Buffer.from('data'), contentType: 'text/plain', suggestedFileName: 'memo.txt',
+      });
+      setup(client);
+      const dir = mkdtempSync(join(tmpdir(), 'ofw-dl-'));
+      try {
+        const result = await handlers.get('ofw_download_attachment')!({ fileId: 12, inline: false, saveTo: dir + '/' });
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.path).toMatch(/memo\.txt$/);
+        expect(parsed.mode).toBeUndefined();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    } finally {
+      if (prev === undefined) delete process.env.OFW_INLINE_ATTACHMENTS;
+      else process.env.OFW_INLINE_ATTACHMENTS = prev;
+    }
+  });
+
   it('inline:true reuses on-disk bytes instead of re-fetching when previously downloaded', async () => {
     const client = new OFWClient();
     const bytes = Buffer.from('local-copy', 'utf8');

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -943,6 +943,82 @@ describe('ofw_download_attachment', () => {
     }
   });
 
+  it('inline:true falls through to a network fetch when the on-disk copy is missing', async () => {
+    const client = new OFWClient();
+    const bytes = Buffer.from('fresh-bytes', 'utf8');
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      fileId: 77, fileName: 'gone.txt', label: 'gone.txt',
+      fileType: 'text/plain', fileSize: bytes.length,
+    });
+    const binSpy = vi.spyOn(client, 'requestBinary')
+      .mockResolvedValueOnce({ body: bytes, contentType: 'text/plain', suggestedFileName: 'gone.txt' })
+      .mockResolvedValueOnce({ body: bytes, contentType: 'text/plain', suggestedFileName: 'gone.txt' });
+    setup(client);
+
+    const dir = mkdtempSync(join(tmpdir(), 'ofw-dl-'));
+    try {
+      // Populate downloadedPath in the attachment cache, then delete the actual file.
+      const first = await handlers.get('ofw_download_attachment')!({ fileId: 77, saveTo: dir + '/' });
+      const path = JSON.parse(first.content[0].text).path;
+      rmSync(path);
+
+      // Inline mode should detect the missing file and re-fetch from the network.
+      const result = await handlers.get('ofw_download_attachment')!({ fileId: 77, inline: true });
+      expect(binSpy).toHaveBeenCalledTimes(2);
+      const res = result.content[1];
+      expect(res.type).toBe('resource');
+      expect(Buffer.from(res.resource.blob, 'base64').equals(bytes)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('inline:true falls back to cached mime/filename when the server omits Content-Type/Disposition', async () => {
+    const client = new OFWClient();
+    const bytes = Buffer.from('%PDF-1.4 fake', 'utf8');
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      fileId: 88, fileName: 'cached.pdf', label: 'cached.pdf',
+      fileType: 'application/pdf', fileSize: bytes.length,
+    });
+    vi.spyOn(client, 'requestBinary').mockResolvedValueOnce({
+      body: bytes, contentType: null, suggestedFileName: null,
+    });
+    setup(client);
+
+    const result = await handlers.get('ofw_download_attachment')!({ fileId: 88, inline: true });
+    const meta = JSON.parse(result.content[0].text);
+    expect(meta.mimeType).toBe('application/pdf');
+    expect(meta.fileName).toBe('cached.pdf');
+    const res = result.content[1];
+    expect(res.type).toBe('resource');
+    expect(res.resource.mimeType).toBe('application/pdf');
+    expect(res.resource.uri).toBe('ofw://attachment/88/cached.pdf');
+  });
+
+  it('disk mode falls back to cached mime/filename when the server omits Content-Type/Disposition', async () => {
+    const client = new OFWClient();
+    const bytes = Buffer.from('zipdata', 'utf8');
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      fileId: 89, fileName: 'archive.zip', label: 'archive.zip',
+      fileType: 'application/zip', fileSize: bytes.length,
+    });
+    vi.spyOn(client, 'requestBinary').mockResolvedValueOnce({
+      body: bytes, contentType: null, suggestedFileName: null,
+    });
+    setup(client);
+
+    const dir = mkdtempSync(join(tmpdir(), 'ofw-dl-'));
+    try {
+      const result = await handlers.get('ofw_download_attachment')!({ fileId: 89, saveTo: dir + '/' });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.mimeType).toBe('application/zip');
+      expect(parsed.fileName).toBe('archive.zip');
+      expect(parsed.path.endsWith('89-archive.zip')).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('skips re-download when the file is already at the same path (no force)', async () => {
     const client = new OFWClient();
     const reqSpy = vi.spyOn(client, 'request').mockResolvedValueOnce({

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -815,6 +815,77 @@ describe('ofw_download_attachment', () => {
     }
   });
 
+  it('inline:true returns ImageContent for image MIME and writes no file', async () => {
+    const client = new OFWClient();
+    const pngBytes = Buffer.from('\x89PNGfake-png-bytes', 'binary');
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      fileId: 42, fileName: 'kid.png', label: 'kid.png',
+      fileType: 'image/png', fileSize: pngBytes.length,
+    });
+    const binSpy = vi.spyOn(client, 'requestBinary').mockResolvedValueOnce({
+      body: pngBytes, contentType: 'image/png', suggestedFileName: 'kid.png',
+    });
+    setup(client);
+
+    const result = await handlers.get('ofw_download_attachment')!({ fileId: 42, inline: true });
+    expect(binSpy).toHaveBeenCalledTimes(1);
+    expect(result.content).toHaveLength(2);
+    const meta = JSON.parse(result.content[0].text);
+    expect(meta).toMatchObject({ fileId: 42, fileName: 'kid.png', mimeType: 'image/png', mode: 'inline', sizeBytes: pngBytes.length });
+    const img = result.content[1];
+    expect(img.type).toBe('image');
+    expect(img.mimeType).toBe('image/png');
+    expect(Buffer.from(img.data, 'base64').equals(pngBytes)).toBe(true);
+  });
+
+  it('inline:true returns EmbeddedResource blob for non-image MIME', async () => {
+    const client = new OFWClient();
+    const pdfBytes = Buffer.from('%PDF-1.4 fake pdf', 'utf8');
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      fileId: 7, fileName: 'receipt.pdf', label: 'receipt.pdf',
+      fileType: 'application/pdf', fileSize: pdfBytes.length,
+    });
+    vi.spyOn(client, 'requestBinary').mockResolvedValueOnce({
+      body: pdfBytes, contentType: 'application/pdf', suggestedFileName: 'receipt.pdf',
+    });
+    setup(client);
+
+    const result = await handlers.get('ofw_download_attachment')!({ fileId: 7, inline: true });
+    expect(result.content).toHaveLength(2);
+    const res = result.content[1];
+    expect(res.type).toBe('resource');
+    expect(res.resource.mimeType).toBe('application/pdf');
+    expect(res.resource.uri).toBe('ofw://attachment/7/receipt.pdf');
+    expect(Buffer.from(res.resource.blob, 'base64').equals(pdfBytes)).toBe(true);
+  });
+
+  it('inline:true reuses on-disk bytes instead of re-fetching when previously downloaded', async () => {
+    const client = new OFWClient();
+    const bytes = Buffer.from('local-copy', 'utf8');
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      fileId: 99, fileName: 'note.txt', label: 'note.txt',
+      fileType: 'text/plain', fileSize: bytes.length,
+    });
+    const binSpy = vi.spyOn(client, 'requestBinary').mockResolvedValueOnce({
+      body: bytes, contentType: 'text/plain', suggestedFileName: 'note.txt',
+    });
+    setup(client);
+
+    const dir = mkdtempSync(join(tmpdir(), 'ofw-dl-'));
+    try {
+      // First: disk download populates downloadedPath.
+      await handlers.get('ofw_download_attachment')!({ fileId: 99, saveTo: dir + '/' });
+      // Second: inline mode should read from disk, not hit the network.
+      const result = await handlers.get('ofw_download_attachment')!({ fileId: 99, inline: true });
+      expect(binSpy).toHaveBeenCalledTimes(1);
+      const res = result.content[1];
+      expect(res.type).toBe('resource');
+      expect(Buffer.from(res.resource.blob, 'base64').equals(bytes)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('skips re-download when the file is already at the same path (no force)', async () => {
     const client = new OFWClient();
     const reqSpy = vi.spyOn(client, 'request').mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

This PR consolidates HTTP request/retry logic in the OFW API client, extracts common response formatting utilities, and adds support for inline attachment delivery (base64-encoded images and resource blobs). It also updates the default attachments directory to `~/Downloads/ofw-mcp` for better compatibility with sandboxed MCP hosts.

## Key Changes

**Client & Protocol**
- Renamed `STATIC_HEADERS` → `OFW_PROTOCOL_HEADERS` and removed redundant `Accept`/`Content-Type` (now set per-call)
- Unified `doRequest` and `doRequestBinary` into a single `fetchWithRetry(method, path, body, accept, isRetry)` scaffold that handles 401 (re-auth + retry), 429 (wait 2s + retry), and non-2xx errors
- Extracted `parseContentDispositionFilename()` helper for RFC 6266 filename parsing (prefers `filename*=UTF-8''…` over legacy `filename="…"`)
- `request()` now calls `fetchWithRetry` and parses the response text; `requestBinary()` returns the raw Response object for callers to extract bytes

**Shared Utilities** (`src/tools/_shared.ts` — new file)
- `jsonResponse(payload)` — wraps data as pretty-printed JSON text content
- `textResponse(text)` — wraps plain text content
- `mapRecipients(items)` — translates OFW API recipient shape to cache Recipient (used in 5 places: sync, get_message, send, save_draft, get_draft)
- `expandPath(p)` — expands `~/` to `$HOME` and resolves relative paths to absolute

**Configuration**
- `getAttachmentsDir()` now defaults to `~/Downloads/ofw-mcp` instead of `~/.cache/ofw-mcp/attachments/<hash>` (hidden cache dirs are often outside sandboxed host filesystem allowlists)
- Added `getDefaultInlineAttachments()` to read `OFW_INLINE_ATTACHMENTS` env var (truthy values: `"1"`, `"true"`, `"yes"`, `"on"`)

**Message Tools**
- `ofw_download_attachment` now supports `inline: boolean` parameter:
  - `inline: true` returns base64-encoded `ImageContent` for images or `EmbeddedResource` blobs for other MIME types (no file written)
  - `inline: false` writes to disk (existing behavior)
  - Defaults to `OFW_INLINE_ATTACHMENTS` env var if omitted
  - Reuses on-disk bytes when available; falls back to network fetch if file is missing
- Replaced inline JSON/text response boilerplate with `jsonResponse()` and `textResponse()` helpers across all tool files
- Extracted `deleteOFWMessages()` helper for message deletion logic

**Cache & Sync**
- Extracted `buildMessageFilter()` to deduplicate WHERE clause logic between `listMessages()` and `countMessages()`
- Renamed `fetchAndCacheAttachmentMeta()` → `fetchAttachmentMeta()` and moved error handling to the caller (`fetchAttachmentMetaForMessage()` wraps in try/catch for best-effort bulk-sync)
- Extracted `recipientsFromList()` logic into shared `mapRecipients()` utility

**Tests**
- Added comprehensive `tests/tools/_shared.test.ts` covering `jsonResponse`, `textResponse`, `mapRecipients`, and `expandPath`
- Added `tests/client.test.ts` tests for `requestBinary()`: 401/429 retry, Content-Disposition parsing (RFC 6266 + legacy formats), error handling
- Added `tests/tools/messages.test.ts` tests for inline attachment modes, env var defaults, and on-disk reuse
- Updated `tests/config.test.ts` to cover new `getAttachmentsDir()` and `getDefaultInlineAttachments()` functions

## Notable Implementation Details

- The unified `fetchWithRetry` scaffold returns the raw `

https://claude.ai/code/session_01KoCr9NMpB3fkwGMTxpHAxU