### PR TITLE
Configure auto-generated release notes and adopt PR-based workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,48 @@
+# Configuration for GitHub's auto-generated release notes.
+# Honored by softprops/action-gh-release when generate_release_notes: true,
+# and by the GitHub web UI when drafting release notes.
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes/automatically-generated-release-notes#configuration-options
+#
+# Only PRs merged into the default branch appear in release notes — direct
+# pushes to main (e.g. the Tag & Bump bot) are not listed. Apply one of the
+# labels below to every PR so it lands in the right section.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+      - dependabot[bot]
+      - github-actions
+      - github-actions[bot]
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: Security
+      labels:
+        - security
+    - title: Refactor
+      labels:
+        - refactor
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Tests
+      labels:
+        - test
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: CI & Build
+      labels:
+        - ci
+        - github_actions
+    - title: Other Changes
+      labels:
+        - "*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,3 +58,27 @@ Main is always one version ahead of the latest tag. To release, run the **Cut & 
 - `showNeverViewed` (boolean on message list items) is the reliable indicator for unread sent messages. The detail endpoint's `viewed` field is inconsistent (returns `null` for read messages instead of the epoch sentinel the list endpoint uses)
 - `ofw-version: 1.0.0` header is required on all API requests — this is the OFW protocol version, not our package version
 - Auth uses Spring Security session cookie + login POST, tokens expire ~6h
+
+<!-- pr-workflow:v1 -->
+## Pull requests & release notes
+
+**Default workflow: branch + PR, even for solo work.** Direct pushes to `main` skip review *and* skip auto-generated release notes — GitHub's `generate_release_notes` (configured in `.github/release.yml`) only picks up merged PRs. Push directly to `main` only when the user explicitly asks for it (e.g. emergency hotfix).
+
+For every PR, apply exactly one label so it lands in the right release-notes section:
+
+| Label                | Section in release notes |
+|----------------------|--------------------------|
+| `enhancement`        | Features                 |
+| `bug`                | Bug Fixes                |
+| `security`           | Security                 |
+| `refactor`           | Refactor                 |
+| `documentation`      | Documentation            |
+| `test`               | Tests                    |
+| `dependencies`       | Dependencies             |
+| `ci` / `github_actions` | CI & Build            |
+| *(none / unmatched)* | Other Changes            |
+| `ignore-for-release` | Hidden from notes        |
+
+The **PR title** becomes the bullet — write it like a user-facing changelog entry, not internal shorthand. Conventional-commit prefixes are still fine in commit messages, but the PR title should read clean.
+
+Open with `gh pr create --label <label>` (or `--label ignore-for-release` for chores not worth a line), then **immediately** run `gh pr merge <num> --auto --merge` so the PR merges as soon as CI passes. The repo allows merge commits only (no squash, no rebase) — don't pass `--squash`/`--rebase` or the call will fail.


### PR DESCRIPTION
## Summary
- Add `.github/release.yml` so the next release's auto-generated notes group merged PRs into Features / Bug Fixes / Security / Refactor / Docs / Tests / Dependencies / CI & Build / Other.
- Exclude dependabot and github-actions authors, and any PR labeled `ignore-for-release`, from the notes.
- Document the workflow in `CLAUDE.md`: branch + PR even for solo work, apply one label per PR, PR title = changelog bullet.

Repo labels `security`, `refactor`, `test`, `ci`, and `ignore-for-release` are also created (if missing) to match the categories.

Part of a cross-repo standardization — same config landed in chrischall/creditkarma-mcp#5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)