### PR TITLE
ci: idempotent npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,18 @@ jobs:
           npx @anthropic-ai/mcpb pack
           mv ofw-mcp.mcpb "ofw-mcp-${VERSION}.mcpb"
 
+      # Idempotent: skip if this version is already on the registry, so the
+      # workflow can be re-run safely on the same tag (e.g. after a flaky
+      # downstream publish step).
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: |
+          PKG=$(node -p "require('./package.json').name")
+          PUBLISHED=$(npm view "${PKG}@${VERSION}" version 2>/dev/null || true)
+          if [ "$PUBLISHED" = "$VERSION" ]; then
+            echo "npm already has ${PKG}@${VERSION} — skipping publish."
+            exit 0
+          fi
+          npm publish --access public --provenance
 
       # ─── modelcontextprotocol/registry (PulseMCP auto-ingests weekly) ───
       - name: Install mcp-publisher


### PR DESCRIPTION
## Summary
- Wrap `npm publish` in a `npm view` precheck so re-runs of the same tag don’t fail with E409.
- No behavior change on a first successful publish; only affects retries on an already-published version.

## Test plan
- [ ] Re-run a past `Release` workflow on an existing tag and confirm the npm step logs `npm already has … — skipping publish.` instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)