### PR TITLE
feat: optional @fetchproxy/bootstrap fallback for auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,19 +17,21 @@ npm run dev          # node --env-file=.env dist/index.js (requires built dist)
 
 ```
 src/
-  index.ts       MCP server entry — McpServer + StdioServerTransport, registers all tools
-  client.ts      OFWClient (Spring Security login, Bearer token, 401/429 retry, JSON + binary)
-  config.ts      env-driven cache dir + sha256(OFW_USERNAME) DB path + attachments dir
-  cache.ts       node:sqlite cache (messages, drafts, attachments, sync_state, meta) with typed CRUD + findLatestReplyTip
-  sync.ts        resolveFolderIds + syncMessageFolder/syncDrafts/syncAll + attachment-meta fetch
+  index.ts          MCP server entry — McpServer + StdioServerTransport, registers all tools
+  client.ts         OFWClient (Bearer token, 401/429 retry, JSON + binary). Delegates auth to ./auth.ts
+  auth.ts           resolveAuth(): three-path priority (env vars → fetchproxy fallback → error). Template for sibling MCPs
+  auth-password.ts  loginWithPassword(): legacy OFW Spring Security form login (kept as own module so auth.ts can mock it cleanly)
+  config.ts         env-driven cache dir + sha256(OFW_CACHE_IDENTITY|OFW_USERNAME|"_default") DB path + attachments dir
+  cache.ts          node:sqlite cache (messages, drafts, attachments, sync_state, meta) with typed CRUD + findLatestReplyTip
+  sync.ts           resolveFolderIds + syncMessageFolder/syncDrafts/syncAll + attachment-meta fetch
   tools/
-    _shared.ts   recipient mapping, response helpers, path expansion
-    user.ts      ofw_get_profile, ofw_get_notifications
-    messages.ts  folders, list, get, send, drafts, get_unread_sent, upload/download_attachment, sync_messages
-    calendar.ts  list/create/update/delete events
-    expenses.ts  totals, list, create
-    journal.ts   list, create entries
-tests/           mirrors src/; mocks OFWClient.request via vi.spyOn; cache tests use OFW_CACHE_DIR + tmp dir
+    _shared.ts      recipient mapping, response helpers, path expansion
+    user.ts         ofw_get_profile, ofw_get_notifications
+    messages.ts     folders, list, get, send, drafts, get_unread_sent, upload/download_attachment, sync_messages
+    calendar.ts     list/create/update/delete events
+    expenses.ts     totals, list, create
+    journal.ts      list, create entries
+tests/              mirrors src/; mocks OFWClient.request via vi.spyOn; cache tests use OFW_CACHE_DIR + tmp dir
 ```
 
 Tool files use `server.registerTool(name, schema, handler)`. `index.ts` wires `registerXTools(server, client)` for each domain.
@@ -37,16 +39,28 @@ Tool files use `server.registerTool(name, schema, handler)`. `index.ts` wires `r
 ## Environment
 
 ```
-OFW_USERNAME              Required. OFW login email
-OFW_PASSWORD              Required. OFW password
+OFW_USERNAME              Optional. OFW login email (legacy env-var auth path; also serves as cache key)
+OFW_PASSWORD              Optional. OFW password (legacy env-var auth path)
+OFW_DISABLE_FETCHPROXY    Optional. "1|true|yes|on" → skip the fetchproxy fallback (missing creds become a hard error)
+OFW_CACHE_IDENTITY        Optional. Explicit cache-key label; overrides OFW_USERNAME for fetchproxy-only multi-account setups
 OFW_CACHE_DIR             Optional. Overrides cache dir (default ~/.cache/ofw-mcp)
 OFW_ATTACHMENTS_DIR       Optional. Where ofw_download_attachment writes (default ~/Downloads/ofw-mcp)
 OFW_INLINE_ATTACHMENTS    Optional. "1|true|yes|on" → return attachments as MCP content blocks by default
 ```
 
-`client.ts` ignores blank values, the strings `"undefined"`/`"null"`, and unsubstituted `${VAR}` placeholders — defensive against MCP hosts passing the env block through unexpanded.
+`auth.ts` ignores blank values, the strings `"undefined"`/`"null"`, and unsubstituted `${VAR}` placeholders — defensive against MCP hosts passing the env block through unexpanded.
 
 `.env` (project root) is loaded by `client.ts` via dynamic `dotenv` import (silently skipped if unavailable, e.g. inside the mcpb bundle). Real env vars take precedence (`override: false`).
+
+## Auth resolution (Pattern A template)
+
+`src/auth.ts` is the canonical "browser-bootstrap + Node-direct" auth shape used across our MCP servers. Six sibling MCPs model their auth on this file — keep the structure flat, the path-selection explicit, the error messages actionable. Three paths in priority order:
+
+1. **Env-var credentials** (`OFW_USERNAME` + `OFW_PASSWORD`) → `src/auth-password.ts` does the legacy Spring Security form login. Unchanged from pre-fetchproxy behavior.
+2. **fetchproxy fallback** → `@fetchproxy/bootstrap` snapshots `localStorage["auth"]` + `localStorage["tokenExpiry"]` from a signed-in `ourfamilywizard.com` tab in ~one round-trip, then closes the bridge. All subsequent OFW API calls go out via direct Node fetch — fetchproxy is NOT in the hot path.
+3. **Error** → tells the user how to fix it (set creds, OR install the extension and sign in).
+
+The split into `auth.ts` + `auth-password.ts` is deliberate: tests mock `auth-password.js` and `@fetchproxy/bootstrap` at the module boundary, so path-selection logic in `resolveAuth()` stays independent of either implementation. Sibling MCPs should copy this split.
 
 ## Message Cache
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,15 @@ Quit completely (Cmd+Q on Mac, not just close the window) and relaunch.
 
 Ask Claude: *"What does my OFW dashboard look like?"* — it should show your unread message count, upcoming events, and outstanding expenses.
 
-## Credentials
+## Authentication
 
-Credentials are read from environment variables, with two ways to provide them:
+`ofw-mcp` tries three auth paths in order; whichever succeeds first is used. Existing setups keep working unchanged.
+
+1. **Env-var credentials (legacy, recommended for Claude Desktop).** Set `OFW_USERNAME` + `OFW_PASSWORD` and the server logs in via OFW's form endpoint. This is the path shown in the Claude Desktop config above.
+2. **fetchproxy fallback (no env vars needed).** When the credentials are absent, the server reads `localStorage["auth"]` once at startup from your already-signed-in `ourfamilywizard.com` tab via the [fetchproxy](https://github.com/chrischall/fetchproxy) browser extension. After that one read, all OFW API calls go directly from Node — the extension is **not** in the request hot path. Install the fetchproxy extension (Chrome Web Store / Safari `.dmg`), sign into OurFamilyWizard once, and the MCP just works. If you have multiple OFW accounts and want them to use separate caches, set `OFW_CACHE_IDENTITY` to a label per profile.
+3. **Error.** If neither path is available, the server tells you exactly which fix to apply. Set `OFW_DISABLE_FETCHPROXY=1` to skip the fetchproxy fallback entirely (turns missing credentials into a hard error — useful in headless CI).
+
+### Credential options (env-var path)
 
 **Option A — env block in Claude Desktop config** (shown above, recommended):
 
@@ -121,7 +127,9 @@ Read-only tools run automatically. Write tools ask for your confirmation first.
 
 **"0 messages"** — Claude may have read the notification counts rather than the actual messages. Ask explicitly: *"List the messages in my OFW inbox"* or *"Use ofw_list_message_folders then ofw_list_messages"*.
 
-**"OFW_USERNAME and OFW_PASSWORD must be set"** — credentials are missing. Check the `env` block in your Claude Desktop config or your `.env` file.
+**"OFW auth: set OFW_USERNAME + OFW_PASSWORD, or install the fetchproxy extension…"** — neither auth path is configured. Either fill in the `env` block in your Claude Desktop config, or install the [fetchproxy extension](https://github.com/chrischall/fetchproxy) and sign into `ourfamilywizard.com` in your browser.
+
+**"fetchproxy fallback failed"** — the env-var path wasn't configured and the extension couldn't be reached. Confirm the fetchproxy extension is installed, signed into OFW, and that it's running (open the extension popup). If you want to disable the fallback entirely, set `OFW_DISABLE_FETCHPROXY=1`.
 
 **403 Forbidden** — wrong credentials. Verify your username/password at [ofw.ourfamilywizard.com](https://ofw.ourfamilywizard.com).
 
@@ -162,14 +170,17 @@ tests/
 
 ### Auth flow
 
-OFW uses Spring Security form login:
+Auth resolution lives in `src/auth.ts`. Three paths, in priority order:
 
-1. `GET /ofw/login.form` — establishes a session cookie
-2. `POST /ofw/login` — submits credentials, returns `{ auth: "<token>" }`
-3. All API calls use `Authorization: Bearer <token>`
-4. On 401, re-authenticates automatically and retries once
+1. **Env vars present** → `src/auth-password.ts` does the legacy OFW Spring Security form login:
+   1. `GET /ofw/login.form` — establishes a session cookie
+   2. `POST /ofw/login` — submits credentials, returns `{ auth: "<token>" }`
+2. **Env vars absent (and `OFW_DISABLE_FETCHPROXY` unset)** → `@fetchproxy/bootstrap` reads `localStorage["auth"]` + `localStorage["tokenExpiry"]` once from the user's signed-in `ourfamilywizard.com` tab, then closes the bridge.
+3. **Nothing configured** → throws with both fixes spelled out.
 
-Tokens are cached for 6 hours.
+Either path returns a Bearer token to `OFWClient`, which then operates from Node with `Authorization: Bearer <token>` — fetchproxy is **not** in the request hot path. On 401 the client re-resolves auth and replays once. Tokens are cached for 6h (env-var path) or until `tokenExpiry` (fetchproxy path).
+
+Also see the [fetchproxy README](https://github.com/chrischall/fetchproxy) for extension install instructions.
 
 ## License
 

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -5,7 +5,13 @@ var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __commonJS = (cb, mod) => function __require() {
+var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
+  get: (a, b) => (typeof require !== "undefined" ? require : a)[b]
+}) : x)(function(x) {
+  if (typeof require !== "undefined") return require.apply(this, arguments);
+  throw Error('Dynamic require of "' + x + '" is not supported');
+});
+var __commonJS = (cb, mod) => function __require2() {
   return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
 };
 var __export = (target, all) => {
@@ -6795,6 +6801,3627 @@ var require_dist = __commonJS({
     module.exports = exports = formatsPlugin;
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = formatsPlugin;
+  }
+});
+
+// node_modules/ws/lib/constants.js
+var require_constants = __commonJS({
+  "node_modules/ws/lib/constants.js"(exports, module) {
+    "use strict";
+    var BINARY_TYPES = ["nodebuffer", "arraybuffer", "fragments"];
+    var hasBlob = typeof Blob !== "undefined";
+    if (hasBlob) BINARY_TYPES.push("blob");
+    module.exports = {
+      BINARY_TYPES,
+      CLOSE_TIMEOUT: 3e4,
+      EMPTY_BUFFER: Buffer.alloc(0),
+      GUID: "258EAFA5-E914-47DA-95CA-C5AB0DC85B11",
+      hasBlob,
+      kForOnEventAttribute: /* @__PURE__ */ Symbol("kIsForOnEventAttribute"),
+      kListener: /* @__PURE__ */ Symbol("kListener"),
+      kStatusCode: /* @__PURE__ */ Symbol("status-code"),
+      kWebSocket: /* @__PURE__ */ Symbol("websocket"),
+      NOOP: () => {
+      }
+    };
+  }
+});
+
+// node_modules/ws/lib/buffer-util.js
+var require_buffer_util = __commonJS({
+  "node_modules/ws/lib/buffer-util.js"(exports, module) {
+    "use strict";
+    var { EMPTY_BUFFER } = require_constants();
+    var FastBuffer = Buffer[Symbol.species];
+    function concat(list, totalLength) {
+      if (list.length === 0) return EMPTY_BUFFER;
+      if (list.length === 1) return list[0];
+      const target = Buffer.allocUnsafe(totalLength);
+      let offset = 0;
+      for (let i = 0; i < list.length; i++) {
+        const buf = list[i];
+        target.set(buf, offset);
+        offset += buf.length;
+      }
+      if (offset < totalLength) {
+        return new FastBuffer(target.buffer, target.byteOffset, offset);
+      }
+      return target;
+    }
+    function _mask(source, mask, output, offset, length) {
+      for (let i = 0; i < length; i++) {
+        output[offset + i] = source[i] ^ mask[i & 3];
+      }
+    }
+    function _unmask(buffer, mask) {
+      for (let i = 0; i < buffer.length; i++) {
+        buffer[i] ^= mask[i & 3];
+      }
+    }
+    function toArrayBuffer(buf) {
+      if (buf.length === buf.buffer.byteLength) {
+        return buf.buffer;
+      }
+      return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.length);
+    }
+    function toBuffer(data) {
+      toBuffer.readOnly = true;
+      if (Buffer.isBuffer(data)) return data;
+      let buf;
+      if (data instanceof ArrayBuffer) {
+        buf = new FastBuffer(data);
+      } else if (ArrayBuffer.isView(data)) {
+        buf = new FastBuffer(data.buffer, data.byteOffset, data.byteLength);
+      } else {
+        buf = Buffer.from(data);
+        toBuffer.readOnly = false;
+      }
+      return buf;
+    }
+    module.exports = {
+      concat,
+      mask: _mask,
+      toArrayBuffer,
+      toBuffer,
+      unmask: _unmask
+    };
+    if (!process.env.WS_NO_BUFFER_UTIL) {
+      try {
+        const bufferUtil = __require("bufferutil");
+        module.exports.mask = function(source, mask, output, offset, length) {
+          if (length < 48) _mask(source, mask, output, offset, length);
+          else bufferUtil.mask(source, mask, output, offset, length);
+        };
+        module.exports.unmask = function(buffer, mask) {
+          if (buffer.length < 32) _unmask(buffer, mask);
+          else bufferUtil.unmask(buffer, mask);
+        };
+      } catch (e) {
+      }
+    }
+  }
+});
+
+// node_modules/ws/lib/limiter.js
+var require_limiter = __commonJS({
+  "node_modules/ws/lib/limiter.js"(exports, module) {
+    "use strict";
+    var kDone = /* @__PURE__ */ Symbol("kDone");
+    var kRun = /* @__PURE__ */ Symbol("kRun");
+    var Limiter = class {
+      /**
+       * Creates a new `Limiter`.
+       *
+       * @param {Number} [concurrency=Infinity] The maximum number of jobs allowed
+       *     to run concurrently
+       */
+      constructor(concurrency) {
+        this[kDone] = () => {
+          this.pending--;
+          this[kRun]();
+        };
+        this.concurrency = concurrency || Infinity;
+        this.jobs = [];
+        this.pending = 0;
+      }
+      /**
+       * Adds a job to the queue.
+       *
+       * @param {Function} job The job to run
+       * @public
+       */
+      add(job) {
+        this.jobs.push(job);
+        this[kRun]();
+      }
+      /**
+       * Removes a job from the queue and runs it if possible.
+       *
+       * @private
+       */
+      [kRun]() {
+        if (this.pending === this.concurrency) return;
+        if (this.jobs.length) {
+          const job = this.jobs.shift();
+          this.pending++;
+          job(this[kDone]);
+        }
+      }
+    };
+    module.exports = Limiter;
+  }
+});
+
+// node_modules/ws/lib/permessage-deflate.js
+var require_permessage_deflate = __commonJS({
+  "node_modules/ws/lib/permessage-deflate.js"(exports, module) {
+    "use strict";
+    var zlib = __require("zlib");
+    var bufferUtil = require_buffer_util();
+    var Limiter = require_limiter();
+    var { kStatusCode } = require_constants();
+    var FastBuffer = Buffer[Symbol.species];
+    var TRAILER = Buffer.from([0, 0, 255, 255]);
+    var kPerMessageDeflate = /* @__PURE__ */ Symbol("permessage-deflate");
+    var kTotalLength = /* @__PURE__ */ Symbol("total-length");
+    var kCallback = /* @__PURE__ */ Symbol("callback");
+    var kBuffers = /* @__PURE__ */ Symbol("buffers");
+    var kError = /* @__PURE__ */ Symbol("error");
+    var zlibLimiter;
+    var PerMessageDeflate2 = class {
+      /**
+       * Creates a PerMessageDeflate instance.
+       *
+       * @param {Object} [options] Configuration options
+       * @param {(Boolean|Number)} [options.clientMaxWindowBits] Advertise support
+       *     for, or request, a custom client window size
+       * @param {Boolean} [options.clientNoContextTakeover=false] Advertise/
+       *     acknowledge disabling of client context takeover
+       * @param {Number} [options.concurrencyLimit=10] The number of concurrent
+       *     calls to zlib
+       * @param {Boolean} [options.isServer=false] Create the instance in either
+       *     server or client mode
+       * @param {Number} [options.maxPayload=0] The maximum allowed message length
+       * @param {(Boolean|Number)} [options.serverMaxWindowBits] Request/confirm the
+       *     use of a custom server window size
+       * @param {Boolean} [options.serverNoContextTakeover=false] Request/accept
+       *     disabling of server context takeover
+       * @param {Number} [options.threshold=1024] Size (in bytes) below which
+       *     messages should not be compressed if context takeover is disabled
+       * @param {Object} [options.zlibDeflateOptions] Options to pass to zlib on
+       *     deflate
+       * @param {Object} [options.zlibInflateOptions] Options to pass to zlib on
+       *     inflate
+       */
+      constructor(options) {
+        this._options = options || {};
+        this._threshold = this._options.threshold !== void 0 ? this._options.threshold : 1024;
+        this._maxPayload = this._options.maxPayload | 0;
+        this._isServer = !!this._options.isServer;
+        this._deflate = null;
+        this._inflate = null;
+        this.params = null;
+        if (!zlibLimiter) {
+          const concurrency = this._options.concurrencyLimit !== void 0 ? this._options.concurrencyLimit : 10;
+          zlibLimiter = new Limiter(concurrency);
+        }
+      }
+      /**
+       * @type {String}
+       */
+      static get extensionName() {
+        return "permessage-deflate";
+      }
+      /**
+       * Create an extension negotiation offer.
+       *
+       * @return {Object} Extension parameters
+       * @public
+       */
+      offer() {
+        const params = {};
+        if (this._options.serverNoContextTakeover) {
+          params.server_no_context_takeover = true;
+        }
+        if (this._options.clientNoContextTakeover) {
+          params.client_no_context_takeover = true;
+        }
+        if (this._options.serverMaxWindowBits) {
+          params.server_max_window_bits = this._options.serverMaxWindowBits;
+        }
+        if (this._options.clientMaxWindowBits) {
+          params.client_max_window_bits = this._options.clientMaxWindowBits;
+        } else if (this._options.clientMaxWindowBits == null) {
+          params.client_max_window_bits = true;
+        }
+        return params;
+      }
+      /**
+       * Accept an extension negotiation offer/response.
+       *
+       * @param {Array} configurations The extension negotiation offers/reponse
+       * @return {Object} Accepted configuration
+       * @public
+       */
+      accept(configurations) {
+        configurations = this.normalizeParams(configurations);
+        this.params = this._isServer ? this.acceptAsServer(configurations) : this.acceptAsClient(configurations);
+        return this.params;
+      }
+      /**
+       * Releases all resources used by the extension.
+       *
+       * @public
+       */
+      cleanup() {
+        if (this._inflate) {
+          this._inflate.close();
+          this._inflate = null;
+        }
+        if (this._deflate) {
+          const callback = this._deflate[kCallback];
+          this._deflate.close();
+          this._deflate = null;
+          if (callback) {
+            callback(
+              new Error(
+                "The deflate stream was closed while data was being processed"
+              )
+            );
+          }
+        }
+      }
+      /**
+       *  Accept an extension negotiation offer.
+       *
+       * @param {Array} offers The extension negotiation offers
+       * @return {Object} Accepted configuration
+       * @private
+       */
+      acceptAsServer(offers) {
+        const opts = this._options;
+        const accepted = offers.find((params) => {
+          if (opts.serverNoContextTakeover === false && params.server_no_context_takeover || params.server_max_window_bits && (opts.serverMaxWindowBits === false || typeof opts.serverMaxWindowBits === "number" && opts.serverMaxWindowBits > params.server_max_window_bits) || typeof opts.clientMaxWindowBits === "number" && !params.client_max_window_bits) {
+            return false;
+          }
+          return true;
+        });
+        if (!accepted) {
+          throw new Error("None of the extension offers can be accepted");
+        }
+        if (opts.serverNoContextTakeover) {
+          accepted.server_no_context_takeover = true;
+        }
+        if (opts.clientNoContextTakeover) {
+          accepted.client_no_context_takeover = true;
+        }
+        if (typeof opts.serverMaxWindowBits === "number") {
+          accepted.server_max_window_bits = opts.serverMaxWindowBits;
+        }
+        if (typeof opts.clientMaxWindowBits === "number") {
+          accepted.client_max_window_bits = opts.clientMaxWindowBits;
+        } else if (accepted.client_max_window_bits === true || opts.clientMaxWindowBits === false) {
+          delete accepted.client_max_window_bits;
+        }
+        return accepted;
+      }
+      /**
+       * Accept the extension negotiation response.
+       *
+       * @param {Array} response The extension negotiation response
+       * @return {Object} Accepted configuration
+       * @private
+       */
+      acceptAsClient(response) {
+        const params = response[0];
+        if (this._options.clientNoContextTakeover === false && params.client_no_context_takeover) {
+          throw new Error('Unexpected parameter "client_no_context_takeover"');
+        }
+        if (!params.client_max_window_bits) {
+          if (typeof this._options.clientMaxWindowBits === "number") {
+            params.client_max_window_bits = this._options.clientMaxWindowBits;
+          }
+        } else if (this._options.clientMaxWindowBits === false || typeof this._options.clientMaxWindowBits === "number" && params.client_max_window_bits > this._options.clientMaxWindowBits) {
+          throw new Error(
+            'Unexpected or invalid parameter "client_max_window_bits"'
+          );
+        }
+        return params;
+      }
+      /**
+       * Normalize parameters.
+       *
+       * @param {Array} configurations The extension negotiation offers/reponse
+       * @return {Array} The offers/response with normalized parameters
+       * @private
+       */
+      normalizeParams(configurations) {
+        configurations.forEach((params) => {
+          Object.keys(params).forEach((key) => {
+            let value = params[key];
+            if (value.length > 1) {
+              throw new Error(`Parameter "${key}" must have only a single value`);
+            }
+            value = value[0];
+            if (key === "client_max_window_bits") {
+              if (value !== true) {
+                const num = +value;
+                if (!Number.isInteger(num) || num < 8 || num > 15) {
+                  throw new TypeError(
+                    `Invalid value for parameter "${key}": ${value}`
+                  );
+                }
+                value = num;
+              } else if (!this._isServer) {
+                throw new TypeError(
+                  `Invalid value for parameter "${key}": ${value}`
+                );
+              }
+            } else if (key === "server_max_window_bits") {
+              const num = +value;
+              if (!Number.isInteger(num) || num < 8 || num > 15) {
+                throw new TypeError(
+                  `Invalid value for parameter "${key}": ${value}`
+                );
+              }
+              value = num;
+            } else if (key === "client_no_context_takeover" || key === "server_no_context_takeover") {
+              if (value !== true) {
+                throw new TypeError(
+                  `Invalid value for parameter "${key}": ${value}`
+                );
+              }
+            } else {
+              throw new Error(`Unknown parameter "${key}"`);
+            }
+            params[key] = value;
+          });
+        });
+        return configurations;
+      }
+      /**
+       * Decompress data. Concurrency limited.
+       *
+       * @param {Buffer} data Compressed data
+       * @param {Boolean} fin Specifies whether or not this is the last fragment
+       * @param {Function} callback Callback
+       * @public
+       */
+      decompress(data, fin, callback) {
+        zlibLimiter.add((done) => {
+          this._decompress(data, fin, (err, result) => {
+            done();
+            callback(err, result);
+          });
+        });
+      }
+      /**
+       * Compress data. Concurrency limited.
+       *
+       * @param {(Buffer|String)} data Data to compress
+       * @param {Boolean} fin Specifies whether or not this is the last fragment
+       * @param {Function} callback Callback
+       * @public
+       */
+      compress(data, fin, callback) {
+        zlibLimiter.add((done) => {
+          this._compress(data, fin, (err, result) => {
+            done();
+            callback(err, result);
+          });
+        });
+      }
+      /**
+       * Decompress data.
+       *
+       * @param {Buffer} data Compressed data
+       * @param {Boolean} fin Specifies whether or not this is the last fragment
+       * @param {Function} callback Callback
+       * @private
+       */
+      _decompress(data, fin, callback) {
+        const endpoint = this._isServer ? "client" : "server";
+        if (!this._inflate) {
+          const key = `${endpoint}_max_window_bits`;
+          const windowBits = typeof this.params[key] !== "number" ? zlib.Z_DEFAULT_WINDOWBITS : this.params[key];
+          this._inflate = zlib.createInflateRaw({
+            ...this._options.zlibInflateOptions,
+            windowBits
+          });
+          this._inflate[kPerMessageDeflate] = this;
+          this._inflate[kTotalLength] = 0;
+          this._inflate[kBuffers] = [];
+          this._inflate.on("error", inflateOnError);
+          this._inflate.on("data", inflateOnData);
+        }
+        this._inflate[kCallback] = callback;
+        this._inflate.write(data);
+        if (fin) this._inflate.write(TRAILER);
+        this._inflate.flush(() => {
+          const err = this._inflate[kError];
+          if (err) {
+            this._inflate.close();
+            this._inflate = null;
+            callback(err);
+            return;
+          }
+          const data2 = bufferUtil.concat(
+            this._inflate[kBuffers],
+            this._inflate[kTotalLength]
+          );
+          if (this._inflate._readableState.endEmitted) {
+            this._inflate.close();
+            this._inflate = null;
+          } else {
+            this._inflate[kTotalLength] = 0;
+            this._inflate[kBuffers] = [];
+            if (fin && this.params[`${endpoint}_no_context_takeover`]) {
+              this._inflate.reset();
+            }
+          }
+          callback(null, data2);
+        });
+      }
+      /**
+       * Compress data.
+       *
+       * @param {(Buffer|String)} data Data to compress
+       * @param {Boolean} fin Specifies whether or not this is the last fragment
+       * @param {Function} callback Callback
+       * @private
+       */
+      _compress(data, fin, callback) {
+        const endpoint = this._isServer ? "server" : "client";
+        if (!this._deflate) {
+          const key = `${endpoint}_max_window_bits`;
+          const windowBits = typeof this.params[key] !== "number" ? zlib.Z_DEFAULT_WINDOWBITS : this.params[key];
+          this._deflate = zlib.createDeflateRaw({
+            ...this._options.zlibDeflateOptions,
+            windowBits
+          });
+          this._deflate[kTotalLength] = 0;
+          this._deflate[kBuffers] = [];
+          this._deflate.on("data", deflateOnData);
+        }
+        this._deflate[kCallback] = callback;
+        this._deflate.write(data);
+        this._deflate.flush(zlib.Z_SYNC_FLUSH, () => {
+          if (!this._deflate) {
+            return;
+          }
+          let data2 = bufferUtil.concat(
+            this._deflate[kBuffers],
+            this._deflate[kTotalLength]
+          );
+          if (fin) {
+            data2 = new FastBuffer(data2.buffer, data2.byteOffset, data2.length - 4);
+          }
+          this._deflate[kCallback] = null;
+          this._deflate[kTotalLength] = 0;
+          this._deflate[kBuffers] = [];
+          if (fin && this.params[`${endpoint}_no_context_takeover`]) {
+            this._deflate.reset();
+          }
+          callback(null, data2);
+        });
+      }
+    };
+    module.exports = PerMessageDeflate2;
+    function deflateOnData(chunk) {
+      this[kBuffers].push(chunk);
+      this[kTotalLength] += chunk.length;
+    }
+    function inflateOnData(chunk) {
+      this[kTotalLength] += chunk.length;
+      if (this[kPerMessageDeflate]._maxPayload < 1 || this[kTotalLength] <= this[kPerMessageDeflate]._maxPayload) {
+        this[kBuffers].push(chunk);
+        return;
+      }
+      this[kError] = new RangeError("Max payload size exceeded");
+      this[kError].code = "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH";
+      this[kError][kStatusCode] = 1009;
+      this.removeListener("data", inflateOnData);
+      this.reset();
+    }
+    function inflateOnError(err) {
+      this[kPerMessageDeflate]._inflate = null;
+      if (this[kError]) {
+        this[kCallback](this[kError]);
+        return;
+      }
+      err[kStatusCode] = 1007;
+      this[kCallback](err);
+    }
+  }
+});
+
+// node_modules/ws/lib/validation.js
+var require_validation2 = __commonJS({
+  "node_modules/ws/lib/validation.js"(exports, module) {
+    "use strict";
+    var { isUtf8 } = __require("buffer");
+    var { hasBlob } = require_constants();
+    var tokenChars = [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      // 0 - 15
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      // 16 - 31
+      0,
+      1,
+      0,
+      1,
+      1,
+      1,
+      1,
+      1,
+      0,
+      0,
+      1,
+      1,
+      0,
+      1,
+      1,
+      0,
+      // 32 - 47
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      // 48 - 63
+      0,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      // 64 - 79
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      0,
+      0,
+      0,
+      1,
+      1,
+      // 80 - 95
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      // 96 - 111
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0
+      // 112 - 127
+    ];
+    function isValidStatusCode(code) {
+      return code >= 1e3 && code <= 1014 && code !== 1004 && code !== 1005 && code !== 1006 || code >= 3e3 && code <= 4999;
+    }
+    function _isValidUTF8(buf) {
+      const len = buf.length;
+      let i = 0;
+      while (i < len) {
+        if ((buf[i] & 128) === 0) {
+          i++;
+        } else if ((buf[i] & 224) === 192) {
+          if (i + 1 === len || (buf[i + 1] & 192) !== 128 || (buf[i] & 254) === 192) {
+            return false;
+          }
+          i += 2;
+        } else if ((buf[i] & 240) === 224) {
+          if (i + 2 >= len || (buf[i + 1] & 192) !== 128 || (buf[i + 2] & 192) !== 128 || buf[i] === 224 && (buf[i + 1] & 224) === 128 || // Overlong
+          buf[i] === 237 && (buf[i + 1] & 224) === 160) {
+            return false;
+          }
+          i += 3;
+        } else if ((buf[i] & 248) === 240) {
+          if (i + 3 >= len || (buf[i + 1] & 192) !== 128 || (buf[i + 2] & 192) !== 128 || (buf[i + 3] & 192) !== 128 || buf[i] === 240 && (buf[i + 1] & 240) === 128 || // Overlong
+          buf[i] === 244 && buf[i + 1] > 143 || buf[i] > 244) {
+            return false;
+          }
+          i += 4;
+        } else {
+          return false;
+        }
+      }
+      return true;
+    }
+    function isBlob(value) {
+      return hasBlob && typeof value === "object" && typeof value.arrayBuffer === "function" && typeof value.type === "string" && typeof value.stream === "function" && (value[Symbol.toStringTag] === "Blob" || value[Symbol.toStringTag] === "File");
+    }
+    module.exports = {
+      isBlob,
+      isValidStatusCode,
+      isValidUTF8: _isValidUTF8,
+      tokenChars
+    };
+    if (isUtf8) {
+      module.exports.isValidUTF8 = function(buf) {
+        return buf.length < 24 ? _isValidUTF8(buf) : isUtf8(buf);
+      };
+    } else if (!process.env.WS_NO_UTF_8_VALIDATE) {
+      try {
+        const isValidUTF8 = __require("utf-8-validate");
+        module.exports.isValidUTF8 = function(buf) {
+          return buf.length < 32 ? _isValidUTF8(buf) : isValidUTF8(buf);
+        };
+      } catch (e) {
+      }
+    }
+  }
+});
+
+// node_modules/ws/lib/receiver.js
+var require_receiver = __commonJS({
+  "node_modules/ws/lib/receiver.js"(exports, module) {
+    "use strict";
+    var { Writable } = __require("stream");
+    var PerMessageDeflate2 = require_permessage_deflate();
+    var {
+      BINARY_TYPES,
+      EMPTY_BUFFER,
+      kStatusCode,
+      kWebSocket
+    } = require_constants();
+    var { concat, toArrayBuffer, unmask } = require_buffer_util();
+    var { isValidStatusCode, isValidUTF8 } = require_validation2();
+    var FastBuffer = Buffer[Symbol.species];
+    var GET_INFO = 0;
+    var GET_PAYLOAD_LENGTH_16 = 1;
+    var GET_PAYLOAD_LENGTH_64 = 2;
+    var GET_MASK = 3;
+    var GET_DATA = 4;
+    var INFLATING = 5;
+    var DEFER_EVENT = 6;
+    var Receiver2 = class extends Writable {
+      /**
+       * Creates a Receiver instance.
+       *
+       * @param {Object} [options] Options object
+       * @param {Boolean} [options.allowSynchronousEvents=true] Specifies whether
+       *     any of the `'message'`, `'ping'`, and `'pong'` events can be emitted
+       *     multiple times in the same tick
+       * @param {String} [options.binaryType=nodebuffer] The type for binary data
+       * @param {Object} [options.extensions] An object containing the negotiated
+       *     extensions
+       * @param {Boolean} [options.isServer=false] Specifies whether to operate in
+       *     client or server mode
+       * @param {Number} [options.maxPayload=0] The maximum allowed message length
+       * @param {Boolean} [options.skipUTF8Validation=false] Specifies whether or
+       *     not to skip UTF-8 validation for text and close messages
+       */
+      constructor(options = {}) {
+        super();
+        this._allowSynchronousEvents = options.allowSynchronousEvents !== void 0 ? options.allowSynchronousEvents : true;
+        this._binaryType = options.binaryType || BINARY_TYPES[0];
+        this._extensions = options.extensions || {};
+        this._isServer = !!options.isServer;
+        this._maxPayload = options.maxPayload | 0;
+        this._skipUTF8Validation = !!options.skipUTF8Validation;
+        this[kWebSocket] = void 0;
+        this._bufferedBytes = 0;
+        this._buffers = [];
+        this._compressed = false;
+        this._payloadLength = 0;
+        this._mask = void 0;
+        this._fragmented = 0;
+        this._masked = false;
+        this._fin = false;
+        this._opcode = 0;
+        this._totalPayloadLength = 0;
+        this._messageLength = 0;
+        this._fragments = [];
+        this._errored = false;
+        this._loop = false;
+        this._state = GET_INFO;
+      }
+      /**
+       * Implements `Writable.prototype._write()`.
+       *
+       * @param {Buffer} chunk The chunk of data to write
+       * @param {String} encoding The character encoding of `chunk`
+       * @param {Function} cb Callback
+       * @private
+       */
+      _write(chunk, encoding, cb) {
+        if (this._opcode === 8 && this._state == GET_INFO) return cb();
+        this._bufferedBytes += chunk.length;
+        this._buffers.push(chunk);
+        this.startLoop(cb);
+      }
+      /**
+       * Consumes `n` bytes from the buffered data.
+       *
+       * @param {Number} n The number of bytes to consume
+       * @return {Buffer} The consumed bytes
+       * @private
+       */
+      consume(n) {
+        this._bufferedBytes -= n;
+        if (n === this._buffers[0].length) return this._buffers.shift();
+        if (n < this._buffers[0].length) {
+          const buf = this._buffers[0];
+          this._buffers[0] = new FastBuffer(
+            buf.buffer,
+            buf.byteOffset + n,
+            buf.length - n
+          );
+          return new FastBuffer(buf.buffer, buf.byteOffset, n);
+        }
+        const dst = Buffer.allocUnsafe(n);
+        do {
+          const buf = this._buffers[0];
+          const offset = dst.length - n;
+          if (n >= buf.length) {
+            dst.set(this._buffers.shift(), offset);
+          } else {
+            dst.set(new Uint8Array(buf.buffer, buf.byteOffset, n), offset);
+            this._buffers[0] = new FastBuffer(
+              buf.buffer,
+              buf.byteOffset + n,
+              buf.length - n
+            );
+          }
+          n -= buf.length;
+        } while (n > 0);
+        return dst;
+      }
+      /**
+       * Starts the parsing loop.
+       *
+       * @param {Function} cb Callback
+       * @private
+       */
+      startLoop(cb) {
+        this._loop = true;
+        do {
+          switch (this._state) {
+            case GET_INFO:
+              this.getInfo(cb);
+              break;
+            case GET_PAYLOAD_LENGTH_16:
+              this.getPayloadLength16(cb);
+              break;
+            case GET_PAYLOAD_LENGTH_64:
+              this.getPayloadLength64(cb);
+              break;
+            case GET_MASK:
+              this.getMask();
+              break;
+            case GET_DATA:
+              this.getData(cb);
+              break;
+            case INFLATING:
+            case DEFER_EVENT:
+              this._loop = false;
+              return;
+          }
+        } while (this._loop);
+        if (!this._errored) cb();
+      }
+      /**
+       * Reads the first two bytes of a frame.
+       *
+       * @param {Function} cb Callback
+       * @private
+       */
+      getInfo(cb) {
+        if (this._bufferedBytes < 2) {
+          this._loop = false;
+          return;
+        }
+        const buf = this.consume(2);
+        if ((buf[0] & 48) !== 0) {
+          const error51 = this.createError(
+            RangeError,
+            "RSV2 and RSV3 must be clear",
+            true,
+            1002,
+            "WS_ERR_UNEXPECTED_RSV_2_3"
+          );
+          cb(error51);
+          return;
+        }
+        const compressed = (buf[0] & 64) === 64;
+        if (compressed && !this._extensions[PerMessageDeflate2.extensionName]) {
+          const error51 = this.createError(
+            RangeError,
+            "RSV1 must be clear",
+            true,
+            1002,
+            "WS_ERR_UNEXPECTED_RSV_1"
+          );
+          cb(error51);
+          return;
+        }
+        this._fin = (buf[0] & 128) === 128;
+        this._opcode = buf[0] & 15;
+        this._payloadLength = buf[1] & 127;
+        if (this._opcode === 0) {
+          if (compressed) {
+            const error51 = this.createError(
+              RangeError,
+              "RSV1 must be clear",
+              true,
+              1002,
+              "WS_ERR_UNEXPECTED_RSV_1"
+            );
+            cb(error51);
+            return;
+          }
+          if (!this._fragmented) {
+            const error51 = this.createError(
+              RangeError,
+              "invalid opcode 0",
+              true,
+              1002,
+              "WS_ERR_INVALID_OPCODE"
+            );
+            cb(error51);
+            return;
+          }
+          this._opcode = this._fragmented;
+        } else if (this._opcode === 1 || this._opcode === 2) {
+          if (this._fragmented) {
+            const error51 = this.createError(
+              RangeError,
+              `invalid opcode ${this._opcode}`,
+              true,
+              1002,
+              "WS_ERR_INVALID_OPCODE"
+            );
+            cb(error51);
+            return;
+          }
+          this._compressed = compressed;
+        } else if (this._opcode > 7 && this._opcode < 11) {
+          if (!this._fin) {
+            const error51 = this.createError(
+              RangeError,
+              "FIN must be set",
+              true,
+              1002,
+              "WS_ERR_EXPECTED_FIN"
+            );
+            cb(error51);
+            return;
+          }
+          if (compressed) {
+            const error51 = this.createError(
+              RangeError,
+              "RSV1 must be clear",
+              true,
+              1002,
+              "WS_ERR_UNEXPECTED_RSV_1"
+            );
+            cb(error51);
+            return;
+          }
+          if (this._payloadLength > 125 || this._opcode === 8 && this._payloadLength === 1) {
+            const error51 = this.createError(
+              RangeError,
+              `invalid payload length ${this._payloadLength}`,
+              true,
+              1002,
+              "WS_ERR_INVALID_CONTROL_PAYLOAD_LENGTH"
+            );
+            cb(error51);
+            return;
+          }
+        } else {
+          const error51 = this.createError(
+            RangeError,
+            `invalid opcode ${this._opcode}`,
+            true,
+            1002,
+            "WS_ERR_INVALID_OPCODE"
+          );
+          cb(error51);
+          return;
+        }
+        if (!this._fin && !this._fragmented) this._fragmented = this._opcode;
+        this._masked = (buf[1] & 128) === 128;
+        if (this._isServer) {
+          if (!this._masked) {
+            const error51 = this.createError(
+              RangeError,
+              "MASK must be set",
+              true,
+              1002,
+              "WS_ERR_EXPECTED_MASK"
+            );
+            cb(error51);
+            return;
+          }
+        } else if (this._masked) {
+          const error51 = this.createError(
+            RangeError,
+            "MASK must be clear",
+            true,
+            1002,
+            "WS_ERR_UNEXPECTED_MASK"
+          );
+          cb(error51);
+          return;
+        }
+        if (this._payloadLength === 126) this._state = GET_PAYLOAD_LENGTH_16;
+        else if (this._payloadLength === 127) this._state = GET_PAYLOAD_LENGTH_64;
+        else this.haveLength(cb);
+      }
+      /**
+       * Gets extended payload length (7+16).
+       *
+       * @param {Function} cb Callback
+       * @private
+       */
+      getPayloadLength16(cb) {
+        if (this._bufferedBytes < 2) {
+          this._loop = false;
+          return;
+        }
+        this._payloadLength = this.consume(2).readUInt16BE(0);
+        this.haveLength(cb);
+      }
+      /**
+       * Gets extended payload length (7+64).
+       *
+       * @param {Function} cb Callback
+       * @private
+       */
+      getPayloadLength64(cb) {
+        if (this._bufferedBytes < 8) {
+          this._loop = false;
+          return;
+        }
+        const buf = this.consume(8);
+        const num = buf.readUInt32BE(0);
+        if (num > Math.pow(2, 53 - 32) - 1) {
+          const error51 = this.createError(
+            RangeError,
+            "Unsupported WebSocket frame: payload length > 2^53 - 1",
+            false,
+            1009,
+            "WS_ERR_UNSUPPORTED_DATA_PAYLOAD_LENGTH"
+          );
+          cb(error51);
+          return;
+        }
+        this._payloadLength = num * Math.pow(2, 32) + buf.readUInt32BE(4);
+        this.haveLength(cb);
+      }
+      /**
+       * Payload length has been read.
+       *
+       * @param {Function} cb Callback
+       * @private
+       */
+      haveLength(cb) {
+        if (this._payloadLength && this._opcode < 8) {
+          this._totalPayloadLength += this._payloadLength;
+          if (this._totalPayloadLength > this._maxPayload && this._maxPayload > 0) {
+            const error51 = this.createError(
+              RangeError,
+              "Max payload size exceeded",
+              false,
+              1009,
+              "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH"
+            );
+            cb(error51);
+            return;
+          }
+        }
+        if (this._masked) this._state = GET_MASK;
+        else this._state = GET_DATA;
+      }
+      /**
+       * Reads mask bytes.
+       *
+       * @private
+       */
+      getMask() {
+        if (this._bufferedBytes < 4) {
+          this._loop = false;
+          return;
+        }
+        this._mask = this.consume(4);
+        this._state = GET_DATA;
+      }
+      /**
+       * Reads data bytes.
+       *
+       * @param {Function} cb Callback
+       * @private
+       */
+      getData(cb) {
+        let data = EMPTY_BUFFER;
+        if (this._payloadLength) {
+          if (this._bufferedBytes < this._payloadLength) {
+            this._loop = false;
+            return;
+          }
+          data = this.consume(this._payloadLength);
+          if (this._masked && (this._mask[0] | this._mask[1] | this._mask[2] | this._mask[3]) !== 0) {
+            unmask(data, this._mask);
+          }
+        }
+        if (this._opcode > 7) {
+          this.controlMessage(data, cb);
+          return;
+        }
+        if (this._compressed) {
+          this._state = INFLATING;
+          this.decompress(data, cb);
+          return;
+        }
+        if (data.length) {
+          this._messageLength = this._totalPayloadLength;
+          this._fragments.push(data);
+        }
+        this.dataMessage(cb);
+      }
+      /**
+       * Decompresses data.
+       *
+       * @param {Buffer} data Compressed data
+       * @param {Function} cb Callback
+       * @private
+       */
+      decompress(data, cb) {
+        const perMessageDeflate = this._extensions[PerMessageDeflate2.extensionName];
+        perMessageDeflate.decompress(data, this._fin, (err, buf) => {
+          if (err) return cb(err);
+          if (buf.length) {
+            this._messageLength += buf.length;
+            if (this._messageLength > this._maxPayload && this._maxPayload > 0) {
+              const error51 = this.createError(
+                RangeError,
+                "Max payload size exceeded",
+                false,
+                1009,
+                "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH"
+              );
+              cb(error51);
+              return;
+            }
+            this._fragments.push(buf);
+          }
+          this.dataMessage(cb);
+          if (this._state === GET_INFO) this.startLoop(cb);
+        });
+      }
+      /**
+       * Handles a data message.
+       *
+       * @param {Function} cb Callback
+       * @private
+       */
+      dataMessage(cb) {
+        if (!this._fin) {
+          this._state = GET_INFO;
+          return;
+        }
+        const messageLength = this._messageLength;
+        const fragments = this._fragments;
+        this._totalPayloadLength = 0;
+        this._messageLength = 0;
+        this._fragmented = 0;
+        this._fragments = [];
+        if (this._opcode === 2) {
+          let data;
+          if (this._binaryType === "nodebuffer") {
+            data = concat(fragments, messageLength);
+          } else if (this._binaryType === "arraybuffer") {
+            data = toArrayBuffer(concat(fragments, messageLength));
+          } else if (this._binaryType === "blob") {
+            data = new Blob(fragments);
+          } else {
+            data = fragments;
+          }
+          if (this._allowSynchronousEvents) {
+            this.emit("message", data, true);
+            this._state = GET_INFO;
+          } else {
+            this._state = DEFER_EVENT;
+            setImmediate(() => {
+              this.emit("message", data, true);
+              this._state = GET_INFO;
+              this.startLoop(cb);
+            });
+          }
+        } else {
+          const buf = concat(fragments, messageLength);
+          if (!this._skipUTF8Validation && !isValidUTF8(buf)) {
+            const error51 = this.createError(
+              Error,
+              "invalid UTF-8 sequence",
+              true,
+              1007,
+              "WS_ERR_INVALID_UTF8"
+            );
+            cb(error51);
+            return;
+          }
+          if (this._state === INFLATING || this._allowSynchronousEvents) {
+            this.emit("message", buf, false);
+            this._state = GET_INFO;
+          } else {
+            this._state = DEFER_EVENT;
+            setImmediate(() => {
+              this.emit("message", buf, false);
+              this._state = GET_INFO;
+              this.startLoop(cb);
+            });
+          }
+        }
+      }
+      /**
+       * Handles a control message.
+       *
+       * @param {Buffer} data Data to handle
+       * @return {(Error|RangeError|undefined)} A possible error
+       * @private
+       */
+      controlMessage(data, cb) {
+        if (this._opcode === 8) {
+          if (data.length === 0) {
+            this._loop = false;
+            this.emit("conclude", 1005, EMPTY_BUFFER);
+            this.end();
+          } else {
+            const code = data.readUInt16BE(0);
+            if (!isValidStatusCode(code)) {
+              const error51 = this.createError(
+                RangeError,
+                `invalid status code ${code}`,
+                true,
+                1002,
+                "WS_ERR_INVALID_CLOSE_CODE"
+              );
+              cb(error51);
+              return;
+            }
+            const buf = new FastBuffer(
+              data.buffer,
+              data.byteOffset + 2,
+              data.length - 2
+            );
+            if (!this._skipUTF8Validation && !isValidUTF8(buf)) {
+              const error51 = this.createError(
+                Error,
+                "invalid UTF-8 sequence",
+                true,
+                1007,
+                "WS_ERR_INVALID_UTF8"
+              );
+              cb(error51);
+              return;
+            }
+            this._loop = false;
+            this.emit("conclude", code, buf);
+            this.end();
+          }
+          this._state = GET_INFO;
+          return;
+        }
+        if (this._allowSynchronousEvents) {
+          this.emit(this._opcode === 9 ? "ping" : "pong", data);
+          this._state = GET_INFO;
+        } else {
+          this._state = DEFER_EVENT;
+          setImmediate(() => {
+            this.emit(this._opcode === 9 ? "ping" : "pong", data);
+            this._state = GET_INFO;
+            this.startLoop(cb);
+          });
+        }
+      }
+      /**
+       * Builds an error object.
+       *
+       * @param {function(new:Error|RangeError)} ErrorCtor The error constructor
+       * @param {String} message The error message
+       * @param {Boolean} prefix Specifies whether or not to add a default prefix to
+       *     `message`
+       * @param {Number} statusCode The status code
+       * @param {String} errorCode The exposed error code
+       * @return {(Error|RangeError)} The error
+       * @private
+       */
+      createError(ErrorCtor, message, prefix, statusCode, errorCode) {
+        this._loop = false;
+        this._errored = true;
+        const err = new ErrorCtor(
+          prefix ? `Invalid WebSocket frame: ${message}` : message
+        );
+        Error.captureStackTrace(err, this.createError);
+        err.code = errorCode;
+        err[kStatusCode] = statusCode;
+        return err;
+      }
+    };
+    module.exports = Receiver2;
+  }
+});
+
+// node_modules/ws/lib/sender.js
+var require_sender = __commonJS({
+  "node_modules/ws/lib/sender.js"(exports, module) {
+    "use strict";
+    var { Duplex } = __require("stream");
+    var { randomFillSync } = __require("crypto");
+    var {
+      types: { isUint8Array }
+    } = __require("util");
+    var PerMessageDeflate2 = require_permessage_deflate();
+    var { EMPTY_BUFFER, kWebSocket, NOOP } = require_constants();
+    var { isBlob, isValidStatusCode } = require_validation2();
+    var { mask: applyMask, toBuffer } = require_buffer_util();
+    var kByteLength = /* @__PURE__ */ Symbol("kByteLength");
+    var maskBuffer = Buffer.alloc(4);
+    var RANDOM_POOL_SIZE = 8 * 1024;
+    var randomPool;
+    var randomPoolPointer = RANDOM_POOL_SIZE;
+    var DEFAULT = 0;
+    var DEFLATING = 1;
+    var GET_BLOB_DATA = 2;
+    var Sender2 = class _Sender {
+      /**
+       * Creates a Sender instance.
+       *
+       * @param {Duplex} socket The connection socket
+       * @param {Object} [extensions] An object containing the negotiated extensions
+       * @param {Function} [generateMask] The function used to generate the masking
+       *     key
+       */
+      constructor(socket, extensions, generateMask) {
+        this._extensions = extensions || {};
+        if (generateMask) {
+          this._generateMask = generateMask;
+          this._maskBuffer = Buffer.alloc(4);
+        }
+        this._socket = socket;
+        this._firstFragment = true;
+        this._compress = false;
+        this._bufferedBytes = 0;
+        this._queue = [];
+        this._state = DEFAULT;
+        this.onerror = NOOP;
+        this[kWebSocket] = void 0;
+      }
+      /**
+       * Frames a piece of data according to the HyBi WebSocket protocol.
+       *
+       * @param {(Buffer|String)} data The data to frame
+       * @param {Object} options Options object
+       * @param {Boolean} [options.fin=false] Specifies whether or not to set the
+       *     FIN bit
+       * @param {Function} [options.generateMask] The function used to generate the
+       *     masking key
+       * @param {Boolean} [options.mask=false] Specifies whether or not to mask
+       *     `data`
+       * @param {Buffer} [options.maskBuffer] The buffer used to store the masking
+       *     key
+       * @param {Number} options.opcode The opcode
+       * @param {Boolean} [options.readOnly=false] Specifies whether `data` can be
+       *     modified
+       * @param {Boolean} [options.rsv1=false] Specifies whether or not to set the
+       *     RSV1 bit
+       * @return {(Buffer|String)[]} The framed data
+       * @public
+       */
+      static frame(data, options) {
+        let mask;
+        let merge2 = false;
+        let offset = 2;
+        let skipMasking = false;
+        if (options.mask) {
+          mask = options.maskBuffer || maskBuffer;
+          if (options.generateMask) {
+            options.generateMask(mask);
+          } else {
+            if (randomPoolPointer === RANDOM_POOL_SIZE) {
+              if (randomPool === void 0) {
+                randomPool = Buffer.alloc(RANDOM_POOL_SIZE);
+              }
+              randomFillSync(randomPool, 0, RANDOM_POOL_SIZE);
+              randomPoolPointer = 0;
+            }
+            mask[0] = randomPool[randomPoolPointer++];
+            mask[1] = randomPool[randomPoolPointer++];
+            mask[2] = randomPool[randomPoolPointer++];
+            mask[3] = randomPool[randomPoolPointer++];
+          }
+          skipMasking = (mask[0] | mask[1] | mask[2] | mask[3]) === 0;
+          offset = 6;
+        }
+        let dataLength;
+        if (typeof data === "string") {
+          if ((!options.mask || skipMasking) && options[kByteLength] !== void 0) {
+            dataLength = options[kByteLength];
+          } else {
+            data = Buffer.from(data);
+            dataLength = data.length;
+          }
+        } else {
+          dataLength = data.length;
+          merge2 = options.mask && options.readOnly && !skipMasking;
+        }
+        let payloadLength = dataLength;
+        if (dataLength >= 65536) {
+          offset += 8;
+          payloadLength = 127;
+        } else if (dataLength > 125) {
+          offset += 2;
+          payloadLength = 126;
+        }
+        const target = Buffer.allocUnsafe(merge2 ? dataLength + offset : offset);
+        target[0] = options.fin ? options.opcode | 128 : options.opcode;
+        if (options.rsv1) target[0] |= 64;
+        target[1] = payloadLength;
+        if (payloadLength === 126) {
+          target.writeUInt16BE(dataLength, 2);
+        } else if (payloadLength === 127) {
+          target[2] = target[3] = 0;
+          target.writeUIntBE(dataLength, 4, 6);
+        }
+        if (!options.mask) return [target, data];
+        target[1] |= 128;
+        target[offset - 4] = mask[0];
+        target[offset - 3] = mask[1];
+        target[offset - 2] = mask[2];
+        target[offset - 1] = mask[3];
+        if (skipMasking) return [target, data];
+        if (merge2) {
+          applyMask(data, mask, target, offset, dataLength);
+          return [target];
+        }
+        applyMask(data, mask, data, 0, dataLength);
+        return [target, data];
+      }
+      /**
+       * Sends a close message to the other peer.
+       *
+       * @param {Number} [code] The status code component of the body
+       * @param {(String|Buffer)} [data] The message component of the body
+       * @param {Boolean} [mask=false] Specifies whether or not to mask the message
+       * @param {Function} [cb] Callback
+       * @public
+       */
+      close(code, data, mask, cb) {
+        let buf;
+        if (code === void 0) {
+          buf = EMPTY_BUFFER;
+        } else if (typeof code !== "number" || !isValidStatusCode(code)) {
+          throw new TypeError("First argument must be a valid error code number");
+        } else if (data === void 0 || !data.length) {
+          buf = Buffer.allocUnsafe(2);
+          buf.writeUInt16BE(code, 0);
+        } else {
+          const length = Buffer.byteLength(data);
+          if (length > 123) {
+            throw new RangeError("The message must not be greater than 123 bytes");
+          }
+          buf = Buffer.allocUnsafe(2 + length);
+          buf.writeUInt16BE(code, 0);
+          if (typeof data === "string") {
+            buf.write(data, 2);
+          } else if (isUint8Array(data)) {
+            buf.set(data, 2);
+          } else {
+            throw new TypeError("Second argument must be a string or a Uint8Array");
+          }
+        }
+        const options = {
+          [kByteLength]: buf.length,
+          fin: true,
+          generateMask: this._generateMask,
+          mask,
+          maskBuffer: this._maskBuffer,
+          opcode: 8,
+          readOnly: false,
+          rsv1: false
+        };
+        if (this._state !== DEFAULT) {
+          this.enqueue([this.dispatch, buf, false, options, cb]);
+        } else {
+          this.sendFrame(_Sender.frame(buf, options), cb);
+        }
+      }
+      /**
+       * Sends a ping message to the other peer.
+       *
+       * @param {*} data The message to send
+       * @param {Boolean} [mask=false] Specifies whether or not to mask `data`
+       * @param {Function} [cb] Callback
+       * @public
+       */
+      ping(data, mask, cb) {
+        let byteLength;
+        let readOnly;
+        if (typeof data === "string") {
+          byteLength = Buffer.byteLength(data);
+          readOnly = false;
+        } else if (isBlob(data)) {
+          byteLength = data.size;
+          readOnly = false;
+        } else {
+          data = toBuffer(data);
+          byteLength = data.length;
+          readOnly = toBuffer.readOnly;
+        }
+        if (byteLength > 125) {
+          throw new RangeError("The data size must not be greater than 125 bytes");
+        }
+        const options = {
+          [kByteLength]: byteLength,
+          fin: true,
+          generateMask: this._generateMask,
+          mask,
+          maskBuffer: this._maskBuffer,
+          opcode: 9,
+          readOnly,
+          rsv1: false
+        };
+        if (isBlob(data)) {
+          if (this._state !== DEFAULT) {
+            this.enqueue([this.getBlobData, data, false, options, cb]);
+          } else {
+            this.getBlobData(data, false, options, cb);
+          }
+        } else if (this._state !== DEFAULT) {
+          this.enqueue([this.dispatch, data, false, options, cb]);
+        } else {
+          this.sendFrame(_Sender.frame(data, options), cb);
+        }
+      }
+      /**
+       * Sends a pong message to the other peer.
+       *
+       * @param {*} data The message to send
+       * @param {Boolean} [mask=false] Specifies whether or not to mask `data`
+       * @param {Function} [cb] Callback
+       * @public
+       */
+      pong(data, mask, cb) {
+        let byteLength;
+        let readOnly;
+        if (typeof data === "string") {
+          byteLength = Buffer.byteLength(data);
+          readOnly = false;
+        } else if (isBlob(data)) {
+          byteLength = data.size;
+          readOnly = false;
+        } else {
+          data = toBuffer(data);
+          byteLength = data.length;
+          readOnly = toBuffer.readOnly;
+        }
+        if (byteLength > 125) {
+          throw new RangeError("The data size must not be greater than 125 bytes");
+        }
+        const options = {
+          [kByteLength]: byteLength,
+          fin: true,
+          generateMask: this._generateMask,
+          mask,
+          maskBuffer: this._maskBuffer,
+          opcode: 10,
+          readOnly,
+          rsv1: false
+        };
+        if (isBlob(data)) {
+          if (this._state !== DEFAULT) {
+            this.enqueue([this.getBlobData, data, false, options, cb]);
+          } else {
+            this.getBlobData(data, false, options, cb);
+          }
+        } else if (this._state !== DEFAULT) {
+          this.enqueue([this.dispatch, data, false, options, cb]);
+        } else {
+          this.sendFrame(_Sender.frame(data, options), cb);
+        }
+      }
+      /**
+       * Sends a data message to the other peer.
+       *
+       * @param {*} data The message to send
+       * @param {Object} options Options object
+       * @param {Boolean} [options.binary=false] Specifies whether `data` is binary
+       *     or text
+       * @param {Boolean} [options.compress=false] Specifies whether or not to
+       *     compress `data`
+       * @param {Boolean} [options.fin=false] Specifies whether the fragment is the
+       *     last one
+       * @param {Boolean} [options.mask=false] Specifies whether or not to mask
+       *     `data`
+       * @param {Function} [cb] Callback
+       * @public
+       */
+      send(data, options, cb) {
+        const perMessageDeflate = this._extensions[PerMessageDeflate2.extensionName];
+        let opcode = options.binary ? 2 : 1;
+        let rsv1 = options.compress;
+        let byteLength;
+        let readOnly;
+        if (typeof data === "string") {
+          byteLength = Buffer.byteLength(data);
+          readOnly = false;
+        } else if (isBlob(data)) {
+          byteLength = data.size;
+          readOnly = false;
+        } else {
+          data = toBuffer(data);
+          byteLength = data.length;
+          readOnly = toBuffer.readOnly;
+        }
+        if (this._firstFragment) {
+          this._firstFragment = false;
+          if (rsv1 && perMessageDeflate && perMessageDeflate.params[perMessageDeflate._isServer ? "server_no_context_takeover" : "client_no_context_takeover"]) {
+            rsv1 = byteLength >= perMessageDeflate._threshold;
+          }
+          this._compress = rsv1;
+        } else {
+          rsv1 = false;
+          opcode = 0;
+        }
+        if (options.fin) this._firstFragment = true;
+        const opts = {
+          [kByteLength]: byteLength,
+          fin: options.fin,
+          generateMask: this._generateMask,
+          mask: options.mask,
+          maskBuffer: this._maskBuffer,
+          opcode,
+          readOnly,
+          rsv1
+        };
+        if (isBlob(data)) {
+          if (this._state !== DEFAULT) {
+            this.enqueue([this.getBlobData, data, this._compress, opts, cb]);
+          } else {
+            this.getBlobData(data, this._compress, opts, cb);
+          }
+        } else if (this._state !== DEFAULT) {
+          this.enqueue([this.dispatch, data, this._compress, opts, cb]);
+        } else {
+          this.dispatch(data, this._compress, opts, cb);
+        }
+      }
+      /**
+       * Gets the contents of a blob as binary data.
+       *
+       * @param {Blob} blob The blob
+       * @param {Boolean} [compress=false] Specifies whether or not to compress
+       *     the data
+       * @param {Object} options Options object
+       * @param {Boolean} [options.fin=false] Specifies whether or not to set the
+       *     FIN bit
+       * @param {Function} [options.generateMask] The function used to generate the
+       *     masking key
+       * @param {Boolean} [options.mask=false] Specifies whether or not to mask
+       *     `data`
+       * @param {Buffer} [options.maskBuffer] The buffer used to store the masking
+       *     key
+       * @param {Number} options.opcode The opcode
+       * @param {Boolean} [options.readOnly=false] Specifies whether `data` can be
+       *     modified
+       * @param {Boolean} [options.rsv1=false] Specifies whether or not to set the
+       *     RSV1 bit
+       * @param {Function} [cb] Callback
+       * @private
+       */
+      getBlobData(blob, compress, options, cb) {
+        this._bufferedBytes += options[kByteLength];
+        this._state = GET_BLOB_DATA;
+        blob.arrayBuffer().then((arrayBuffer) => {
+          if (this._socket.destroyed) {
+            const err = new Error(
+              "The socket was closed while the blob was being read"
+            );
+            process.nextTick(callCallbacks, this, err, cb);
+            return;
+          }
+          this._bufferedBytes -= options[kByteLength];
+          const data = toBuffer(arrayBuffer);
+          if (!compress) {
+            this._state = DEFAULT;
+            this.sendFrame(_Sender.frame(data, options), cb);
+            this.dequeue();
+          } else {
+            this.dispatch(data, compress, options, cb);
+          }
+        }).catch((err) => {
+          process.nextTick(onError, this, err, cb);
+        });
+      }
+      /**
+       * Dispatches a message.
+       *
+       * @param {(Buffer|String)} data The message to send
+       * @param {Boolean} [compress=false] Specifies whether or not to compress
+       *     `data`
+       * @param {Object} options Options object
+       * @param {Boolean} [options.fin=false] Specifies whether or not to set the
+       *     FIN bit
+       * @param {Function} [options.generateMask] The function used to generate the
+       *     masking key
+       * @param {Boolean} [options.mask=false] Specifies whether or not to mask
+       *     `data`
+       * @param {Buffer} [options.maskBuffer] The buffer used to store the masking
+       *     key
+       * @param {Number} options.opcode The opcode
+       * @param {Boolean} [options.readOnly=false] Specifies whether `data` can be
+       *     modified
+       * @param {Boolean} [options.rsv1=false] Specifies whether or not to set the
+       *     RSV1 bit
+       * @param {Function} [cb] Callback
+       * @private
+       */
+      dispatch(data, compress, options, cb) {
+        if (!compress) {
+          this.sendFrame(_Sender.frame(data, options), cb);
+          return;
+        }
+        const perMessageDeflate = this._extensions[PerMessageDeflate2.extensionName];
+        this._bufferedBytes += options[kByteLength];
+        this._state = DEFLATING;
+        perMessageDeflate.compress(data, options.fin, (_, buf) => {
+          if (this._socket.destroyed) {
+            const err = new Error(
+              "The socket was closed while data was being compressed"
+            );
+            callCallbacks(this, err, cb);
+            return;
+          }
+          this._bufferedBytes -= options[kByteLength];
+          this._state = DEFAULT;
+          options.readOnly = false;
+          this.sendFrame(_Sender.frame(buf, options), cb);
+          this.dequeue();
+        });
+      }
+      /**
+       * Executes queued send operations.
+       *
+       * @private
+       */
+      dequeue() {
+        while (this._state === DEFAULT && this._queue.length) {
+          const params = this._queue.shift();
+          this._bufferedBytes -= params[3][kByteLength];
+          Reflect.apply(params[0], this, params.slice(1));
+        }
+      }
+      /**
+       * Enqueues a send operation.
+       *
+       * @param {Array} params Send operation parameters.
+       * @private
+       */
+      enqueue(params) {
+        this._bufferedBytes += params[3][kByteLength];
+        this._queue.push(params);
+      }
+      /**
+       * Sends a frame.
+       *
+       * @param {(Buffer | String)[]} list The frame to send
+       * @param {Function} [cb] Callback
+       * @private
+       */
+      sendFrame(list, cb) {
+        if (list.length === 2) {
+          this._socket.cork();
+          this._socket.write(list[0]);
+          this._socket.write(list[1], cb);
+          this._socket.uncork();
+        } else {
+          this._socket.write(list[0], cb);
+        }
+      }
+    };
+    module.exports = Sender2;
+    function callCallbacks(sender, err, cb) {
+      if (typeof cb === "function") cb(err);
+      for (let i = 0; i < sender._queue.length; i++) {
+        const params = sender._queue[i];
+        const callback = params[params.length - 1];
+        if (typeof callback === "function") callback(err);
+      }
+    }
+    function onError(sender, err, cb) {
+      callCallbacks(sender, err, cb);
+      sender.onerror(err);
+    }
+  }
+});
+
+// node_modules/ws/lib/event-target.js
+var require_event_target = __commonJS({
+  "node_modules/ws/lib/event-target.js"(exports, module) {
+    "use strict";
+    var { kForOnEventAttribute, kListener } = require_constants();
+    var kCode = /* @__PURE__ */ Symbol("kCode");
+    var kData = /* @__PURE__ */ Symbol("kData");
+    var kError = /* @__PURE__ */ Symbol("kError");
+    var kMessage = /* @__PURE__ */ Symbol("kMessage");
+    var kReason = /* @__PURE__ */ Symbol("kReason");
+    var kTarget = /* @__PURE__ */ Symbol("kTarget");
+    var kType = /* @__PURE__ */ Symbol("kType");
+    var kWasClean = /* @__PURE__ */ Symbol("kWasClean");
+    var Event = class {
+      /**
+       * Create a new `Event`.
+       *
+       * @param {String} type The name of the event
+       * @throws {TypeError} If the `type` argument is not specified
+       */
+      constructor(type) {
+        this[kTarget] = null;
+        this[kType] = type;
+      }
+      /**
+       * @type {*}
+       */
+      get target() {
+        return this[kTarget];
+      }
+      /**
+       * @type {String}
+       */
+      get type() {
+        return this[kType];
+      }
+    };
+    Object.defineProperty(Event.prototype, "target", { enumerable: true });
+    Object.defineProperty(Event.prototype, "type", { enumerable: true });
+    var CloseEvent = class extends Event {
+      /**
+       * Create a new `CloseEvent`.
+       *
+       * @param {String} type The name of the event
+       * @param {Object} [options] A dictionary object that allows for setting
+       *     attributes via object members of the same name
+       * @param {Number} [options.code=0] The status code explaining why the
+       *     connection was closed
+       * @param {String} [options.reason=''] A human-readable string explaining why
+       *     the connection was closed
+       * @param {Boolean} [options.wasClean=false] Indicates whether or not the
+       *     connection was cleanly closed
+       */
+      constructor(type, options = {}) {
+        super(type);
+        this[kCode] = options.code === void 0 ? 0 : options.code;
+        this[kReason] = options.reason === void 0 ? "" : options.reason;
+        this[kWasClean] = options.wasClean === void 0 ? false : options.wasClean;
+      }
+      /**
+       * @type {Number}
+       */
+      get code() {
+        return this[kCode];
+      }
+      /**
+       * @type {String}
+       */
+      get reason() {
+        return this[kReason];
+      }
+      /**
+       * @type {Boolean}
+       */
+      get wasClean() {
+        return this[kWasClean];
+      }
+    };
+    Object.defineProperty(CloseEvent.prototype, "code", { enumerable: true });
+    Object.defineProperty(CloseEvent.prototype, "reason", { enumerable: true });
+    Object.defineProperty(CloseEvent.prototype, "wasClean", { enumerable: true });
+    var ErrorEvent = class extends Event {
+      /**
+       * Create a new `ErrorEvent`.
+       *
+       * @param {String} type The name of the event
+       * @param {Object} [options] A dictionary object that allows for setting
+       *     attributes via object members of the same name
+       * @param {*} [options.error=null] The error that generated this event
+       * @param {String} [options.message=''] The error message
+       */
+      constructor(type, options = {}) {
+        super(type);
+        this[kError] = options.error === void 0 ? null : options.error;
+        this[kMessage] = options.message === void 0 ? "" : options.message;
+      }
+      /**
+       * @type {*}
+       */
+      get error() {
+        return this[kError];
+      }
+      /**
+       * @type {String}
+       */
+      get message() {
+        return this[kMessage];
+      }
+    };
+    Object.defineProperty(ErrorEvent.prototype, "error", { enumerable: true });
+    Object.defineProperty(ErrorEvent.prototype, "message", { enumerable: true });
+    var MessageEvent = class extends Event {
+      /**
+       * Create a new `MessageEvent`.
+       *
+       * @param {String} type The name of the event
+       * @param {Object} [options] A dictionary object that allows for setting
+       *     attributes via object members of the same name
+       * @param {*} [options.data=null] The message content
+       */
+      constructor(type, options = {}) {
+        super(type);
+        this[kData] = options.data === void 0 ? null : options.data;
+      }
+      /**
+       * @type {*}
+       */
+      get data() {
+        return this[kData];
+      }
+    };
+    Object.defineProperty(MessageEvent.prototype, "data", { enumerable: true });
+    var EventTarget = {
+      /**
+       * Register an event listener.
+       *
+       * @param {String} type A string representing the event type to listen for
+       * @param {(Function|Object)} handler The listener to add
+       * @param {Object} [options] An options object specifies characteristics about
+       *     the event listener
+       * @param {Boolean} [options.once=false] A `Boolean` indicating that the
+       *     listener should be invoked at most once after being added. If `true`,
+       *     the listener would be automatically removed when invoked.
+       * @public
+       */
+      addEventListener(type, handler, options = {}) {
+        for (const listener of this.listeners(type)) {
+          if (!options[kForOnEventAttribute] && listener[kListener] === handler && !listener[kForOnEventAttribute]) {
+            return;
+          }
+        }
+        let wrapper;
+        if (type === "message") {
+          wrapper = function onMessage(data, isBinary) {
+            const event = new MessageEvent("message", {
+              data: isBinary ? data : data.toString()
+            });
+            event[kTarget] = this;
+            callListener(handler, this, event);
+          };
+        } else if (type === "close") {
+          wrapper = function onClose(code, message) {
+            const event = new CloseEvent("close", {
+              code,
+              reason: message.toString(),
+              wasClean: this._closeFrameReceived && this._closeFrameSent
+            });
+            event[kTarget] = this;
+            callListener(handler, this, event);
+          };
+        } else if (type === "error") {
+          wrapper = function onError(error51) {
+            const event = new ErrorEvent("error", {
+              error: error51,
+              message: error51.message
+            });
+            event[kTarget] = this;
+            callListener(handler, this, event);
+          };
+        } else if (type === "open") {
+          wrapper = function onOpen() {
+            const event = new Event("open");
+            event[kTarget] = this;
+            callListener(handler, this, event);
+          };
+        } else {
+          return;
+        }
+        wrapper[kForOnEventAttribute] = !!options[kForOnEventAttribute];
+        wrapper[kListener] = handler;
+        if (options.once) {
+          this.once(type, wrapper);
+        } else {
+          this.on(type, wrapper);
+        }
+      },
+      /**
+       * Remove an event listener.
+       *
+       * @param {String} type A string representing the event type to remove
+       * @param {(Function|Object)} handler The listener to remove
+       * @public
+       */
+      removeEventListener(type, handler) {
+        for (const listener of this.listeners(type)) {
+          if (listener[kListener] === handler && !listener[kForOnEventAttribute]) {
+            this.removeListener(type, listener);
+            break;
+          }
+        }
+      }
+    };
+    module.exports = {
+      CloseEvent,
+      ErrorEvent,
+      Event,
+      EventTarget,
+      MessageEvent
+    };
+    function callListener(listener, thisArg, event) {
+      if (typeof listener === "object" && listener.handleEvent) {
+        listener.handleEvent.call(listener, event);
+      } else {
+        listener.call(thisArg, event);
+      }
+    }
+  }
+});
+
+// node_modules/ws/lib/extension.js
+var require_extension = __commonJS({
+  "node_modules/ws/lib/extension.js"(exports, module) {
+    "use strict";
+    var { tokenChars } = require_validation2();
+    function push(dest, name, elem) {
+      if (dest[name] === void 0) dest[name] = [elem];
+      else dest[name].push(elem);
+    }
+    function parse3(header) {
+      const offers = /* @__PURE__ */ Object.create(null);
+      let params = /* @__PURE__ */ Object.create(null);
+      let mustUnescape = false;
+      let isEscaping = false;
+      let inQuotes = false;
+      let extensionName;
+      let paramName;
+      let start = -1;
+      let code = -1;
+      let end = -1;
+      let i = 0;
+      for (; i < header.length; i++) {
+        code = header.charCodeAt(i);
+        if (extensionName === void 0) {
+          if (end === -1 && tokenChars[code] === 1) {
+            if (start === -1) start = i;
+          } else if (i !== 0 && (code === 32 || code === 9)) {
+            if (end === -1 && start !== -1) end = i;
+          } else if (code === 59 || code === 44) {
+            if (start === -1) {
+              throw new SyntaxError(`Unexpected character at index ${i}`);
+            }
+            if (end === -1) end = i;
+            const name = header.slice(start, end);
+            if (code === 44) {
+              push(offers, name, params);
+              params = /* @__PURE__ */ Object.create(null);
+            } else {
+              extensionName = name;
+            }
+            start = end = -1;
+          } else {
+            throw new SyntaxError(`Unexpected character at index ${i}`);
+          }
+        } else if (paramName === void 0) {
+          if (end === -1 && tokenChars[code] === 1) {
+            if (start === -1) start = i;
+          } else if (code === 32 || code === 9) {
+            if (end === -1 && start !== -1) end = i;
+          } else if (code === 59 || code === 44) {
+            if (start === -1) {
+              throw new SyntaxError(`Unexpected character at index ${i}`);
+            }
+            if (end === -1) end = i;
+            push(params, header.slice(start, end), true);
+            if (code === 44) {
+              push(offers, extensionName, params);
+              params = /* @__PURE__ */ Object.create(null);
+              extensionName = void 0;
+            }
+            start = end = -1;
+          } else if (code === 61 && start !== -1 && end === -1) {
+            paramName = header.slice(start, i);
+            start = end = -1;
+          } else {
+            throw new SyntaxError(`Unexpected character at index ${i}`);
+          }
+        } else {
+          if (isEscaping) {
+            if (tokenChars[code] !== 1) {
+              throw new SyntaxError(`Unexpected character at index ${i}`);
+            }
+            if (start === -1) start = i;
+            else if (!mustUnescape) mustUnescape = true;
+            isEscaping = false;
+          } else if (inQuotes) {
+            if (tokenChars[code] === 1) {
+              if (start === -1) start = i;
+            } else if (code === 34 && start !== -1) {
+              inQuotes = false;
+              end = i;
+            } else if (code === 92) {
+              isEscaping = true;
+            } else {
+              throw new SyntaxError(`Unexpected character at index ${i}`);
+            }
+          } else if (code === 34 && header.charCodeAt(i - 1) === 61) {
+            inQuotes = true;
+          } else if (end === -1 && tokenChars[code] === 1) {
+            if (start === -1) start = i;
+          } else if (start !== -1 && (code === 32 || code === 9)) {
+            if (end === -1) end = i;
+          } else if (code === 59 || code === 44) {
+            if (start === -1) {
+              throw new SyntaxError(`Unexpected character at index ${i}`);
+            }
+            if (end === -1) end = i;
+            let value = header.slice(start, end);
+            if (mustUnescape) {
+              value = value.replace(/\\/g, "");
+              mustUnescape = false;
+            }
+            push(params, paramName, value);
+            if (code === 44) {
+              push(offers, extensionName, params);
+              params = /* @__PURE__ */ Object.create(null);
+              extensionName = void 0;
+            }
+            paramName = void 0;
+            start = end = -1;
+          } else {
+            throw new SyntaxError(`Unexpected character at index ${i}`);
+          }
+        }
+      }
+      if (start === -1 || inQuotes || code === 32 || code === 9) {
+        throw new SyntaxError("Unexpected end of input");
+      }
+      if (end === -1) end = i;
+      const token = header.slice(start, end);
+      if (extensionName === void 0) {
+        push(offers, token, params);
+      } else {
+        if (paramName === void 0) {
+          push(params, token, true);
+        } else if (mustUnescape) {
+          push(params, paramName, token.replace(/\\/g, ""));
+        } else {
+          push(params, paramName, token);
+        }
+        push(offers, extensionName, params);
+      }
+      return offers;
+    }
+    function format(extensions) {
+      return Object.keys(extensions).map((extension2) => {
+        let configurations = extensions[extension2];
+        if (!Array.isArray(configurations)) configurations = [configurations];
+        return configurations.map((params) => {
+          return [extension2].concat(
+            Object.keys(params).map((k) => {
+              let values = params[k];
+              if (!Array.isArray(values)) values = [values];
+              return values.map((v) => v === true ? k : `${k}=${v}`).join("; ");
+            })
+          ).join("; ");
+        }).join(", ");
+      }).join(", ");
+    }
+    module.exports = { format, parse: parse3 };
+  }
+});
+
+// node_modules/ws/lib/websocket.js
+var require_websocket = __commonJS({
+  "node_modules/ws/lib/websocket.js"(exports, module) {
+    "use strict";
+    var EventEmitter = __require("events");
+    var https = __require("https");
+    var http = __require("http");
+    var net = __require("net");
+    var tls = __require("tls");
+    var { randomBytes, createHash: createHash2 } = __require("crypto");
+    var { Duplex, Readable } = __require("stream");
+    var { URL: URL2 } = __require("url");
+    var PerMessageDeflate2 = require_permessage_deflate();
+    var Receiver2 = require_receiver();
+    var Sender2 = require_sender();
+    var { isBlob } = require_validation2();
+    var {
+      BINARY_TYPES,
+      CLOSE_TIMEOUT,
+      EMPTY_BUFFER,
+      GUID,
+      kForOnEventAttribute,
+      kListener,
+      kStatusCode,
+      kWebSocket,
+      NOOP
+    } = require_constants();
+    var {
+      EventTarget: { addEventListener, removeEventListener }
+    } = require_event_target();
+    var { format, parse: parse3 } = require_extension();
+    var { toBuffer } = require_buffer_util();
+    var kAborted = /* @__PURE__ */ Symbol("kAborted");
+    var protocolVersions = [8, 13];
+    var readyStates = ["CONNECTING", "OPEN", "CLOSING", "CLOSED"];
+    var subprotocolRegex = /^[!#$%&'*+\-.0-9A-Z^_`|a-z~]+$/;
+    var WebSocket2 = class _WebSocket extends EventEmitter {
+      /**
+       * Create a new `WebSocket`.
+       *
+       * @param {(String|URL)} address The URL to which to connect
+       * @param {(String|String[])} [protocols] The subprotocols
+       * @param {Object} [options] Connection options
+       */
+      constructor(address, protocols, options) {
+        super();
+        this._binaryType = BINARY_TYPES[0];
+        this._closeCode = 1006;
+        this._closeFrameReceived = false;
+        this._closeFrameSent = false;
+        this._closeMessage = EMPTY_BUFFER;
+        this._closeTimer = null;
+        this._errorEmitted = false;
+        this._extensions = {};
+        this._paused = false;
+        this._protocol = "";
+        this._readyState = _WebSocket.CONNECTING;
+        this._receiver = null;
+        this._sender = null;
+        this._socket = null;
+        if (address !== null) {
+          this._bufferedAmount = 0;
+          this._isServer = false;
+          this._redirects = 0;
+          if (protocols === void 0) {
+            protocols = [];
+          } else if (!Array.isArray(protocols)) {
+            if (typeof protocols === "object" && protocols !== null) {
+              options = protocols;
+              protocols = [];
+            } else {
+              protocols = [protocols];
+            }
+          }
+          initAsClient(this, address, protocols, options);
+        } else {
+          this._autoPong = options.autoPong;
+          this._closeTimeout = options.closeTimeout;
+          this._isServer = true;
+        }
+      }
+      /**
+       * For historical reasons, the custom "nodebuffer" type is used by the default
+       * instead of "blob".
+       *
+       * @type {String}
+       */
+      get binaryType() {
+        return this._binaryType;
+      }
+      set binaryType(type) {
+        if (!BINARY_TYPES.includes(type)) return;
+        this._binaryType = type;
+        if (this._receiver) this._receiver._binaryType = type;
+      }
+      /**
+       * @type {Number}
+       */
+      get bufferedAmount() {
+        if (!this._socket) return this._bufferedAmount;
+        return this._socket._writableState.length + this._sender._bufferedBytes;
+      }
+      /**
+       * @type {String}
+       */
+      get extensions() {
+        return Object.keys(this._extensions).join();
+      }
+      /**
+       * @type {Boolean}
+       */
+      get isPaused() {
+        return this._paused;
+      }
+      /**
+       * @type {Function}
+       */
+      /* istanbul ignore next */
+      get onclose() {
+        return null;
+      }
+      /**
+       * @type {Function}
+       */
+      /* istanbul ignore next */
+      get onerror() {
+        return null;
+      }
+      /**
+       * @type {Function}
+       */
+      /* istanbul ignore next */
+      get onopen() {
+        return null;
+      }
+      /**
+       * @type {Function}
+       */
+      /* istanbul ignore next */
+      get onmessage() {
+        return null;
+      }
+      /**
+       * @type {String}
+       */
+      get protocol() {
+        return this._protocol;
+      }
+      /**
+       * @type {Number}
+       */
+      get readyState() {
+        return this._readyState;
+      }
+      /**
+       * @type {String}
+       */
+      get url() {
+        return this._url;
+      }
+      /**
+       * Set up the socket and the internal resources.
+       *
+       * @param {Duplex} socket The network socket between the server and client
+       * @param {Buffer} head The first packet of the upgraded stream
+       * @param {Object} options Options object
+       * @param {Boolean} [options.allowSynchronousEvents=false] Specifies whether
+       *     any of the `'message'`, `'ping'`, and `'pong'` events can be emitted
+       *     multiple times in the same tick
+       * @param {Function} [options.generateMask] The function used to generate the
+       *     masking key
+       * @param {Number} [options.maxPayload=0] The maximum allowed message size
+       * @param {Boolean} [options.skipUTF8Validation=false] Specifies whether or
+       *     not to skip UTF-8 validation for text and close messages
+       * @private
+       */
+      setSocket(socket, head, options) {
+        const receiver = new Receiver2({
+          allowSynchronousEvents: options.allowSynchronousEvents,
+          binaryType: this.binaryType,
+          extensions: this._extensions,
+          isServer: this._isServer,
+          maxPayload: options.maxPayload,
+          skipUTF8Validation: options.skipUTF8Validation
+        });
+        const sender = new Sender2(socket, this._extensions, options.generateMask);
+        this._receiver = receiver;
+        this._sender = sender;
+        this._socket = socket;
+        receiver[kWebSocket] = this;
+        sender[kWebSocket] = this;
+        socket[kWebSocket] = this;
+        receiver.on("conclude", receiverOnConclude);
+        receiver.on("drain", receiverOnDrain);
+        receiver.on("error", receiverOnError);
+        receiver.on("message", receiverOnMessage);
+        receiver.on("ping", receiverOnPing);
+        receiver.on("pong", receiverOnPong);
+        sender.onerror = senderOnError;
+        if (socket.setTimeout) socket.setTimeout(0);
+        if (socket.setNoDelay) socket.setNoDelay();
+        if (head.length > 0) socket.unshift(head);
+        socket.on("close", socketOnClose);
+        socket.on("data", socketOnData);
+        socket.on("end", socketOnEnd);
+        socket.on("error", socketOnError);
+        this._readyState = _WebSocket.OPEN;
+        this.emit("open");
+      }
+      /**
+       * Emit the `'close'` event.
+       *
+       * @private
+       */
+      emitClose() {
+        if (!this._socket) {
+          this._readyState = _WebSocket.CLOSED;
+          this.emit("close", this._closeCode, this._closeMessage);
+          return;
+        }
+        if (this._extensions[PerMessageDeflate2.extensionName]) {
+          this._extensions[PerMessageDeflate2.extensionName].cleanup();
+        }
+        this._receiver.removeAllListeners();
+        this._readyState = _WebSocket.CLOSED;
+        this.emit("close", this._closeCode, this._closeMessage);
+      }
+      /**
+       * Start a closing handshake.
+       *
+       *          +----------+   +-----------+   +----------+
+       *     - - -|ws.close()|-->|close frame|-->|ws.close()|- - -
+       *    |     +----------+   +-----------+   +----------+     |
+       *          +----------+   +-----------+         |
+       * CLOSING  |ws.close()|<--|close frame|<--+-----+       CLOSING
+       *          +----------+   +-----------+   |
+       *    |           |                        |   +---+        |
+       *                +------------------------+-->|fin| - - - -
+       *    |         +---+                      |   +---+
+       *     - - - - -|fin|<---------------------+
+       *              +---+
+       *
+       * @param {Number} [code] Status code explaining why the connection is closing
+       * @param {(String|Buffer)} [data] The reason why the connection is
+       *     closing
+       * @public
+       */
+      close(code, data) {
+        if (this.readyState === _WebSocket.CLOSED) return;
+        if (this.readyState === _WebSocket.CONNECTING) {
+          const msg = "WebSocket was closed before the connection was established";
+          abortHandshake(this, this._req, msg);
+          return;
+        }
+        if (this.readyState === _WebSocket.CLOSING) {
+          if (this._closeFrameSent && (this._closeFrameReceived || this._receiver._writableState.errorEmitted)) {
+            this._socket.end();
+          }
+          return;
+        }
+        this._readyState = _WebSocket.CLOSING;
+        this._sender.close(code, data, !this._isServer, (err) => {
+          if (err) return;
+          this._closeFrameSent = true;
+          if (this._closeFrameReceived || this._receiver._writableState.errorEmitted) {
+            this._socket.end();
+          }
+        });
+        setCloseTimer(this);
+      }
+      /**
+       * Pause the socket.
+       *
+       * @public
+       */
+      pause() {
+        if (this.readyState === _WebSocket.CONNECTING || this.readyState === _WebSocket.CLOSED) {
+          return;
+        }
+        this._paused = true;
+        this._socket.pause();
+      }
+      /**
+       * Send a ping.
+       *
+       * @param {*} [data] The data to send
+       * @param {Boolean} [mask] Indicates whether or not to mask `data`
+       * @param {Function} [cb] Callback which is executed when the ping is sent
+       * @public
+       */
+      ping(data, mask, cb) {
+        if (this.readyState === _WebSocket.CONNECTING) {
+          throw new Error("WebSocket is not open: readyState 0 (CONNECTING)");
+        }
+        if (typeof data === "function") {
+          cb = data;
+          data = mask = void 0;
+        } else if (typeof mask === "function") {
+          cb = mask;
+          mask = void 0;
+        }
+        if (typeof data === "number") data = data.toString();
+        if (this.readyState !== _WebSocket.OPEN) {
+          sendAfterClose(this, data, cb);
+          return;
+        }
+        if (mask === void 0) mask = !this._isServer;
+        this._sender.ping(data || EMPTY_BUFFER, mask, cb);
+      }
+      /**
+       * Send a pong.
+       *
+       * @param {*} [data] The data to send
+       * @param {Boolean} [mask] Indicates whether or not to mask `data`
+       * @param {Function} [cb] Callback which is executed when the pong is sent
+       * @public
+       */
+      pong(data, mask, cb) {
+        if (this.readyState === _WebSocket.CONNECTING) {
+          throw new Error("WebSocket is not open: readyState 0 (CONNECTING)");
+        }
+        if (typeof data === "function") {
+          cb = data;
+          data = mask = void 0;
+        } else if (typeof mask === "function") {
+          cb = mask;
+          mask = void 0;
+        }
+        if (typeof data === "number") data = data.toString();
+        if (this.readyState !== _WebSocket.OPEN) {
+          sendAfterClose(this, data, cb);
+          return;
+        }
+        if (mask === void 0) mask = !this._isServer;
+        this._sender.pong(data || EMPTY_BUFFER, mask, cb);
+      }
+      /**
+       * Resume the socket.
+       *
+       * @public
+       */
+      resume() {
+        if (this.readyState === _WebSocket.CONNECTING || this.readyState === _WebSocket.CLOSED) {
+          return;
+        }
+        this._paused = false;
+        if (!this._receiver._writableState.needDrain) this._socket.resume();
+      }
+      /**
+       * Send a data message.
+       *
+       * @param {*} data The message to send
+       * @param {Object} [options] Options object
+       * @param {Boolean} [options.binary] Specifies whether `data` is binary or
+       *     text
+       * @param {Boolean} [options.compress] Specifies whether or not to compress
+       *     `data`
+       * @param {Boolean} [options.fin=true] Specifies whether the fragment is the
+       *     last one
+       * @param {Boolean} [options.mask] Specifies whether or not to mask `data`
+       * @param {Function} [cb] Callback which is executed when data is written out
+       * @public
+       */
+      send(data, options, cb) {
+        if (this.readyState === _WebSocket.CONNECTING) {
+          throw new Error("WebSocket is not open: readyState 0 (CONNECTING)");
+        }
+        if (typeof options === "function") {
+          cb = options;
+          options = {};
+        }
+        if (typeof data === "number") data = data.toString();
+        if (this.readyState !== _WebSocket.OPEN) {
+          sendAfterClose(this, data, cb);
+          return;
+        }
+        const opts = {
+          binary: typeof data !== "string",
+          mask: !this._isServer,
+          compress: true,
+          fin: true,
+          ...options
+        };
+        if (!this._extensions[PerMessageDeflate2.extensionName]) {
+          opts.compress = false;
+        }
+        this._sender.send(data || EMPTY_BUFFER, opts, cb);
+      }
+      /**
+       * Forcibly close the connection.
+       *
+       * @public
+       */
+      terminate() {
+        if (this.readyState === _WebSocket.CLOSED) return;
+        if (this.readyState === _WebSocket.CONNECTING) {
+          const msg = "WebSocket was closed before the connection was established";
+          abortHandshake(this, this._req, msg);
+          return;
+        }
+        if (this._socket) {
+          this._readyState = _WebSocket.CLOSING;
+          this._socket.destroy();
+        }
+      }
+    };
+    Object.defineProperty(WebSocket2, "CONNECTING", {
+      enumerable: true,
+      value: readyStates.indexOf("CONNECTING")
+    });
+    Object.defineProperty(WebSocket2.prototype, "CONNECTING", {
+      enumerable: true,
+      value: readyStates.indexOf("CONNECTING")
+    });
+    Object.defineProperty(WebSocket2, "OPEN", {
+      enumerable: true,
+      value: readyStates.indexOf("OPEN")
+    });
+    Object.defineProperty(WebSocket2.prototype, "OPEN", {
+      enumerable: true,
+      value: readyStates.indexOf("OPEN")
+    });
+    Object.defineProperty(WebSocket2, "CLOSING", {
+      enumerable: true,
+      value: readyStates.indexOf("CLOSING")
+    });
+    Object.defineProperty(WebSocket2.prototype, "CLOSING", {
+      enumerable: true,
+      value: readyStates.indexOf("CLOSING")
+    });
+    Object.defineProperty(WebSocket2, "CLOSED", {
+      enumerable: true,
+      value: readyStates.indexOf("CLOSED")
+    });
+    Object.defineProperty(WebSocket2.prototype, "CLOSED", {
+      enumerable: true,
+      value: readyStates.indexOf("CLOSED")
+    });
+    [
+      "binaryType",
+      "bufferedAmount",
+      "extensions",
+      "isPaused",
+      "protocol",
+      "readyState",
+      "url"
+    ].forEach((property) => {
+      Object.defineProperty(WebSocket2.prototype, property, { enumerable: true });
+    });
+    ["open", "error", "close", "message"].forEach((method) => {
+      Object.defineProperty(WebSocket2.prototype, `on${method}`, {
+        enumerable: true,
+        get() {
+          for (const listener of this.listeners(method)) {
+            if (listener[kForOnEventAttribute]) return listener[kListener];
+          }
+          return null;
+        },
+        set(handler) {
+          for (const listener of this.listeners(method)) {
+            if (listener[kForOnEventAttribute]) {
+              this.removeListener(method, listener);
+              break;
+            }
+          }
+          if (typeof handler !== "function") return;
+          this.addEventListener(method, handler, {
+            [kForOnEventAttribute]: true
+          });
+        }
+      });
+    });
+    WebSocket2.prototype.addEventListener = addEventListener;
+    WebSocket2.prototype.removeEventListener = removeEventListener;
+    module.exports = WebSocket2;
+    function initAsClient(websocket, address, protocols, options) {
+      const opts = {
+        allowSynchronousEvents: true,
+        autoPong: true,
+        closeTimeout: CLOSE_TIMEOUT,
+        protocolVersion: protocolVersions[1],
+        maxPayload: 100 * 1024 * 1024,
+        skipUTF8Validation: false,
+        perMessageDeflate: true,
+        followRedirects: false,
+        maxRedirects: 10,
+        ...options,
+        socketPath: void 0,
+        hostname: void 0,
+        protocol: void 0,
+        timeout: void 0,
+        method: "GET",
+        host: void 0,
+        path: void 0,
+        port: void 0
+      };
+      websocket._autoPong = opts.autoPong;
+      websocket._closeTimeout = opts.closeTimeout;
+      if (!protocolVersions.includes(opts.protocolVersion)) {
+        throw new RangeError(
+          `Unsupported protocol version: ${opts.protocolVersion} (supported versions: ${protocolVersions.join(", ")})`
+        );
+      }
+      let parsedUrl;
+      if (address instanceof URL2) {
+        parsedUrl = address;
+      } else {
+        try {
+          parsedUrl = new URL2(address);
+        } catch {
+          throw new SyntaxError(`Invalid URL: ${address}`);
+        }
+      }
+      if (parsedUrl.protocol === "http:") {
+        parsedUrl.protocol = "ws:";
+      } else if (parsedUrl.protocol === "https:") {
+        parsedUrl.protocol = "wss:";
+      }
+      websocket._url = parsedUrl.href;
+      const isSecure = parsedUrl.protocol === "wss:";
+      const isIpcUrl = parsedUrl.protocol === "ws+unix:";
+      let invalidUrlMessage;
+      if (parsedUrl.protocol !== "ws:" && !isSecure && !isIpcUrl) {
+        invalidUrlMessage = `The URL's protocol must be one of "ws:", "wss:", "http:", "https:", or "ws+unix:"`;
+      } else if (isIpcUrl && !parsedUrl.pathname) {
+        invalidUrlMessage = "The URL's pathname is empty";
+      } else if (parsedUrl.hash) {
+        invalidUrlMessage = "The URL contains a fragment identifier";
+      }
+      if (invalidUrlMessage) {
+        const err = new SyntaxError(invalidUrlMessage);
+        if (websocket._redirects === 0) {
+          throw err;
+        } else {
+          emitErrorAndClose(websocket, err);
+          return;
+        }
+      }
+      const defaultPort = isSecure ? 443 : 80;
+      const key = randomBytes(16).toString("base64");
+      const request = isSecure ? https.request : http.request;
+      const protocolSet = /* @__PURE__ */ new Set();
+      let perMessageDeflate;
+      opts.createConnection = opts.createConnection || (isSecure ? tlsConnect : netConnect);
+      opts.defaultPort = opts.defaultPort || defaultPort;
+      opts.port = parsedUrl.port || defaultPort;
+      opts.host = parsedUrl.hostname.startsWith("[") ? parsedUrl.hostname.slice(1, -1) : parsedUrl.hostname;
+      opts.headers = {
+        ...opts.headers,
+        "Sec-WebSocket-Version": opts.protocolVersion,
+        "Sec-WebSocket-Key": key,
+        Connection: "Upgrade",
+        Upgrade: "websocket"
+      };
+      opts.path = parsedUrl.pathname + parsedUrl.search;
+      opts.timeout = opts.handshakeTimeout;
+      if (opts.perMessageDeflate) {
+        perMessageDeflate = new PerMessageDeflate2({
+          ...opts.perMessageDeflate,
+          isServer: false,
+          maxPayload: opts.maxPayload
+        });
+        opts.headers["Sec-WebSocket-Extensions"] = format({
+          [PerMessageDeflate2.extensionName]: perMessageDeflate.offer()
+        });
+      }
+      if (protocols.length) {
+        for (const protocol of protocols) {
+          if (typeof protocol !== "string" || !subprotocolRegex.test(protocol) || protocolSet.has(protocol)) {
+            throw new SyntaxError(
+              "An invalid or duplicated subprotocol was specified"
+            );
+          }
+          protocolSet.add(protocol);
+        }
+        opts.headers["Sec-WebSocket-Protocol"] = protocols.join(",");
+      }
+      if (opts.origin) {
+        if (opts.protocolVersion < 13) {
+          opts.headers["Sec-WebSocket-Origin"] = opts.origin;
+        } else {
+          opts.headers.Origin = opts.origin;
+        }
+      }
+      if (parsedUrl.username || parsedUrl.password) {
+        opts.auth = `${parsedUrl.username}:${parsedUrl.password}`;
+      }
+      if (isIpcUrl) {
+        const parts = opts.path.split(":");
+        opts.socketPath = parts[0];
+        opts.path = parts[1];
+      }
+      let req;
+      if (opts.followRedirects) {
+        if (websocket._redirects === 0) {
+          websocket._originalIpc = isIpcUrl;
+          websocket._originalSecure = isSecure;
+          websocket._originalHostOrSocketPath = isIpcUrl ? opts.socketPath : parsedUrl.host;
+          const headers = options && options.headers;
+          options = { ...options, headers: {} };
+          if (headers) {
+            for (const [key2, value] of Object.entries(headers)) {
+              options.headers[key2.toLowerCase()] = value;
+            }
+          }
+        } else if (websocket.listenerCount("redirect") === 0) {
+          const isSameHost = isIpcUrl ? websocket._originalIpc ? opts.socketPath === websocket._originalHostOrSocketPath : false : websocket._originalIpc ? false : parsedUrl.host === websocket._originalHostOrSocketPath;
+          if (!isSameHost || websocket._originalSecure && !isSecure) {
+            delete opts.headers.authorization;
+            delete opts.headers.cookie;
+            if (!isSameHost) delete opts.headers.host;
+            opts.auth = void 0;
+          }
+        }
+        if (opts.auth && !options.headers.authorization) {
+          options.headers.authorization = "Basic " + Buffer.from(opts.auth).toString("base64");
+        }
+        req = websocket._req = request(opts);
+        if (websocket._redirects) {
+          websocket.emit("redirect", websocket.url, req);
+        }
+      } else {
+        req = websocket._req = request(opts);
+      }
+      if (opts.timeout) {
+        req.on("timeout", () => {
+          abortHandshake(websocket, req, "Opening handshake has timed out");
+        });
+      }
+      req.on("error", (err) => {
+        if (req === null || req[kAborted]) return;
+        req = websocket._req = null;
+        emitErrorAndClose(websocket, err);
+      });
+      req.on("response", (res) => {
+        const location = res.headers.location;
+        const statusCode = res.statusCode;
+        if (location && opts.followRedirects && statusCode >= 300 && statusCode < 400) {
+          if (++websocket._redirects > opts.maxRedirects) {
+            abortHandshake(websocket, req, "Maximum redirects exceeded");
+            return;
+          }
+          req.abort();
+          let addr;
+          try {
+            addr = new URL2(location, address);
+          } catch (e) {
+            const err = new SyntaxError(`Invalid URL: ${location}`);
+            emitErrorAndClose(websocket, err);
+            return;
+          }
+          initAsClient(websocket, addr, protocols, options);
+        } else if (!websocket.emit("unexpected-response", req, res)) {
+          abortHandshake(
+            websocket,
+            req,
+            `Unexpected server response: ${res.statusCode}`
+          );
+        }
+      });
+      req.on("upgrade", (res, socket, head) => {
+        websocket.emit("upgrade", res);
+        if (websocket.readyState !== WebSocket2.CONNECTING) return;
+        req = websocket._req = null;
+        const upgrade = res.headers.upgrade;
+        if (upgrade === void 0 || upgrade.toLowerCase() !== "websocket") {
+          abortHandshake(websocket, socket, "Invalid Upgrade header");
+          return;
+        }
+        const digest = createHash2("sha1").update(key + GUID).digest("base64");
+        if (res.headers["sec-websocket-accept"] !== digest) {
+          abortHandshake(websocket, socket, "Invalid Sec-WebSocket-Accept header");
+          return;
+        }
+        const serverProt = res.headers["sec-websocket-protocol"];
+        let protError;
+        if (serverProt !== void 0) {
+          if (!protocolSet.size) {
+            protError = "Server sent a subprotocol but none was requested";
+          } else if (!protocolSet.has(serverProt)) {
+            protError = "Server sent an invalid subprotocol";
+          }
+        } else if (protocolSet.size) {
+          protError = "Server sent no subprotocol";
+        }
+        if (protError) {
+          abortHandshake(websocket, socket, protError);
+          return;
+        }
+        if (serverProt) websocket._protocol = serverProt;
+        const secWebSocketExtensions = res.headers["sec-websocket-extensions"];
+        if (secWebSocketExtensions !== void 0) {
+          if (!perMessageDeflate) {
+            const message = "Server sent a Sec-WebSocket-Extensions header but no extension was requested";
+            abortHandshake(websocket, socket, message);
+            return;
+          }
+          let extensions;
+          try {
+            extensions = parse3(secWebSocketExtensions);
+          } catch (err) {
+            const message = "Invalid Sec-WebSocket-Extensions header";
+            abortHandshake(websocket, socket, message);
+            return;
+          }
+          const extensionNames = Object.keys(extensions);
+          if (extensionNames.length !== 1 || extensionNames[0] !== PerMessageDeflate2.extensionName) {
+            const message = "Server indicated an extension that was not requested";
+            abortHandshake(websocket, socket, message);
+            return;
+          }
+          try {
+            perMessageDeflate.accept(extensions[PerMessageDeflate2.extensionName]);
+          } catch (err) {
+            const message = "Invalid Sec-WebSocket-Extensions header";
+            abortHandshake(websocket, socket, message);
+            return;
+          }
+          websocket._extensions[PerMessageDeflate2.extensionName] = perMessageDeflate;
+        }
+        websocket.setSocket(socket, head, {
+          allowSynchronousEvents: opts.allowSynchronousEvents,
+          generateMask: opts.generateMask,
+          maxPayload: opts.maxPayload,
+          skipUTF8Validation: opts.skipUTF8Validation
+        });
+      });
+      if (opts.finishRequest) {
+        opts.finishRequest(req, websocket);
+      } else {
+        req.end();
+      }
+    }
+    function emitErrorAndClose(websocket, err) {
+      websocket._readyState = WebSocket2.CLOSING;
+      websocket._errorEmitted = true;
+      websocket.emit("error", err);
+      websocket.emitClose();
+    }
+    function netConnect(options) {
+      options.path = options.socketPath;
+      return net.connect(options);
+    }
+    function tlsConnect(options) {
+      options.path = void 0;
+      if (!options.servername && options.servername !== "") {
+        options.servername = net.isIP(options.host) ? "" : options.host;
+      }
+      return tls.connect(options);
+    }
+    function abortHandshake(websocket, stream, message) {
+      websocket._readyState = WebSocket2.CLOSING;
+      const err = new Error(message);
+      Error.captureStackTrace(err, abortHandshake);
+      if (stream.setHeader) {
+        stream[kAborted] = true;
+        stream.abort();
+        if (stream.socket && !stream.socket.destroyed) {
+          stream.socket.destroy();
+        }
+        process.nextTick(emitErrorAndClose, websocket, err);
+      } else {
+        stream.destroy(err);
+        stream.once("error", websocket.emit.bind(websocket, "error"));
+        stream.once("close", websocket.emitClose.bind(websocket));
+      }
+    }
+    function sendAfterClose(websocket, data, cb) {
+      if (data) {
+        const length = isBlob(data) ? data.size : toBuffer(data).length;
+        if (websocket._socket) websocket._sender._bufferedBytes += length;
+        else websocket._bufferedAmount += length;
+      }
+      if (cb) {
+        const err = new Error(
+          `WebSocket is not open: readyState ${websocket.readyState} (${readyStates[websocket.readyState]})`
+        );
+        process.nextTick(cb, err);
+      }
+    }
+    function receiverOnConclude(code, reason) {
+      const websocket = this[kWebSocket];
+      websocket._closeFrameReceived = true;
+      websocket._closeMessage = reason;
+      websocket._closeCode = code;
+      if (websocket._socket[kWebSocket] === void 0) return;
+      websocket._socket.removeListener("data", socketOnData);
+      process.nextTick(resume, websocket._socket);
+      if (code === 1005) websocket.close();
+      else websocket.close(code, reason);
+    }
+    function receiverOnDrain() {
+      const websocket = this[kWebSocket];
+      if (!websocket.isPaused) websocket._socket.resume();
+    }
+    function receiverOnError(err) {
+      const websocket = this[kWebSocket];
+      if (websocket._socket[kWebSocket] !== void 0) {
+        websocket._socket.removeListener("data", socketOnData);
+        process.nextTick(resume, websocket._socket);
+        websocket.close(err[kStatusCode]);
+      }
+      if (!websocket._errorEmitted) {
+        websocket._errorEmitted = true;
+        websocket.emit("error", err);
+      }
+    }
+    function receiverOnFinish() {
+      this[kWebSocket].emitClose();
+    }
+    function receiverOnMessage(data, isBinary) {
+      this[kWebSocket].emit("message", data, isBinary);
+    }
+    function receiverOnPing(data) {
+      const websocket = this[kWebSocket];
+      if (websocket._autoPong) websocket.pong(data, !this._isServer, NOOP);
+      websocket.emit("ping", data);
+    }
+    function receiverOnPong(data) {
+      this[kWebSocket].emit("pong", data);
+    }
+    function resume(stream) {
+      stream.resume();
+    }
+    function senderOnError(err) {
+      const websocket = this[kWebSocket];
+      if (websocket.readyState === WebSocket2.CLOSED) return;
+      if (websocket.readyState === WebSocket2.OPEN) {
+        websocket._readyState = WebSocket2.CLOSING;
+        setCloseTimer(websocket);
+      }
+      this._socket.end();
+      if (!websocket._errorEmitted) {
+        websocket._errorEmitted = true;
+        websocket.emit("error", err);
+      }
+    }
+    function setCloseTimer(websocket) {
+      websocket._closeTimer = setTimeout(
+        websocket._socket.destroy.bind(websocket._socket),
+        websocket._closeTimeout
+      );
+    }
+    function socketOnClose() {
+      const websocket = this[kWebSocket];
+      this.removeListener("close", socketOnClose);
+      this.removeListener("data", socketOnData);
+      this.removeListener("end", socketOnEnd);
+      websocket._readyState = WebSocket2.CLOSING;
+      if (!this._readableState.endEmitted && !websocket._closeFrameReceived && !websocket._receiver._writableState.errorEmitted && this._readableState.length !== 0) {
+        const chunk = this.read(this._readableState.length);
+        websocket._receiver.write(chunk);
+      }
+      websocket._receiver.end();
+      this[kWebSocket] = void 0;
+      clearTimeout(websocket._closeTimer);
+      if (websocket._receiver._writableState.finished || websocket._receiver._writableState.errorEmitted) {
+        websocket.emitClose();
+      } else {
+        websocket._receiver.on("error", receiverOnFinish);
+        websocket._receiver.on("finish", receiverOnFinish);
+      }
+    }
+    function socketOnData(chunk) {
+      if (!this[kWebSocket]._receiver.write(chunk)) {
+        this.pause();
+      }
+    }
+    function socketOnEnd() {
+      const websocket = this[kWebSocket];
+      websocket._readyState = WebSocket2.CLOSING;
+      websocket._receiver.end();
+      this.end();
+    }
+    function socketOnError() {
+      const websocket = this[kWebSocket];
+      this.removeListener("error", socketOnError);
+      this.on("error", NOOP);
+      if (websocket) {
+        websocket._readyState = WebSocket2.CLOSING;
+        this.destroy();
+      }
+    }
+  }
+});
+
+// node_modules/ws/lib/stream.js
+var require_stream = __commonJS({
+  "node_modules/ws/lib/stream.js"(exports, module) {
+    "use strict";
+    var WebSocket2 = require_websocket();
+    var { Duplex } = __require("stream");
+    function emitClose(stream) {
+      stream.emit("close");
+    }
+    function duplexOnEnd() {
+      if (!this.destroyed && this._writableState.finished) {
+        this.destroy();
+      }
+    }
+    function duplexOnError(err) {
+      this.removeListener("error", duplexOnError);
+      this.destroy();
+      if (this.listenerCount("error") === 0) {
+        this.emit("error", err);
+      }
+    }
+    function createWebSocketStream2(ws, options) {
+      let terminateOnDestroy = true;
+      const duplex = new Duplex({
+        ...options,
+        autoDestroy: false,
+        emitClose: false,
+        objectMode: false,
+        writableObjectMode: false
+      });
+      ws.on("message", function message(msg, isBinary) {
+        const data = !isBinary && duplex._readableState.objectMode ? msg.toString() : msg;
+        if (!duplex.push(data)) ws.pause();
+      });
+      ws.once("error", function error51(err) {
+        if (duplex.destroyed) return;
+        terminateOnDestroy = false;
+        duplex.destroy(err);
+      });
+      ws.once("close", function close() {
+        if (duplex.destroyed) return;
+        duplex.push(null);
+      });
+      duplex._destroy = function(err, callback) {
+        if (ws.readyState === ws.CLOSED) {
+          callback(err);
+          process.nextTick(emitClose, duplex);
+          return;
+        }
+        let called = false;
+        ws.once("error", function error51(err2) {
+          called = true;
+          callback(err2);
+        });
+        ws.once("close", function close() {
+          if (!called) callback(err);
+          process.nextTick(emitClose, duplex);
+        });
+        if (terminateOnDestroy) ws.terminate();
+      };
+      duplex._final = function(callback) {
+        if (ws.readyState === ws.CONNECTING) {
+          ws.once("open", function open() {
+            duplex._final(callback);
+          });
+          return;
+        }
+        if (ws._socket === null) return;
+        if (ws._socket._writableState.finished) {
+          callback();
+          if (duplex._readableState.endEmitted) duplex.destroy();
+        } else {
+          ws._socket.once("finish", function finish() {
+            callback();
+          });
+          ws.close();
+        }
+      };
+      duplex._read = function() {
+        if (ws.isPaused) ws.resume();
+      };
+      duplex._write = function(chunk, encoding, callback) {
+        if (ws.readyState === ws.CONNECTING) {
+          ws.once("open", function open() {
+            duplex._write(chunk, encoding, callback);
+          });
+          return;
+        }
+        ws.send(chunk, callback);
+      };
+      duplex.on("end", duplexOnEnd);
+      duplex.on("error", duplexOnError);
+      return duplex;
+    }
+    module.exports = createWebSocketStream2;
+  }
+});
+
+// node_modules/ws/lib/subprotocol.js
+var require_subprotocol = __commonJS({
+  "node_modules/ws/lib/subprotocol.js"(exports, module) {
+    "use strict";
+    var { tokenChars } = require_validation2();
+    function parse3(header) {
+      const protocols = /* @__PURE__ */ new Set();
+      let start = -1;
+      let end = -1;
+      let i = 0;
+      for (i; i < header.length; i++) {
+        const code = header.charCodeAt(i);
+        if (end === -1 && tokenChars[code] === 1) {
+          if (start === -1) start = i;
+        } else if (i !== 0 && (code === 32 || code === 9)) {
+          if (end === -1 && start !== -1) end = i;
+        } else if (code === 44) {
+          if (start === -1) {
+            throw new SyntaxError(`Unexpected character at index ${i}`);
+          }
+          if (end === -1) end = i;
+          const protocol2 = header.slice(start, end);
+          if (protocols.has(protocol2)) {
+            throw new SyntaxError(`The "${protocol2}" subprotocol is duplicated`);
+          }
+          protocols.add(protocol2);
+          start = end = -1;
+        } else {
+          throw new SyntaxError(`Unexpected character at index ${i}`);
+        }
+      }
+      if (start === -1 || end !== -1) {
+        throw new SyntaxError("Unexpected end of input");
+      }
+      const protocol = header.slice(start, i);
+      if (protocols.has(protocol)) {
+        throw new SyntaxError(`The "${protocol}" subprotocol is duplicated`);
+      }
+      protocols.add(protocol);
+      return protocols;
+    }
+    module.exports = { parse: parse3 };
+  }
+});
+
+// node_modules/ws/lib/websocket-server.js
+var require_websocket_server = __commonJS({
+  "node_modules/ws/lib/websocket-server.js"(exports, module) {
+    "use strict";
+    var EventEmitter = __require("events");
+    var http = __require("http");
+    var { Duplex } = __require("stream");
+    var { createHash: createHash2 } = __require("crypto");
+    var extension2 = require_extension();
+    var PerMessageDeflate2 = require_permessage_deflate();
+    var subprotocol2 = require_subprotocol();
+    var WebSocket2 = require_websocket();
+    var { CLOSE_TIMEOUT, GUID, kWebSocket } = require_constants();
+    var keyRegex = /^[+/0-9A-Za-z]{22}==$/;
+    var RUNNING = 0;
+    var CLOSING = 1;
+    var CLOSED = 2;
+    var WebSocketServer2 = class extends EventEmitter {
+      /**
+       * Create a `WebSocketServer` instance.
+       *
+       * @param {Object} options Configuration options
+       * @param {Boolean} [options.allowSynchronousEvents=true] Specifies whether
+       *     any of the `'message'`, `'ping'`, and `'pong'` events can be emitted
+       *     multiple times in the same tick
+       * @param {Boolean} [options.autoPong=true] Specifies whether or not to
+       *     automatically send a pong in response to a ping
+       * @param {Number} [options.backlog=511] The maximum length of the queue of
+       *     pending connections
+       * @param {Boolean} [options.clientTracking=true] Specifies whether or not to
+       *     track clients
+       * @param {Number} [options.closeTimeout=30000] Duration in milliseconds to
+       *     wait for the closing handshake to finish after `websocket.close()` is
+       *     called
+       * @param {Function} [options.handleProtocols] A hook to handle protocols
+       * @param {String} [options.host] The hostname where to bind the server
+       * @param {Number} [options.maxPayload=104857600] The maximum allowed message
+       *     size
+       * @param {Boolean} [options.noServer=false] Enable no server mode
+       * @param {String} [options.path] Accept only connections matching this path
+       * @param {(Boolean|Object)} [options.perMessageDeflate=false] Enable/disable
+       *     permessage-deflate
+       * @param {Number} [options.port] The port where to bind the server
+       * @param {(http.Server|https.Server)} [options.server] A pre-created HTTP/S
+       *     server to use
+       * @param {Boolean} [options.skipUTF8Validation=false] Specifies whether or
+       *     not to skip UTF-8 validation for text and close messages
+       * @param {Function} [options.verifyClient] A hook to reject connections
+       * @param {Function} [options.WebSocket=WebSocket] Specifies the `WebSocket`
+       *     class to use. It must be the `WebSocket` class or class that extends it
+       * @param {Function} [callback] A listener for the `listening` event
+       */
+      constructor(options, callback) {
+        super();
+        options = {
+          allowSynchronousEvents: true,
+          autoPong: true,
+          maxPayload: 100 * 1024 * 1024,
+          skipUTF8Validation: false,
+          perMessageDeflate: false,
+          handleProtocols: null,
+          clientTracking: true,
+          closeTimeout: CLOSE_TIMEOUT,
+          verifyClient: null,
+          noServer: false,
+          backlog: null,
+          // use default (511 as implemented in net.js)
+          server: null,
+          host: null,
+          path: null,
+          port: null,
+          WebSocket: WebSocket2,
+          ...options
+        };
+        if (options.port == null && !options.server && !options.noServer || options.port != null && (options.server || options.noServer) || options.server && options.noServer) {
+          throw new TypeError(
+            'One and only one of the "port", "server", or "noServer" options must be specified'
+          );
+        }
+        if (options.port != null) {
+          this._server = http.createServer((req, res) => {
+            const body = http.STATUS_CODES[426];
+            res.writeHead(426, {
+              "Content-Length": body.length,
+              "Content-Type": "text/plain"
+            });
+            res.end(body);
+          });
+          this._server.listen(
+            options.port,
+            options.host,
+            options.backlog,
+            callback
+          );
+        } else if (options.server) {
+          this._server = options.server;
+        }
+        if (this._server) {
+          const emitConnection = this.emit.bind(this, "connection");
+          this._removeListeners = addListeners(this._server, {
+            listening: this.emit.bind(this, "listening"),
+            error: this.emit.bind(this, "error"),
+            upgrade: (req, socket, head) => {
+              this.handleUpgrade(req, socket, head, emitConnection);
+            }
+          });
+        }
+        if (options.perMessageDeflate === true) options.perMessageDeflate = {};
+        if (options.clientTracking) {
+          this.clients = /* @__PURE__ */ new Set();
+          this._shouldEmitClose = false;
+        }
+        this.options = options;
+        this._state = RUNNING;
+      }
+      /**
+       * Returns the bound address, the address family name, and port of the server
+       * as reported by the operating system if listening on an IP socket.
+       * If the server is listening on a pipe or UNIX domain socket, the name is
+       * returned as a string.
+       *
+       * @return {(Object|String|null)} The address of the server
+       * @public
+       */
+      address() {
+        if (this.options.noServer) {
+          throw new Error('The server is operating in "noServer" mode');
+        }
+        if (!this._server) return null;
+        return this._server.address();
+      }
+      /**
+       * Stop the server from accepting new connections and emit the `'close'` event
+       * when all existing connections are closed.
+       *
+       * @param {Function} [cb] A one-time listener for the `'close'` event
+       * @public
+       */
+      close(cb) {
+        if (this._state === CLOSED) {
+          if (cb) {
+            this.once("close", () => {
+              cb(new Error("The server is not running"));
+            });
+          }
+          process.nextTick(emitClose, this);
+          return;
+        }
+        if (cb) this.once("close", cb);
+        if (this._state === CLOSING) return;
+        this._state = CLOSING;
+        if (this.options.noServer || this.options.server) {
+          if (this._server) {
+            this._removeListeners();
+            this._removeListeners = this._server = null;
+          }
+          if (this.clients) {
+            if (!this.clients.size) {
+              process.nextTick(emitClose, this);
+            } else {
+              this._shouldEmitClose = true;
+            }
+          } else {
+            process.nextTick(emitClose, this);
+          }
+        } else {
+          const server2 = this._server;
+          this._removeListeners();
+          this._removeListeners = this._server = null;
+          server2.close(() => {
+            emitClose(this);
+          });
+        }
+      }
+      /**
+       * See if a given request should be handled by this server instance.
+       *
+       * @param {http.IncomingMessage} req Request object to inspect
+       * @return {Boolean} `true` if the request is valid, else `false`
+       * @public
+       */
+      shouldHandle(req) {
+        if (this.options.path) {
+          const index = req.url.indexOf("?");
+          const pathname = index !== -1 ? req.url.slice(0, index) : req.url;
+          if (pathname !== this.options.path) return false;
+        }
+        return true;
+      }
+      /**
+       * Handle a HTTP Upgrade request.
+       *
+       * @param {http.IncomingMessage} req The request object
+       * @param {Duplex} socket The network socket between the server and client
+       * @param {Buffer} head The first packet of the upgraded stream
+       * @param {Function} cb Callback
+       * @public
+       */
+      handleUpgrade(req, socket, head, cb) {
+        socket.on("error", socketOnError);
+        const key = req.headers["sec-websocket-key"];
+        const upgrade = req.headers.upgrade;
+        const version2 = +req.headers["sec-websocket-version"];
+        if (req.method !== "GET") {
+          const message = "Invalid HTTP method";
+          abortHandshakeOrEmitwsClientError(this, req, socket, 405, message);
+          return;
+        }
+        if (upgrade === void 0 || upgrade.toLowerCase() !== "websocket") {
+          const message = "Invalid Upgrade header";
+          abortHandshakeOrEmitwsClientError(this, req, socket, 400, message);
+          return;
+        }
+        if (key === void 0 || !keyRegex.test(key)) {
+          const message = "Missing or invalid Sec-WebSocket-Key header";
+          abortHandshakeOrEmitwsClientError(this, req, socket, 400, message);
+          return;
+        }
+        if (version2 !== 13 && version2 !== 8) {
+          const message = "Missing or invalid Sec-WebSocket-Version header";
+          abortHandshakeOrEmitwsClientError(this, req, socket, 400, message, {
+            "Sec-WebSocket-Version": "13, 8"
+          });
+          return;
+        }
+        if (!this.shouldHandle(req)) {
+          abortHandshake(socket, 400);
+          return;
+        }
+        const secWebSocketProtocol = req.headers["sec-websocket-protocol"];
+        let protocols = /* @__PURE__ */ new Set();
+        if (secWebSocketProtocol !== void 0) {
+          try {
+            protocols = subprotocol2.parse(secWebSocketProtocol);
+          } catch (err) {
+            const message = "Invalid Sec-WebSocket-Protocol header";
+            abortHandshakeOrEmitwsClientError(this, req, socket, 400, message);
+            return;
+          }
+        }
+        const secWebSocketExtensions = req.headers["sec-websocket-extensions"];
+        const extensions = {};
+        if (this.options.perMessageDeflate && secWebSocketExtensions !== void 0) {
+          const perMessageDeflate = new PerMessageDeflate2({
+            ...this.options.perMessageDeflate,
+            isServer: true,
+            maxPayload: this.options.maxPayload
+          });
+          try {
+            const offers = extension2.parse(secWebSocketExtensions);
+            if (offers[PerMessageDeflate2.extensionName]) {
+              perMessageDeflate.accept(offers[PerMessageDeflate2.extensionName]);
+              extensions[PerMessageDeflate2.extensionName] = perMessageDeflate;
+            }
+          } catch (err) {
+            const message = "Invalid or unacceptable Sec-WebSocket-Extensions header";
+            abortHandshakeOrEmitwsClientError(this, req, socket, 400, message);
+            return;
+          }
+        }
+        if (this.options.verifyClient) {
+          const info = {
+            origin: req.headers[`${version2 === 8 ? "sec-websocket-origin" : "origin"}`],
+            secure: !!(req.socket.authorized || req.socket.encrypted),
+            req
+          };
+          if (this.options.verifyClient.length === 2) {
+            this.options.verifyClient(info, (verified, code, message, headers) => {
+              if (!verified) {
+                return abortHandshake(socket, code || 401, message, headers);
+              }
+              this.completeUpgrade(
+                extensions,
+                key,
+                protocols,
+                req,
+                socket,
+                head,
+                cb
+              );
+            });
+            return;
+          }
+          if (!this.options.verifyClient(info)) return abortHandshake(socket, 401);
+        }
+        this.completeUpgrade(extensions, key, protocols, req, socket, head, cb);
+      }
+      /**
+       * Upgrade the connection to WebSocket.
+       *
+       * @param {Object} extensions The accepted extensions
+       * @param {String} key The value of the `Sec-WebSocket-Key` header
+       * @param {Set} protocols The subprotocols
+       * @param {http.IncomingMessage} req The request object
+       * @param {Duplex} socket The network socket between the server and client
+       * @param {Buffer} head The first packet of the upgraded stream
+       * @param {Function} cb Callback
+       * @throws {Error} If called more than once with the same socket
+       * @private
+       */
+      completeUpgrade(extensions, key, protocols, req, socket, head, cb) {
+        if (!socket.readable || !socket.writable) return socket.destroy();
+        if (socket[kWebSocket]) {
+          throw new Error(
+            "server.handleUpgrade() was called more than once with the same socket, possibly due to a misconfiguration"
+          );
+        }
+        if (this._state > RUNNING) return abortHandshake(socket, 503);
+        const digest = createHash2("sha1").update(key + GUID).digest("base64");
+        const headers = [
+          "HTTP/1.1 101 Switching Protocols",
+          "Upgrade: websocket",
+          "Connection: Upgrade",
+          `Sec-WebSocket-Accept: ${digest}`
+        ];
+        const ws = new this.options.WebSocket(null, void 0, this.options);
+        if (protocols.size) {
+          const protocol = this.options.handleProtocols ? this.options.handleProtocols(protocols, req) : protocols.values().next().value;
+          if (protocol) {
+            headers.push(`Sec-WebSocket-Protocol: ${protocol}`);
+            ws._protocol = protocol;
+          }
+        }
+        if (extensions[PerMessageDeflate2.extensionName]) {
+          const params = extensions[PerMessageDeflate2.extensionName].params;
+          const value = extension2.format({
+            [PerMessageDeflate2.extensionName]: [params]
+          });
+          headers.push(`Sec-WebSocket-Extensions: ${value}`);
+          ws._extensions = extensions;
+        }
+        this.emit("headers", headers, req);
+        socket.write(headers.concat("\r\n").join("\r\n"));
+        socket.removeListener("error", socketOnError);
+        ws.setSocket(socket, head, {
+          allowSynchronousEvents: this.options.allowSynchronousEvents,
+          maxPayload: this.options.maxPayload,
+          skipUTF8Validation: this.options.skipUTF8Validation
+        });
+        if (this.clients) {
+          this.clients.add(ws);
+          ws.on("close", () => {
+            this.clients.delete(ws);
+            if (this._shouldEmitClose && !this.clients.size) {
+              process.nextTick(emitClose, this);
+            }
+          });
+        }
+        cb(ws, req);
+      }
+    };
+    module.exports = WebSocketServer2;
+    function addListeners(server2, map2) {
+      for (const event of Object.keys(map2)) server2.on(event, map2[event]);
+      return function removeListeners() {
+        for (const event of Object.keys(map2)) {
+          server2.removeListener(event, map2[event]);
+        }
+      };
+    }
+    function emitClose(server2) {
+      server2._state = CLOSED;
+      server2.emit("close");
+    }
+    function socketOnError() {
+      this.destroy();
+    }
+    function abortHandshake(socket, code, message, headers) {
+      message = message || http.STATUS_CODES[code];
+      headers = {
+        Connection: "close",
+        "Content-Type": "text/html",
+        "Content-Length": Buffer.byteLength(message),
+        ...headers
+      };
+      socket.once("finish", socket.destroy);
+      socket.end(
+        `HTTP/1.1 ${code} ${http.STATUS_CODES[code]}\r
+` + Object.keys(headers).map((h) => `${h}: ${headers[h]}`).join("\r\n") + "\r\n\r\n" + message
+      );
+    }
+    function abortHandshakeOrEmitwsClientError(server2, req, socket, code, message, headers) {
+      if (server2.listenerCount("wsClientError")) {
+        const err = new Error(message);
+        Error.captureStackTrace(err, abortHandshakeOrEmitwsClientError);
+        server2.emit("wsClientError", err, socket, req);
+      } else {
+        abortHandshake(socket, code, message, headers);
+      }
+    }
   }
 });
 
@@ -23985,8 +27612,8 @@ function hex2(_params) {
   return _stringFormat(ZodCustomStringFormat, "hex", regexes_exports.hex, _params);
 }
 function hash(alg, params) {
-  const enc = params?.enc ?? "hex";
-  const format = `${alg}_${enc}`;
+  const enc4 = params?.enc ?? "hex";
+  const format = `${alg}_${enc4}`;
   const regex = regexes_exports[format];
   if (!regex)
     throw new Error(`Unrecognized hash format: ${format}`);
@@ -30862,15 +34489,1681 @@ var StdioServerTransport = class {
 };
 
 // src/client.ts
-import { dirname, join } from "path";
+import { dirname, join as join2 } from "path";
 import { fileURLToPath } from "url";
-try {
-  const { config: config2 } = await import("dotenv");
-  const __dirname = dirname(fileURLToPath(import.meta.url));
-  config2({ path: join(__dirname, "..", ".env"), override: false, quiet: true });
-} catch {
+
+// node_modules/@fetchproxy/protocol/dist/frames.js
+var PROTOCOL_VERSION = 1;
+var KNOWN_CAPABILITIES = /* @__PURE__ */ new Set([
+  "fetch",
+  "read_cookies",
+  "read_local_storage",
+  "read_session_storage",
+  "capture_request_header"
+]);
+
+// node_modules/@fetchproxy/protocol/dist/mcp-id.js
+var ID_RE = /^([^:]+):([^:]+):([0-9a-f]{16})$/;
+function generateMcpId(serverName, version2) {
+  if (serverName.includes(":")) {
+    throw new Error(`serverName cannot contain ':': ${serverName}`);
+  }
+  if (version2.includes(":")) {
+    throw new Error(`version cannot contain ':': ${version2}`);
+  }
+  const rand = randomHex(8);
+  return `${serverName}:${version2}:${rand}`;
 }
-function readVar(key) {
+function isValidMcpId(id) {
+  return typeof id === "string" && ID_RE.test(id);
+}
+function randomHex(bytes) {
+  const arr = new Uint8Array(bytes);
+  globalThis.crypto.getRandomValues(arr);
+  return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// node_modules/@fetchproxy/protocol/dist/validate.js
+var ProtocolError = class extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ProtocolError";
+  }
+};
+var FORBIDDEN_KEYS = /* @__PURE__ */ new Set(["__proto__", "constructor", "prototype"]);
+var BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
+var SCOPE_KEY_RE = /^[A-Za-z0-9_.\-]{1,256}$/;
+var HEADER_NAME_RE = /^[A-Za-z0-9_\-]{1,128}$/;
+var HOSTNAME_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/i;
+function assertObject(x, label) {
+  if (typeof x !== "object" || x === null || Array.isArray(x)) {
+    throw new ProtocolError(`${label}: expected object, got ${typeof x}`);
+  }
+  const proto = Object.getPrototypeOf(x);
+  if (proto !== Object.prototype && proto !== null) {
+    throw new ProtocolError(`${label}: non-plain object`);
+  }
+  for (const k of Object.keys(x)) {
+    if (FORBIDDEN_KEYS.has(k))
+      throw new ProtocolError(`${label}: forbidden key ${k}`);
+  }
+}
+function assertString(x, label) {
+  if (typeof x !== "string") {
+    throw new ProtocolError(`${label}: expected string, got ${typeof x}`);
+  }
+}
+function assertBase64(x, label) {
+  assertString(x, label);
+  if (!BASE64_RE.test(x))
+    throw new ProtocolError(`${label}: invalid base64`);
+}
+function assertPositiveInt(x, label) {
+  if (typeof x !== "number" || !Number.isInteger(x) || x <= 0) {
+    throw new ProtocolError(`${label}: expected positive integer`);
+  }
+}
+function assertHttpUrl(x, label) {
+  assertString(x, label);
+  let u;
+  try {
+    u = new URL(x);
+  } catch {
+    throw new ProtocolError(`${label}: not a valid URL`);
+  }
+  if (u.protocol !== "https:" && u.protocol !== "http:") {
+    throw new ProtocolError(`${label}: must be http(s), got ${u.protocol}`);
+  }
+}
+function assertHttpsOriginOnly(x, label) {
+  assertString(x, label);
+  let u;
+  try {
+    u = new URL(x);
+  } catch {
+    throw new ProtocolError(`${label}: not a valid URL`);
+  }
+  if (u.protocol !== "https:") {
+    throw new ProtocolError(`${label}: must be https, got ${u.protocol}`);
+  }
+  if (u.pathname !== "/" && u.pathname !== "") {
+    throw new ProtocolError(`${label}: must be a bare origin (no path)`);
+  }
+  if (u.search || u.hash) {
+    throw new ProtocolError(`${label}: must be a bare origin (no query or fragment)`);
+  }
+}
+function assertScopeKeyArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new ProtocolError(`${label}: expected array, got ${typeof value}`);
+  }
+  const seen = /* @__PURE__ */ new Set();
+  for (const k of value) {
+    if (typeof k !== "string") {
+      throw new ProtocolError(`${label}: entry must be string, got ${typeof k}`);
+    }
+    if (!SCOPE_KEY_RE.test(k)) {
+      throw new ProtocolError(`${label}: invalid key ${JSON.stringify(k)}`);
+    }
+    if (seen.has(k)) {
+      throw new ProtocolError(`${label}: duplicate ${JSON.stringify(k)}`);
+    }
+    seen.add(k);
+  }
+}
+function assertCaptureHeadersArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new ProtocolError(`${label}: expected array, got ${typeof value}`);
+  }
+  const seen = /* @__PURE__ */ new Set();
+  for (let i = 0; i < value.length; i++) {
+    const entry = value[i];
+    assertObject(entry, `${label}[${i}]`);
+    if (entry.urlPattern === void 0) {
+      throw new ProtocolError(`${label}[${i}].urlPattern: missing`);
+    }
+    if (entry.headerName === void 0) {
+      throw new ProtocolError(`${label}[${i}].headerName: missing`);
+    }
+    if (typeof entry.urlPattern !== "string") {
+      throw new ProtocolError(`${label}[${i}].urlPattern: expected string, got ${typeof entry.urlPattern}`);
+    }
+    if (typeof entry.headerName !== "string") {
+      throw new ProtocolError(`${label}[${i}].headerName: expected string, got ${typeof entry.headerName}`);
+    }
+    if (!HEADER_NAME_RE.test(entry.headerName)) {
+      throw new ProtocolError(`${label}[${i}].headerName: invalid name ${JSON.stringify(entry.headerName)}`);
+    }
+    assertCaptureUrlPattern(entry.urlPattern, `${label}[${i}].urlPattern`);
+    const key = `${entry.urlPattern}\0${entry.headerName}`;
+    if (seen.has(key)) {
+      throw new ProtocolError(`${label}: duplicate ${JSON.stringify({ urlPattern: entry.urlPattern, headerName: entry.headerName })}`);
+    }
+    seen.add(key);
+    for (const k of Object.keys(entry)) {
+      if (k !== "urlPattern" && k !== "headerName") {
+        throw new ProtocolError(`${label}[${i}]: unexpected field ${JSON.stringify(k)}`);
+      }
+    }
+  }
+}
+function assertCaptureUrlPattern(pattern, label) {
+  if (!pattern.startsWith("https://")) {
+    throw new ProtocolError(`${label}: must start with https:// (got ${JSON.stringify(pattern)})`);
+  }
+  const afterScheme = pattern.slice("https://".length);
+  const slash = afterScheme.indexOf("/");
+  const host = slash === -1 ? afterScheme : afterScheme.slice(0, slash);
+  if (host.length === 0) {
+    throw new ProtocolError(`${label}: missing host (got ${JSON.stringify(pattern)})`);
+  }
+  if (host.includes("*")) {
+    throw new ProtocolError(`${label}: wildcards not permitted in host (got ${JSON.stringify(pattern)})`);
+  }
+  if (!HOSTNAME_RE.test(host)) {
+    throw new ProtocolError(`${label}: invalid host ${JSON.stringify(host)} in ${JSON.stringify(pattern)}`);
+  }
+}
+function validateFrame(raw) {
+  assertObject(raw, "frame");
+  const t = raw.type;
+  if (t === "hello")
+    return validateHello(raw);
+  if (t === "ready")
+    return validateReady(raw);
+  if (t === "frame")
+    return validateEncrypted(raw);
+  throw new ProtocolError(`unknown frame type: ${String(t)}`);
+}
+function validateHello(raw) {
+  if (raw.protocolVersion !== PROTOCOL_VERSION) {
+    throw new ProtocolError(`hello.protocolVersion: must be ${PROTOCOL_VERSION}`);
+  }
+  const role = raw.role;
+  if (role === "server") {
+    assertString(raw.mcpId, "hello.mcpId");
+    if (!isValidMcpId(raw.mcpId))
+      throw new ProtocolError("hello.mcpId: invalid format");
+    assertString(raw.serverName, "hello.serverName");
+    assertString(raw.version, "hello.version");
+    if (!Array.isArray(raw.domains)) {
+      throw new ProtocolError("hello.domains: expected array");
+    }
+    if (raw.domains.length === 0) {
+      throw new ProtocolError("hello.domains: must be non-empty");
+    }
+    for (const d of raw.domains) {
+      if (typeof d !== "string") {
+        throw new ProtocolError(`hello.domains: entry must be string, got ${typeof d}`);
+      }
+      if (!HOSTNAME_RE.test(d)) {
+        throw new ProtocolError(`hello.domains: invalid hostname ${JSON.stringify(d)}`);
+      }
+    }
+    if (raw.capabilities !== void 0) {
+      if (!Array.isArray(raw.capabilities)) {
+        throw new ProtocolError("hello.capabilities: expected array");
+      }
+      if (raw.capabilities.length === 0) {
+        throw new ProtocolError("hello.capabilities: must be non-empty");
+      }
+      for (const c of raw.capabilities) {
+        if (typeof c !== "string") {
+          throw new ProtocolError(`hello.capabilities: entry must be string, got ${typeof c}`);
+        }
+        if (!KNOWN_CAPABILITIES.has(c)) {
+          throw new ProtocolError(`hello.capabilities: unknown capability ${JSON.stringify(c)}`);
+        }
+      }
+    }
+    if (raw.cookieKeys !== void 0) {
+      assertScopeKeyArray(raw.cookieKeys, "hello.cookieKeys");
+    }
+    if (raw.localStorageKeys !== void 0) {
+      assertScopeKeyArray(raw.localStorageKeys, "hello.localStorageKeys");
+    }
+    if (raw.sessionStorageKeys !== void 0) {
+      assertScopeKeyArray(raw.sessionStorageKeys, "hello.sessionStorageKeys");
+    }
+    if (raw.captureHeaders !== void 0) {
+      assertCaptureHeadersArray(raw.captureHeaders, "hello.captureHeaders");
+    }
+    assertBase64(raw.identityX25519Pub, "hello.identityX25519Pub");
+    assertBase64(raw.identityEd25519Pub, "hello.identityEd25519Pub");
+    assertBase64(raw.sessionNonce, "hello.sessionNonce");
+    assertBase64(raw.sessionSig, "hello.sessionSig");
+    return raw;
+  }
+  if (role === "extension") {
+    assertString(raw.platform, "hello.platform");
+    if (!["chrome", "safari", "firefox"].includes(raw.platform)) {
+      throw new ProtocolError(`hello.platform: invalid (${raw.platform})`);
+    }
+    assertString(raw.extensionId, "hello.extensionId");
+    assertString(raw.version, "hello.version");
+    return raw;
+  }
+  throw new ProtocolError(`hello.role: must be 'server' or 'extension', got ${String(role)}`);
+}
+function validateReady(raw) {
+  assertString(raw.mcpId, "ready.mcpId");
+  if (!isValidMcpId(raw.mcpId))
+    throw new ProtocolError("ready.mcpId: invalid format");
+  assertBase64(raw.extensionSessionPub, "ready.extensionSessionPub");
+  return raw;
+}
+function validateEncrypted(raw) {
+  assertString(raw.mcpId, "frame.mcpId");
+  if (!isValidMcpId(raw.mcpId))
+    throw new ProtocolError("frame.mcpId: invalid format");
+  assertPositiveInt(raw.seq, "frame.seq");
+  assertBase64(raw.iv, "frame.iv");
+  assertBase64(raw.ciphertext, "frame.ciphertext");
+  return raw;
+}
+function validateInnerFrame(raw) {
+  assertObject(raw, "inner");
+  const t = raw.type;
+  if (t === "ping")
+    return { type: "ping" };
+  if (t === "pong")
+    return { type: "pong" };
+  if (t === "request")
+    return validateInnerRequest(raw);
+  if (t === "response")
+    return validateInnerResponse(raw);
+  throw new ProtocolError(`unknown inner frame type: ${String(t)}`);
+}
+function validateInnerRequest(raw) {
+  assertPositiveInt(raw.id, "inner.id");
+  if (raw.op === "fetch") {
+    assertObject(raw.init, "inner.init");
+    assertHttpUrl(raw.init.url, "inner.init.url");
+    assertString(raw.init.method, "inner.init.method");
+    assertHttpUrl(raw.init.tabUrl, "inner.init.tabUrl");
+    if (raw.init.headers !== void 0) {
+      assertObject(raw.init.headers, "inner.init.headers");
+      for (const [k, v] of Object.entries(raw.init.headers)) {
+        if (typeof v !== "string") {
+          throw new ProtocolError(`inner.init.headers[${k}]: must be string`);
+        }
+      }
+    }
+    if (raw.init.body !== void 0) {
+      assertString(raw.init.body, "inner.init.body");
+    }
+    return raw;
+  }
+  if (raw.op === "read_cookies") {
+    assertObject(raw.init, "inner.init");
+    const hasTabUrl = raw.init.tabUrl !== void 0;
+    const hasOrigin = raw.init.origin !== void 0;
+    const hasKeys = raw.init.keys !== void 0;
+    if (hasTabUrl && (hasOrigin || hasKeys)) {
+      throw new ProtocolError("inner.init: read_cookies cannot mix legacy tabUrl with origin/keys");
+    }
+    if (hasTabUrl) {
+      assertHttpUrl(raw.init.tabUrl, "inner.init.tabUrl");
+      for (const k of Object.keys(raw.init)) {
+        if (k !== "tabUrl") {
+          throw new ProtocolError(`inner.init: unexpected field ${JSON.stringify(k)} on read_cookies`);
+        }
+      }
+      return raw;
+    }
+    if (!hasOrigin || !hasKeys) {
+      throw new ProtocolError("inner.init: read_cookies must carry { origin, keys } (or legacy { tabUrl })");
+    }
+    assertHttpsOriginOnly(raw.init.origin, "inner.init.origin");
+    assertNonEmptyKeyArray(raw.init.keys, "inner.init.keys");
+    for (const k of Object.keys(raw.init)) {
+      if (k !== "origin" && k !== "keys") {
+        throw new ProtocolError(`inner.init: unexpected field ${JSON.stringify(k)} on read_cookies`);
+      }
+    }
+    return raw;
+  }
+  if (raw.op === "read_local_storage" || raw.op === "read_session_storage") {
+    assertObject(raw.init, "inner.init");
+    if (raw.init.origin === void 0) {
+      throw new ProtocolError("inner.init.origin: missing");
+    }
+    if (raw.init.keys === void 0) {
+      throw new ProtocolError("inner.init.keys: missing");
+    }
+    assertHttpsOriginOnly(raw.init.origin, "inner.init.origin");
+    assertNonEmptyKeyArray(raw.init.keys, "inner.init.keys");
+    for (const k of Object.keys(raw.init)) {
+      if (k !== "origin" && k !== "keys") {
+        throw new ProtocolError(`inner.init: unexpected field ${JSON.stringify(k)} on ${raw.op}`);
+      }
+    }
+    return raw;
+  }
+  if (raw.op === "capture_request_header") {
+    assertObject(raw.init, "inner.init");
+    if (raw.init.urlPattern === void 0) {
+      throw new ProtocolError("inner.init.urlPattern: missing");
+    }
+    if (raw.init.headerName === void 0) {
+      throw new ProtocolError("inner.init.headerName: missing");
+    }
+    assertString(raw.init.urlPattern, "inner.init.urlPattern");
+    assertString(raw.init.headerName, "inner.init.headerName");
+    if (raw.init.timeoutMs !== void 0) {
+      assertPositiveInt(raw.init.timeoutMs, "inner.init.timeoutMs");
+    }
+    for (const k of Object.keys(raw.init)) {
+      if (k !== "urlPattern" && k !== "headerName" && k !== "timeoutMs") {
+        throw new ProtocolError(`inner.init: unexpected field ${JSON.stringify(k)} on capture_request_header`);
+      }
+    }
+    return raw;
+  }
+  throw new ProtocolError(`inner.op: must be one of "fetch", "read_cookies", "read_local_storage", "read_session_storage", "capture_request_header"; got ${JSON.stringify(raw.op)}`);
+}
+function assertNonEmptyKeyArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new ProtocolError(`${label}: expected array, got ${typeof value}`);
+  }
+  if (value.length === 0) {
+    throw new ProtocolError(`${label}: must be non-empty`);
+  }
+  const seen = /* @__PURE__ */ new Set();
+  for (const k of value) {
+    if (typeof k !== "string") {
+      throw new ProtocolError(`${label}: entry must be string, got ${typeof k}`);
+    }
+    if (k.length === 0) {
+      throw new ProtocolError(`${label}: empty key not allowed`);
+    }
+    if (seen.has(k)) {
+      throw new ProtocolError(`${label}: duplicate ${JSON.stringify(k)}`);
+    }
+    seen.add(k);
+  }
+}
+function assertStringMap(value, label) {
+  assertObject(value, label);
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v !== "string") {
+      throw new ProtocolError(`${label}[${k}]: must be string, got ${typeof v}`);
+    }
+  }
+}
+function validateInnerResponse(raw) {
+  assertPositiveInt(raw.id, "inner.id");
+  if (raw.ok === true) {
+    const op = raw.op === void 0 ? "fetch" : raw.op;
+    if (op === "fetch") {
+      assertPositiveInt(raw.status, "inner.status");
+      assertString(raw.url, "inner.url");
+      assertString(raw.body, "inner.body");
+      return raw;
+    }
+    if (op === "read_cookies") {
+      const hasCookies = raw.cookies !== void 0;
+      const hasValues = raw.values !== void 0;
+      if (hasCookies && hasValues) {
+        throw new ProtocolError("inner.response: read_cookies cannot carry both cookies and values");
+      }
+      if (!hasCookies && !hasValues) {
+        throw new ProtocolError("inner.response: read_cookies missing cookies or values");
+      }
+      if (hasCookies) {
+        assertString(raw.cookies, "inner.cookies");
+      } else {
+        assertStringMap(raw.values, "inner.values");
+      }
+      return raw;
+    }
+    if (op === "read_local_storage" || op === "read_session_storage") {
+      if (raw.values === void 0) {
+        throw new ProtocolError(`inner.values: missing on ${String(op)} response`);
+      }
+      assertStringMap(raw.values, "inner.values");
+      return raw;
+    }
+    if (op === "capture_request_header") {
+      if (raw.value === void 0) {
+        throw new ProtocolError("inner.value: missing on capture_request_header response");
+      }
+      assertString(raw.value, "inner.value");
+      return raw;
+    }
+    throw new ProtocolError(`inner.op: unknown success-response op ${JSON.stringify(raw.op)}`);
+  }
+  if (raw.ok === false) {
+    assertString(raw.error, "inner.error");
+    if (raw.op !== void 0) {
+      if (typeof raw.op !== "string" || !KNOWN_CAPABILITIES.has(raw.op)) {
+        throw new ProtocolError(`inner.op: unknown response op ${JSON.stringify(raw.op)}`);
+      }
+    }
+    return raw;
+  }
+  throw new ProtocolError(`inner.ok: must be boolean, got ${typeof raw.ok}`);
+}
+
+// node_modules/@fetchproxy/protocol/dist/crypto.js
+var subtle = globalThis.crypto.subtle;
+async function exportRaw(key, format) {
+  const buf = await subtle.exportKey(format, key);
+  return new Uint8Array(buf);
+}
+async function generateX25519() {
+  const kp = await subtle.generateKey({ name: "X25519" }, true, [
+    "deriveBits"
+  ]);
+  const priv = await exportRaw(kp.privateKey, "pkcs8");
+  const pub = await exportRaw(kp.publicKey, "raw");
+  return { privateKey: priv.slice(-32), publicKey: pub };
+}
+async function generateEd25519() {
+  const kp = await subtle.generateKey({ name: "Ed25519" }, true, [
+    "sign",
+    "verify"
+  ]);
+  const priv = await exportRaw(kp.privateKey, "pkcs8");
+  const pub = await exportRaw(kp.publicKey, "raw");
+  return { privateKey: priv.slice(-32), publicKey: pub };
+}
+async function importX25519Priv(raw) {
+  const prefix = new Uint8Array([
+    48,
+    46,
+    2,
+    1,
+    0,
+    48,
+    5,
+    6,
+    3,
+    43,
+    101,
+    110,
+    4,
+    34,
+    4,
+    32
+  ]);
+  const pkcs8 = new Uint8Array(prefix.length + raw.length);
+  pkcs8.set(prefix, 0);
+  pkcs8.set(raw, prefix.length);
+  return subtle.importKey("pkcs8", pkcs8, { name: "X25519" }, false, [
+    "deriveBits"
+  ]);
+}
+async function importX25519Pub(raw) {
+  return subtle.importKey("raw", raw, { name: "X25519" }, false, []);
+}
+async function importEd25519Priv(raw) {
+  const prefix = new Uint8Array([
+    48,
+    46,
+    2,
+    1,
+    0,
+    48,
+    5,
+    6,
+    3,
+    43,
+    101,
+    112,
+    4,
+    34,
+    4,
+    32
+  ]);
+  const pkcs8 = new Uint8Array(prefix.length + raw.length);
+  pkcs8.set(prefix, 0);
+  pkcs8.set(raw, prefix.length);
+  return subtle.importKey("pkcs8", pkcs8, { name: "Ed25519" }, false, ["sign"]);
+}
+async function ecdhX25519(privRaw, pubRaw) {
+  const priv = await importX25519Priv(privRaw);
+  const pub = await importX25519Pub(pubRaw);
+  const bits = await subtle.deriveBits({ name: "X25519", public: pub }, priv, 256);
+  return new Uint8Array(bits);
+}
+async function ed25519Sign(privRaw, msg) {
+  const priv = await importEd25519Priv(privRaw);
+  const sig = await subtle.sign({ name: "Ed25519" }, priv, msg);
+  return new Uint8Array(sig);
+}
+async function hkdfSha256(ikm, salt, info, lenBytes) {
+  const baseKey = await subtle.importKey("raw", ikm, { name: "HKDF" }, false, [
+    "deriveBits"
+  ]);
+  const bits = await subtle.deriveBits({
+    name: "HKDF",
+    hash: "SHA-256",
+    salt,
+    info
+  }, baseKey, lenBytes * 8);
+  return new Uint8Array(bits);
+}
+async function aesGcmSeal(key, iv, plaintext) {
+  const k = await subtle.importKey("raw", key, { name: "AES-GCM" }, false, [
+    "encrypt"
+  ]);
+  const ct = await subtle.encrypt({ name: "AES-GCM", iv }, k, plaintext);
+  return new Uint8Array(ct);
+}
+async function aesGcmOpen(key, iv, ciphertext) {
+  const k = await subtle.importKey("raw", key, { name: "AES-GCM" }, false, [
+    "decrypt"
+  ]);
+  const pt = await subtle.decrypt({ name: "AES-GCM", iv }, k, ciphertext);
+  return new Uint8Array(pt);
+}
+
+// node_modules/@fetchproxy/protocol/dist/encoding.js
+function toB64(bytes) {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++)
+    s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+function fromB64(s) {
+  const bin = atob(s);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++)
+    out[i] = bin.charCodeAt(i);
+  return out;
+}
+function concatBytes(a, b) {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
+// node_modules/@fetchproxy/protocol/dist/seal.js
+var enc = new TextEncoder();
+var dec = new TextDecoder();
+function randomIv() {
+  const iv = new Uint8Array(12);
+  globalThis.crypto.getRandomValues(iv);
+  return iv;
+}
+async function sealInnerFrame(sessionKey, mcpId, seq, inner) {
+  const iv = randomIv();
+  const pt = enc.encode(JSON.stringify(inner));
+  const ct = await aesGcmSeal(sessionKey, iv, pt);
+  return {
+    type: "frame",
+    mcpId,
+    seq,
+    iv: toB64(iv),
+    ciphertext: toB64(ct)
+  };
+}
+async function openEncryptedFrame(sessionKey, frame) {
+  const iv = fromB64(frame.iv);
+  const ct = fromB64(frame.ciphertext);
+  const pt = await aesGcmOpen(sessionKey, iv, ct);
+  const parsed = JSON.parse(dec.decode(pt));
+  return validateInnerFrame(parsed);
+}
+
+// node_modules/@fetchproxy/server/dist/election.js
+import { createServer, Server as HttpServer } from "node:http";
+async function electRole(opts) {
+  const server2 = createServer();
+  return new Promise((resolve2, reject) => {
+    const onError = (e) => {
+      server2.removeListener("listening", onListening);
+      if (e.code === "EADDRINUSE") {
+        try {
+          server2.close();
+        } catch {
+        }
+        resolve2({ role: "peer" });
+      } else {
+        reject(e);
+      }
+    };
+    const onListening = () => {
+      server2.removeListener("error", onError);
+      resolve2({ role: "host", server: server2 });
+    };
+    server2.once("error", onError);
+    server2.once("listening", onListening);
+    server2.listen(opts.port, opts.host);
+  });
+}
+
+// node_modules/ws/wrapper.mjs
+var import_stream = __toESM(require_stream(), 1);
+var import_extension = __toESM(require_extension(), 1);
+var import_permessage_deflate = __toESM(require_permessage_deflate(), 1);
+var import_receiver = __toESM(require_receiver(), 1);
+var import_sender = __toESM(require_sender(), 1);
+var import_subprotocol = __toESM(require_subprotocol(), 1);
+var import_websocket = __toESM(require_websocket(), 1);
+var import_websocket_server = __toESM(require_websocket_server(), 1);
+
+// node_modules/@fetchproxy/server/dist/build-server-hello.js
+async function buildServerHello(opts) {
+  const sessionNonce = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(sessionNonce);
+  const sig = await ed25519Sign(opts.identity.ed25519Priv, concatBytes(new TextEncoder().encode(opts.mcpId), sessionNonce));
+  const hello = {
+    type: "hello",
+    protocolVersion: PROTOCOL_VERSION,
+    role: "server",
+    mcpId: opts.mcpId,
+    serverName: opts.serverName,
+    version: opts.version,
+    domains: [...opts.domains],
+    capabilities: [...opts.capabilities ?? ["fetch"]],
+    identityX25519Pub: toB64(opts.identity.x25519Pub),
+    identityEd25519Pub: toB64(opts.identity.ed25519Pub),
+    sessionNonce: toB64(sessionNonce),
+    sessionSig: toB64(sig)
+  };
+  if (opts.cookieKeys && opts.cookieKeys.length > 0) {
+    hello.cookieKeys = [...opts.cookieKeys];
+  }
+  if (opts.localStorageKeys && opts.localStorageKeys.length > 0) {
+    hello.localStorageKeys = [...opts.localStorageKeys];
+  }
+  if (opts.sessionStorageKeys && opts.sessionStorageKeys.length > 0) {
+    hello.sessionStorageKeys = [...opts.sessionStorageKeys];
+  }
+  if (opts.captureHeaders && opts.captureHeaders.length > 0) {
+    hello.captureHeaders = opts.captureHeaders.map((d) => ({
+      urlPattern: d.urlPattern,
+      headerName: d.headerName
+    }));
+  }
+  return hello;
+}
+
+// node_modules/@fetchproxy/server/dist/session.js
+var SessionState = class {
+  sessionKey;
+  outboundSeq = 0;
+  lastInboundSeq = 0;
+  constructor(sessionKey) {
+    this.sessionKey = sessionKey;
+  }
+  nextOutboundSeq() {
+    this.outboundSeq += 1;
+    return this.outboundSeq;
+  }
+  acceptInboundSeq(seq) {
+    if (seq <= this.lastInboundSeq)
+      return false;
+    this.lastInboundSeq = seq;
+    return true;
+  }
+};
+
+// node_modules/@fetchproxy/server/dist/host.js
+var PUBLIC_ORIGIN_RE = /^https?:\/\/(?!(127\.0\.0\.1|localhost)(:|$))/i;
+var enc2 = new TextEncoder();
+async function startHost(opts) {
+  const wss = new import_websocket_server.default({
+    server: opts.httpServer,
+    verifyClient: (info, cb) => {
+      const origin = info.req.headers.origin;
+      if (origin && PUBLIC_ORIGIN_RE.test(origin)) {
+        cb(false, 403, "origin not allowed");
+        return;
+      }
+      cb(true);
+    }
+  });
+  const ownHello = await buildServerHello({
+    identity: opts.ownIdentity,
+    mcpId: opts.ownMcpId,
+    serverName: opts.ownServerName,
+    version: opts.ownVersion,
+    domains: opts.ownDomains,
+    capabilities: opts.ownCapabilities,
+    cookieKeys: opts.ownCookieKeys,
+    localStorageKeys: opts.ownLocalStorageKeys,
+    sessionStorageKeys: opts.ownSessionStorageKeys,
+    captureHeaders: opts.ownCaptureHeaders
+  });
+  const ownSessionNonce = fromB64(ownHello.sessionNonce);
+  let extensionWs = null;
+  const peers = /* @__PURE__ */ new Map();
+  const ownInnerListeners = [];
+  let ownSession = null;
+  let resolveOwnSession;
+  let rejectOwnSession;
+  const ownSessionReady = new Promise((resolve2, reject) => {
+    resolveOwnSession = resolve2;
+    rejectOwnSession = reject;
+  });
+  ownSessionReady.catch(() => {
+  });
+  wss.on("connection", (ws) => {
+    let identified = null;
+    let peerMcpId = null;
+    ws.on("message", async (data) => {
+      try {
+        let frame;
+        try {
+          const raw = JSON.parse(data.toString());
+          frame = validateFrame(raw);
+        } catch {
+          ws.close(1002, "protocol error");
+          return;
+        }
+        if (frame.type === "hello" && frame.role === "extension") {
+          if (extensionWs) {
+            ws.close(1008, "extension already connected");
+            return;
+          }
+          identified = "extension";
+          extensionWs = ws;
+          ws.send(JSON.stringify(ownHello));
+          for (const slot of peers.values()) {
+            ws.send(JSON.stringify(slot.helloFrame));
+          }
+          return;
+        }
+        if (frame.type === "hello" && frame.role === "server") {
+          identified = "peer";
+          peerMcpId = frame.mcpId;
+          peers.set(frame.mcpId, { ws, helloFrame: frame });
+          if (extensionWs)
+            extensionWs.send(JSON.stringify(frame));
+          return;
+        }
+        if (frame.type === "ready") {
+          if (frame.mcpId === opts.ownMcpId) {
+            const extPub = fromB64(frame.extensionSessionPub);
+            const shared = await ecdhX25519(opts.ownIdentity.x25519Priv, extPub);
+            const key = await hkdfSha256(shared, ownSessionNonce, enc2.encode("fetchproxy/0.1.0/session"), 32);
+            if (!ownSession) {
+              ownSession = new SessionState(key);
+              resolveOwnSession(ownSession);
+            }
+          } else {
+            const slot = peers.get(frame.mcpId);
+            if (slot)
+              slot.ws.send(JSON.stringify(frame));
+          }
+          return;
+        }
+        if (frame.type === "frame") {
+          if (identified === "extension") {
+            if (frame.mcpId === opts.ownMcpId) {
+              if (!ownSession)
+                return;
+              if (!ownSession.acceptInboundSeq(frame.seq))
+                return;
+              const inner = await openEncryptedFrame(ownSession.sessionKey, frame);
+              ownInnerListeners.forEach((cb) => cb(inner));
+            } else {
+              const slot = peers.get(frame.mcpId);
+              if (slot)
+                slot.ws.send(JSON.stringify(frame));
+            }
+          } else if (identified === "peer") {
+            if (extensionWs)
+              extensionWs.send(JSON.stringify(frame));
+          }
+        }
+      } catch (e) {
+        console.error("[fetchproxy] host: message handler error:", e);
+        try {
+          ws.close(1011, "internal error");
+        } catch {
+        }
+      }
+    });
+    ws.on("close", () => {
+      if (identified === "extension" && extensionWs === ws) {
+        extensionWs = null;
+        if (!ownSession) {
+          rejectOwnSession(new Error("extension disconnected before ready"));
+        }
+      }
+      if (identified === "peer" && peerMcpId)
+        peers.delete(peerMcpId);
+    });
+  });
+  return {
+    close: () => new Promise((resolve2) => {
+      for (const client2 of wss.clients) {
+        try {
+          client2.terminate();
+        } catch {
+        }
+      }
+      wss.close(() => resolve2());
+    }),
+    sendOwnInner: async (inner) => {
+      const session = await ownSessionReady;
+      if (!extensionWs)
+        throw new Error("host: no extension connected");
+      const sealed = await sealInnerFrame(session.sessionKey, opts.ownMcpId, session.nextOutboundSeq(), inner);
+      extensionWs.send(JSON.stringify(sealed));
+    },
+    onOwnInner: (cb) => {
+      ownInnerListeners.push(cb);
+    }
+  };
+}
+
+// node_modules/@fetchproxy/server/dist/peer.js
+var enc3 = new TextEncoder();
+async function startPeer(opts) {
+  const ws = new import_websocket.default(`ws://${opts.host}:${opts.port}`);
+  await new Promise((resolve2, reject) => {
+    ws.once("open", () => resolve2());
+    ws.once("error", reject);
+  });
+  const hello = await buildServerHello({
+    identity: opts.identity,
+    mcpId: opts.mcpId,
+    serverName: opts.serverName,
+    version: opts.version,
+    domains: opts.domains,
+    capabilities: opts.capabilities,
+    cookieKeys: opts.cookieKeys,
+    localStorageKeys: opts.localStorageKeys,
+    sessionStorageKeys: opts.sessionStorageKeys,
+    captureHeaders: opts.captureHeaders
+  });
+  const sessionNonce = fromB64(hello.sessionNonce);
+  ws.send(JSON.stringify(hello));
+  const innerListeners = [];
+  let session = null;
+  const sessionPromise = new Promise((resolve2, reject) => {
+    const onMessage = async (data) => {
+      try {
+        const raw = JSON.parse(data.toString());
+        const frame = validateFrame(raw);
+        if (frame.type === "ready" && frame.mcpId === opts.mcpId) {
+          const extPub = fromB64(frame.extensionSessionPub);
+          const shared = await ecdhX25519(opts.identity.x25519Priv, extPub);
+          const sessionKey = await hkdfSha256(shared, sessionNonce, enc3.encode("fetchproxy/0.1.0/session"), 32);
+          session = new SessionState(sessionKey);
+          resolve2(session);
+          return;
+        }
+        if (frame.type === "frame" && frame.mcpId === opts.mcpId) {
+          if (!session)
+            return;
+          if (!session.acceptInboundSeq(frame.seq))
+            return;
+          const inner = await openEncryptedFrame(session.sessionKey, frame);
+          innerListeners.forEach((cb) => cb(inner));
+        }
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    };
+    ws.on("message", onMessage);
+    ws.once("close", () => {
+      reject(new Error("peer WS closed before ready"));
+    });
+  });
+  sessionPromise.catch(() => {
+  });
+  const handle = {
+    ws,
+    session: sessionPromise,
+    sendInner: async (inner) => {
+      const s = await sessionPromise;
+      const sealed = await sealInnerFrame(s.sessionKey, opts.mcpId, s.nextOutboundSeq(), inner);
+      ws.send(JSON.stringify(sealed));
+    },
+    onInner: (cb) => {
+      innerListeners.push(cb);
+    },
+    close: () => ws.close()
+  };
+  return handle;
+}
+
+// node_modules/@fetchproxy/server/dist/identity.js
+import { readFile, writeFile, mkdir, chmod } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+var SAFE_PLAIN = /^[A-Za-z0-9._-]+$/;
+var SAFE_SCOPED = /^@[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+function defaultIdentityDir() {
+  return join(homedir(), ".fetchproxy", "identity");
+}
+async function loadOrCreateIdentity(serverName, dir = defaultIdentityDir()) {
+  if (!serverName || serverName === ".." || serverName.includes("..") || !SAFE_PLAIN.test(serverName) && !SAFE_SCOPED.test(serverName)) {
+    throw new Error(`unsafe serverName for identity file: ${JSON.stringify(serverName)}`);
+  }
+  const safeFile = serverName.replace(/\//g, "_");
+  const path = join(dir, `${safeFile}.json`);
+  await mkdir(dir, { recursive: true, mode: 448 });
+  try {
+    const raw = await readFile(path, "utf8");
+    const j2 = JSON.parse(raw);
+    return {
+      x25519Priv: fromB64(j2.x25519Priv),
+      x25519Pub: fromB64(j2.x25519Pub),
+      ed25519Priv: fromB64(j2.ed25519Priv),
+      ed25519Pub: fromB64(j2.ed25519Pub),
+      createdAt: j2.createdAt
+    };
+  } catch (e) {
+    if (e.code !== "ENOENT")
+      throw e;
+  }
+  const x = await generateX25519();
+  const ed = await generateEd25519();
+  const id = {
+    x25519Priv: x.privateKey,
+    x25519Pub: x.publicKey,
+    ed25519Priv: ed.privateKey,
+    ed25519Pub: ed.publicKey,
+    createdAt: Date.now()
+  };
+  const j = {
+    x25519Priv: toB64(id.x25519Priv),
+    x25519Pub: toB64(id.x25519Pub),
+    ed25519Priv: toB64(id.ed25519Priv),
+    ed25519Pub: toB64(id.ed25519Pub),
+    createdAt: id.createdAt
+  };
+  await writeFile(path, JSON.stringify(j, null, 2), { mode: 384 });
+  await chmod(path, 384);
+  return id;
+}
+
+// node_modules/@fetchproxy/server/dist/ws-server.js
+var FetchproxyProtocolError = class extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "FetchproxyProtocolError";
+  }
+};
+var FetchproxyHttpError = class extends Error {
+  response;
+  constructor(response, message) {
+    super(message ?? `HTTP ${response.status} on ${response.url}`);
+    this.response = response;
+    this.name = "FetchproxyHttpError";
+  }
+};
+var SUBDOMAIN_LABEL_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
+function assertSubdomainLabel(label) {
+  if (!SUBDOMAIN_LABEL_RE.test(label)) {
+    throw new Error(`FetchproxyServer: subdomain must be a DNS label like "www" or "api" (or dot-separated like "auth.api"), got ${JSON.stringify(label)}`);
+  }
+}
+function assertUrlInDomains(field, url2, domains) {
+  let parsed;
+  try {
+    parsed = new URL(url2);
+  } catch {
+    throw new Error(`FetchproxyServer: ${field} is not a valid URL: ${JSON.stringify(url2)}`);
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error(`FetchproxyServer: ${field} must be http(s), got ${parsed.protocol} (${url2})`);
+  }
+  const host = parsed.hostname.toLowerCase();
+  for (const d of domains) {
+    const expected = d.toLowerCase();
+    if (host === expected || host.endsWith("." + expected))
+      return;
+  }
+  const declared = domains.map((d) => JSON.stringify(d)).join(", ");
+  throw new Error(`FetchproxyServer: ${field} host "${host}" is outside declared domains [${declared}] \u2014 must be one of them or a subdomain`);
+}
+var DEFAULT_JSON_OK_STATUSES = [200, 201, 202, 204];
+var FetchproxyServer = class {
+  /** Set after `listen()` succeeds. Null while not listening. */
+  role = null;
+  opts;
+  hostHandle = null;
+  peerHandle = null;
+  nextRequestId = 1;
+  pending = /* @__PURE__ */ new Map();
+  // Separate pending map for read_cookies so the response shape (cookies
+  // string vs status/body) doesn't have to share a union type with fetch.
+  // Ids are still unique across both maps because `nextRequestId` advances
+  // for every outbound inner request.
+  pendingReadCookies = /* @__PURE__ */ new Map();
+  // 0.3.0+: storage-read awaiters resolve a values map directly. We split
+  // them off from `pending` (fetch) and `pendingReadCookies` (legacy
+  // string-shape) so the response routing in `onInner` stays linear.
+  pendingStorage = /* @__PURE__ */ new Map();
+  // 0.3.0+: capture-header awaiters resolve a single string.
+  pendingCapture = /* @__PURE__ */ new Map();
+  mcpId = null;
+  identity = null;
+  constructor(opts) {
+    if (!Array.isArray(opts.domains) || opts.domains.length === 0) {
+      throw new Error("FetchproxyServer: opts.domains must be a non-empty array of hostnames");
+    }
+    let capabilities;
+    if (opts.capabilities === void 0) {
+      capabilities = ["fetch"];
+    } else {
+      if (!Array.isArray(opts.capabilities) || opts.capabilities.length === 0) {
+        throw new Error('FetchproxyServer: opts.capabilities must be a non-empty array (or omit it for the default ["fetch"])');
+      }
+      for (const c of opts.capabilities) {
+        if (!KNOWN_CAPABILITIES.has(c)) {
+          throw new Error(`FetchproxyServer: unknown capability ${JSON.stringify(c)} \u2014 known values: ["fetch", "read_cookies"]`);
+        }
+      }
+      capabilities = [...opts.capabilities];
+    }
+    this.opts = {
+      port: opts.port ?? 37149,
+      host: opts.host ?? "127.0.0.1",
+      serverName: opts.serverName,
+      version: opts.version,
+      domains: [...opts.domains],
+      capabilities,
+      cookieKeys: [...opts.cookieKeys ?? []],
+      localStorageKeys: [...opts.localStorageKeys ?? []],
+      sessionStorageKeys: [...opts.sessionStorageKeys ?? []],
+      captureHeaders: (opts.captureHeaders ?? []).map((d) => ({
+        urlPattern: d.urlPattern,
+        headerName: d.headerName
+      })),
+      identityDir: opts.identityDir
+    };
+  }
+  /**
+   * Start the WebSocket bridge. Loads the long-term identity keypair
+   * from disk (creating it on first call), elects the host-vs-peer
+   * role by attempting to bind the configured port, and stands up the
+   * matching handshake machinery. Idempotent only insofar as it leaves
+   * `role` non-null on success; calling `listen()` twice without an
+   * intervening `close()` is a programming error.
+   */
+  async listen() {
+    this.identity = await loadOrCreateIdentity(this.opts.serverName, this.opts.identityDir);
+    this.mcpId = generateMcpId(this.opts.serverName, this.opts.version);
+    const el = await electRole({ host: this.opts.host, port: this.opts.port });
+    if (el.role === "host") {
+      this.role = "host";
+      this.hostHandle = await startHost({
+        httpServer: el.server,
+        ownIdentity: this.identity,
+        ownMcpId: this.mcpId,
+        ownServerName: this.opts.serverName,
+        ownVersion: this.opts.version,
+        ownDomains: this.opts.domains,
+        ownCapabilities: this.opts.capabilities,
+        ownCookieKeys: this.opts.cookieKeys,
+        ownLocalStorageKeys: this.opts.localStorageKeys,
+        ownSessionStorageKeys: this.opts.sessionStorageKeys,
+        ownCaptureHeaders: this.opts.captureHeaders
+      });
+      this.hostHandle.onOwnInner((inner) => this.onInner(inner));
+    } else {
+      this.role = "peer";
+      this.peerHandle = await startPeer({
+        host: this.opts.host,
+        port: this.opts.port,
+        identity: this.identity,
+        mcpId: this.mcpId,
+        serverName: this.opts.serverName,
+        version: this.opts.version,
+        domains: this.opts.domains,
+        capabilities: this.opts.capabilities,
+        cookieKeys: this.opts.cookieKeys,
+        localStorageKeys: this.opts.localStorageKeys,
+        sessionStorageKeys: this.opts.sessionStorageKeys,
+        captureHeaders: this.opts.captureHeaders
+      });
+      this.peerHandle.onInner((inner) => this.onInner(inner));
+    }
+  }
+  /**
+   * Raw single-shot fetch through the bridge. Most callers should prefer
+   * the verb shortcuts (`get` / `post` / `getJson` / `postJson` / `getHtml`)
+   * — they build the URL from a path, default sensible status checks, and
+   * map non-2xx into typed errors. This entry point is here for the cases
+   * where you already have a `FetchInit` ready (or need to fully control
+   * `tabUrl` independently of the request URL).
+   *
+   * Returns a discriminated union: `{ ok: true, status, url, body }` on a
+   * successful upstream HTTP response (any 2xx/3xx/4xx/5xx — the upstream
+   * STATUS does not turn this into `ok: false`); `{ ok: false, error }`
+   * only when the bridge itself failed (no signed-in tab, extension
+   * offline, etc.).
+   */
+  async fetch(init) {
+    if (!this.hostHandle && !this.peerHandle) {
+      throw new Error("FetchproxyServer.fetch called before listen() \u2014 not listening");
+    }
+    const id = this.nextRequestId++;
+    const inner = { type: "request", id, op: "fetch", init };
+    const pending = new Promise((resolve2) => {
+      this.pending.set(id, resolve2);
+    });
+    if (this.hostHandle) {
+      await this.hostHandle.sendOwnInner(inner);
+    } else if (this.peerHandle) {
+      await this.peerHandle.sendInner(inner);
+    }
+    return pending;
+  }
+  /**
+   * Convenience wrapper around `fetch()`. Builds the URL from a path
+   * + optional subdomain + optional domain selector, throws on
+   * protocol errors, optionally asserts on the response status.
+   *
+   * Path resolution:
+   *  - Absolute URL (`https://...`) → used as-is (still guarded against
+   *    leaving the declared domain set).
+   *  - Relative path → joined with `https://${subdomain}.${baseDomain}`
+   *    (or `https://${baseDomain}` if no subdomain is given).
+   *
+   * Base-domain selection:
+   *  - Single-domain MCP (`domains: ['x.com']`): `opts.domain` is optional;
+   *    `domains[0]` is used by default.
+   *  - Multi-domain MCP: `opts.domain` is required and must equal one of
+   *    the declared domains exactly.
+   */
+  async request(method, path, opts = {}) {
+    if (opts.subdomain !== void 0)
+      assertSubdomainLabel(opts.subdomain);
+    const baseDomain = this.resolveBaseDomain(opts.domain);
+    const host = opts.subdomain ? `${opts.subdomain}.${baseDomain}` : baseDomain;
+    const url2 = path.startsWith("http://") || path.startsWith("https://") ? path : `https://${host}${path}`;
+    assertUrlInDomains("request url", url2, this.opts.domains);
+    const init = {
+      url: url2,
+      method,
+      tabUrl: `https://${host}/`,
+      headers: opts.headers,
+      body: opts.body
+    };
+    const result = await this.fetch(init);
+    if (!result.ok) {
+      throw new FetchproxyProtocolError(result.error);
+    }
+    const response = {
+      status: result.status,
+      body: result.body,
+      url: result.url
+    };
+    if (opts.expectStatus !== void 0) {
+      const expected = opts.expectStatus;
+      const matched = Array.isArray(expected) ? expected.includes(response.status) : response.status === expected;
+      if (!matched) {
+        throw new FetchproxyHttpError(response);
+      }
+    }
+    return response;
+  }
+  /** Issue a GET against `path` (resolved via `request()` rules). */
+  get(path, opts = {}) {
+    return this.request("GET", path, opts);
+  }
+  /** Issue a POST with optional string body. */
+  post(path, body, opts = {}) {
+    return this.request("POST", path, { ...opts, body });
+  }
+  /** Issue a PUT with optional string body. */
+  put(path, body, opts = {}) {
+    return this.request("PUT", path, { ...opts, body });
+  }
+  /** Issue a PATCH with optional string body. */
+  patch(path, body, opts = {}) {
+    return this.request("PATCH", path, { ...opts, body });
+  }
+  /** Issue a DELETE. No body — bridge does not support DELETE-with-body. */
+  delete(path, opts = {}) {
+    return this.request("DELETE", path, opts);
+  }
+  /**
+   * GET a path and parse the response body as JSON. Throws
+   * `FetchproxyHttpError` if the status is outside the default 2xx
+   * happy-path set (`[200, 201, 202, 204]`); pass a custom
+   * `expectStatus` to override.
+   */
+  async getJson(path, opts = {}) {
+    const response = await this.get(path, this.applyJsonDefaults(opts));
+    return JSON.parse(response.body);
+  }
+  /**
+   * POST a JSON body and parse the response body as JSON. The body is
+   * `JSON.stringify`'d; `Content-Type: application/json` is set unless
+   * the caller already provided one. Defaults `expectStatus` to the 2xx
+   * happy-path set.
+   */
+  async postJson(path, body, opts = {}) {
+    const headers = { ...opts.headers ?? {} };
+    if (body !== void 0 && !this.hasContentType(headers)) {
+      headers["Content-Type"] = "application/json";
+    }
+    const response = await this.request("POST", path, {
+      ...this.applyJsonDefaults(opts),
+      headers,
+      body: body === void 0 ? void 0 : JSON.stringify(body)
+    });
+    return JSON.parse(response.body);
+  }
+  /**
+   * GET a path and return the response body as a string. Throws
+   * `FetchproxyHttpError` if the status is outside the default 2xx
+   * happy-path set.
+   */
+  async getHtml(path, opts = {}) {
+    const response = await this.get(path, this.applyJsonDefaults(opts));
+    return response.body;
+  }
+  /**
+   * Snapshot the user's non-HttpOnly cookies for the chosen domain.
+   *
+   * Requires `'read_cookies'` in `FetchproxyServerOpts.capabilities`.
+   * Throws a developer-facing `Error` at the call site if the MCP did
+   * not declare the capability — this is a programming mistake, not a
+   * runtime condition.
+   *
+   * The returned string is the raw `document.cookie` value (semicolon-
+   * separated `k=v` pairs). HttpOnly cookies are NOT visible to page JS
+   * and are therefore not included; the underlying threat model assumes
+   * the cookies that matter for the auth bootstrap (session tokens, csrf
+   * cookies that the page itself reads) are non-HttpOnly.
+   *
+   * Throws `FetchproxyProtocolError` if the bridge could not deliver
+   * the request (no signed-in tab, extension offline, etc.).
+   */
+  async readCookies(opts = {}) {
+    if (!this.opts.capabilities.includes("read_cookies")) {
+      throw new Error('FetchproxyServer.readCookies(): MCP did not declare "read_cookies" in capabilities \u2014 add it to FetchproxyServerOpts.capabilities to enable this verb');
+    }
+    if (!this.hostHandle && !this.peerHandle) {
+      throw new Error("FetchproxyServer.readCookies called before listen() \u2014 not listening");
+    }
+    if (opts.subdomain !== void 0)
+      assertSubdomainLabel(opts.subdomain);
+    const baseDomain = this.resolveBaseDomain(opts.domain);
+    const host = opts.subdomain ? `${opts.subdomain}.${baseDomain}` : baseDomain;
+    const id = this.nextRequestId++;
+    let inner;
+    if (opts.keys !== void 0) {
+      this.assertScopeSubset(opts.keys, this.opts.cookieKeys, "cookieKeys");
+      const initV3 = {
+        origin: `https://${host}`,
+        keys: [...opts.keys]
+      };
+      inner = { type: "request", id, op: "read_cookies", init: initV3 };
+    } else {
+      const tabUrl = `https://${host}/`;
+      inner = { type: "request", id, op: "read_cookies", init: { tabUrl } };
+    }
+    const pending = new Promise((resolve2) => {
+      this.pendingReadCookies.set(id, resolve2);
+    });
+    if (this.hostHandle) {
+      await this.hostHandle.sendOwnInner(inner);
+    } else if (this.peerHandle) {
+      await this.peerHandle.sendInner(inner);
+    }
+    const result = await pending;
+    if (!result.ok) {
+      throw new FetchproxyProtocolError(result.error);
+    }
+    return result.cookies;
+  }
+  /**
+   * 0.3.0+: read declared localStorage keys from the user's signed-in
+   * tab. Requires `'read_local_storage'` in capabilities AND each key
+   * to be in declared `localStorageKeys`. Returns a `Record<string, string>`
+   * including only keys that exist in storage.
+   */
+  async readLocalStorage(opts) {
+    return this.readStorageImpl("read_local_storage", this.opts.localStorageKeys, opts, "localStorageKeys");
+  }
+  /**
+   * 0.3.0+: read declared sessionStorage keys. Identical shape to
+   * `readLocalStorage` but against sessionStorage.
+   */
+  async readSessionStorage(opts) {
+    return this.readStorageImpl("read_session_storage", this.opts.sessionStorageKeys, opts, "sessionStorageKeys");
+  }
+  async readStorageImpl(op, declaredKeys, opts, declLabel) {
+    if (!this.opts.capabilities.includes(op)) {
+      throw new Error(`FetchproxyServer.${op === "read_local_storage" ? "readLocalStorage" : "readSessionStorage"}(): MCP did not declare ${JSON.stringify(op)} in capabilities`);
+    }
+    if (!this.hostHandle && !this.peerHandle) {
+      throw new Error(`FetchproxyServer.${op} called before listen() \u2014 not listening`);
+    }
+    if (!Array.isArray(opts.keys) || opts.keys.length === 0) {
+      throw new Error(`FetchproxyServer.${op}: opts.keys must be a non-empty array`);
+    }
+    this.assertScopeSubset(opts.keys, declaredKeys, declLabel);
+    if (opts.subdomain !== void 0)
+      assertSubdomainLabel(opts.subdomain);
+    const baseDomain = this.resolveBaseDomain(opts.domain);
+    const host = opts.subdomain ? `${opts.subdomain}.${baseDomain}` : baseDomain;
+    const id = this.nextRequestId++;
+    const inner = {
+      type: "request",
+      id,
+      op,
+      init: { origin: `https://${host}`, keys: [...opts.keys] }
+    };
+    const pending = new Promise((resolve2, reject) => {
+      this.pendingStorage.set(id, { resolve: resolve2, reject });
+    });
+    if (this.hostHandle) {
+      await this.hostHandle.sendOwnInner(inner);
+    } else if (this.peerHandle) {
+      await this.peerHandle.sendInner(inner);
+    }
+    return pending;
+  }
+  /**
+   * 0.3.0+: snapshot the next outgoing request's named header. Single-
+   * shot: the extension registers a one-time `webRequest` listener
+   * filtered on `urlPattern`, captures the named header on the first
+   * match, removes itself, and resolves with the value. Times out
+   * after `timeoutMs` (default 30s on the extension).
+   *
+   * `(urlPattern, headerName)` must exactly match a declared entry in
+   * `FetchproxyServerOpts.captureHeaders`.
+   */
+  async captureRequestHeader(opts) {
+    if (!this.opts.capabilities.includes("capture_request_header")) {
+      throw new Error('FetchproxyServer.captureRequestHeader(): MCP did not declare "capture_request_header" in capabilities');
+    }
+    if (!this.hostHandle && !this.peerHandle) {
+      throw new Error("FetchproxyServer.captureRequestHeader called before listen() \u2014 not listening");
+    }
+    const declared = this.opts.captureHeaders.find((d) => d.urlPattern === opts.urlPattern && d.headerName === opts.headerName);
+    if (!declared) {
+      throw new Error(`FetchproxyServer.captureRequestHeader: (urlPattern=${JSON.stringify(opts.urlPattern)}, headerName=${JSON.stringify(opts.headerName)}) not declared in captureHeaders`);
+    }
+    const id = this.nextRequestId++;
+    const inner = {
+      type: "request",
+      id,
+      op: "capture_request_header",
+      init: {
+        urlPattern: opts.urlPattern,
+        headerName: opts.headerName,
+        ...opts.timeoutMs !== void 0 ? { timeoutMs: opts.timeoutMs } : {}
+      }
+    };
+    const pending = new Promise((resolve2, reject) => {
+      this.pendingCapture.set(id, { resolve: resolve2, reject });
+    });
+    if (this.hostHandle) {
+      await this.hostHandle.sendOwnInner(inner);
+    } else if (this.peerHandle) {
+      await this.peerHandle.sendInner(inner);
+    }
+    return pending;
+  }
+  assertScopeSubset(requested, declared, label) {
+    const declaredSet = new Set(declared);
+    const undeclared = requested.filter((k) => !declaredSet.has(k));
+    if (undeclared.length > 0) {
+      throw new Error(`FetchproxyServer: requested key(s) [${undeclared.map((k) => JSON.stringify(k)).join(", ")}] not in declared ${label} [${declared.map((k) => JSON.stringify(k)).join(", ")}]`);
+    }
+  }
+  resolveBaseDomain(domain2) {
+    if (domain2 !== void 0) {
+      if (!this.opts.domains.includes(domain2)) {
+        const declared2 = this.opts.domains.map((d) => JSON.stringify(d)).join(", ");
+        throw new Error(`FetchproxyServer: opts.domain ${JSON.stringify(domain2)} is not in the declared domains [${declared2}]`);
+      }
+      return domain2;
+    }
+    if (this.opts.domains.length === 1) {
+      return this.opts.domains[0];
+    }
+    const declared = this.opts.domains.map((d) => JSON.stringify(d)).join(", ");
+    throw new Error(`FetchproxyServer: this MCP declared multiple domains [${declared}] \u2014 pass { domain: '<one of them>' } on every per-call request`);
+  }
+  applyJsonDefaults(opts) {
+    if (Object.prototype.hasOwnProperty.call(opts, "expectStatus"))
+      return opts;
+    return { ...opts, expectStatus: [...DEFAULT_JSON_OK_STATUSES] };
+  }
+  hasContentType(headers) {
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === "content-type")
+        return true;
+    }
+    return false;
+  }
+  onInner(inner) {
+    if (inner.type !== "response")
+      return;
+    const fetchCb = this.pending.get(inner.id);
+    if (fetchCb) {
+      this.pending.delete(inner.id);
+      if (inner.ok) {
+        if (inner.op === void 0 || inner.op === "fetch") {
+          fetchCb({ ok: true, status: inner.status, url: inner.url, body: inner.body });
+        } else {
+          fetchCb({ ok: false, error: `unexpected ${inner.op} response on fetch awaiter` });
+        }
+      } else {
+        fetchCb({ ok: false, error: inner.error });
+      }
+      return;
+    }
+    const storageCb = this.pendingStorage.get(inner.id);
+    if (storageCb) {
+      this.pendingStorage.delete(inner.id);
+      if (inner.ok) {
+        if ((inner.op === "read_local_storage" || inner.op === "read_session_storage") && inner.values) {
+          storageCb.resolve({ ...inner.values });
+        } else {
+          storageCb.reject(new FetchproxyProtocolError(`unexpected ${String(inner.op)} response on storage awaiter`));
+        }
+      } else {
+        storageCb.reject(new FetchproxyProtocolError(inner.error));
+      }
+      return;
+    }
+    const captureCb = this.pendingCapture.get(inner.id);
+    if (captureCb) {
+      this.pendingCapture.delete(inner.id);
+      if (inner.ok) {
+        if (inner.op === "capture_request_header" && typeof inner.value === "string") {
+          captureCb.resolve(inner.value);
+        } else {
+          captureCb.reject(new FetchproxyProtocolError(`unexpected ${String(inner.op)} response on capture awaiter`));
+        }
+      } else {
+        captureCb.reject(new FetchproxyProtocolError(inner.error));
+      }
+      return;
+    }
+    const cookiesCb = this.pendingReadCookies.get(inner.id);
+    if (cookiesCb) {
+      this.pendingReadCookies.delete(inner.id);
+      if (inner.ok) {
+        if (inner.op === "read_cookies") {
+          if (typeof inner.cookies === "string") {
+            cookiesCb({ ok: true, cookies: inner.cookies });
+          } else if (inner.values) {
+            const joined = Object.entries(inner.values).map(([k, v]) => `${k}=${v}`).join("; ");
+            cookiesCb({ ok: true, cookies: joined });
+          } else {
+            cookiesCb({ ok: false, error: "read_cookies response carried neither cookies nor values" });
+          }
+        } else {
+          cookiesCb({ ok: false, error: "unexpected fetch response on read_cookies awaiter" });
+        }
+      } else {
+        cookiesCb({ ok: false, error: inner.error });
+      }
+    }
+  }
+  /**
+   * Shut down the bridge. Host: terminates the WebSocket server and any
+   * still-attached extension/peer clients. Peer: closes the upstream
+   * connection to the host. Safe to call before `listen()` (no-op) or
+   * twice in a row.
+   */
+  async close() {
+    if (this.hostHandle)
+      await this.hostHandle.close();
+    if (this.peerHandle)
+      this.peerHandle.close();
+    this.hostHandle = null;
+    this.peerHandle = null;
+    this.role = null;
+  }
+};
+
+// node_modules/@fetchproxy/bootstrap/dist/index.js
+var defaultFactory = (opts) => new FetchproxyServer(opts);
+async function bootstrap(opts) {
+  const factory = opts._serverFactory ?? defaultFactory;
+  const capabilities = ["fetch"];
+  if (opts.declare.cookies.length > 0)
+    capabilities.push("read_cookies");
+  if (opts.declare.localStorage.length > 0)
+    capabilities.push("read_local_storage");
+  if (opts.declare.sessionStorage.length > 0)
+    capabilities.push("read_session_storage");
+  if (opts.declare.captureHeaders.length > 0)
+    capabilities.push("capture_request_header");
+  const server2 = factory({
+    serverName: opts.serverName,
+    version: opts.version,
+    domains: [...opts.domains],
+    capabilities,
+    cookieKeys: [...opts.declare.cookies],
+    localStorageKeys: [...opts.declare.localStorage],
+    sessionStorageKeys: [...opts.declare.sessionStorage],
+    captureHeaders: opts.declare.captureHeaders.map((d) => ({ ...d }))
+  });
+  try {
+    await server2.listen();
+    const cookies = {};
+    if (opts.declare.cookies.length > 0) {
+      const joined = await server2.readCookies({ keys: opts.declare.cookies });
+      for (const piece of joined.split("; ")) {
+        if (!piece)
+          continue;
+        const eq = piece.indexOf("=");
+        if (eq < 0)
+          continue;
+        cookies[piece.slice(0, eq)] = piece.slice(eq + 1);
+      }
+    }
+    const localStorage = opts.declare.localStorage.length > 0 ? await server2.readLocalStorage({ keys: opts.declare.localStorage }) : {};
+    const sessionStorage = opts.declare.sessionStorage.length > 0 ? await server2.readSessionStorage({ keys: opts.declare.sessionStorage }) : {};
+    const capturedHeaders = {};
+    for (const h of opts.declare.captureHeaders) {
+      capturedHeaders[h.headerName] = await server2.captureRequestHeader({
+        urlPattern: h.urlPattern,
+        headerName: h.headerName
+      });
+    }
+    return { cookies, localStorage, sessionStorage, capturedHeaders };
+  } finally {
+    try {
+      await server2.close();
+    } catch {
+    }
+  }
+}
+
+// src/auth-password.ts
+var BASE_URL = "https://ofw.ourfamilywizard.com";
+var OFW_PROTOCOL_HEADERS = {
+  "ofw-client": "WebApplication",
+  "ofw-version": "1.0.0"
+};
+async function loginWithPassword(username, password) {
+  const initResponse = await fetch(`${BASE_URL}/ofw/login.form`, {
+    headers: { ...OFW_PROTOCOL_HEADERS },
+    redirect: "manual"
+  });
+  const setCookie = initResponse.headers.get("set-cookie") ?? "";
+  const sessionCookie = setCookie.split(";")[0];
+  const response = await fetch(`${BASE_URL}/ofw/login`, {
+    method: "POST",
+    headers: {
+      ...OFW_PROTOCOL_HEADERS,
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+      ...sessionCookie ? { Cookie: sessionCookie } : {}
+    },
+    body: new URLSearchParams({
+      submit: "Sign In",
+      _eventId: "submit",
+      username,
+      password
+    }).toString()
+  });
+  if (!response.ok) {
+    throw new Error(`OFW login failed: ${response.status} ${response.statusText}`);
+  }
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    const body = await response.text();
+    throw new Error(`OFW login returned unexpected response (${contentType}): ${body.substring(0, 200)}`);
+  }
+  const data = await response.json();
+  return {
+    token: data.auth,
+    // OFW's login endpoint omits expiry. 6h is the empirical TTL and matches
+    // the historical behavior of this client (a single 401 → re-auth + replay
+    // covers the edge case where this estimate is wrong).
+    expiresAt: new Date(Date.now() + 6 * 60 * 60 * 1e3)
+  };
+}
+
+// package.json
+var package_default = {
+  name: "ofw-mcp",
+  version: "2.0.14",
+  mcpName: "io.github.chrischall/ofw-mcp",
+  description: "OurFamilyWizard MCP server for Claude \u2014 developed and maintained by AI (Claude Code)",
+  author: "Claude Code (AI) <https://www.anthropic.com/claude>",
+  repository: {
+    type: "git",
+    url: "git+https://github.com/chrischall/ofw-mcp.git"
+  },
+  type: "module",
+  bin: {
+    "ofw-mcp": "dist/index.js"
+  },
+  files: [
+    "dist",
+    ".claude-plugin",
+    "skills",
+    ".mcp.json",
+    "server.json"
+  ],
+  scripts: {
+    build: "tsc && npm run bundle",
+    bundle: "esbuild src/index.ts --bundle --platform=node --format=esm --external:dotenv --outfile=dist/bundle.js",
+    dev: "node --env-file=.env dist/index.js",
+    test: "vitest run",
+    "test:watch": "vitest"
+  },
+  dependencies: {
+    "@fetchproxy/bootstrap": "^0.3.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    dotenv: "^17.4.0",
+    zod: "^4.4.2"
+  },
+  devDependencies: {
+    "@types/node": "^25.8.0",
+    "@vitest/coverage-v8": "^4.1.6",
+    esbuild: "^0.28.0",
+    typescript: "^6.0.2",
+    vitest: "^4.1.6"
+  }
+};
+
+// src/auth.ts
+function readEnv(key) {
   const raw = process.env[key];
   if (typeof raw !== "string") return void 0;
   const trimmed = raw.trim();
@@ -30879,8 +36172,71 @@ function readVar(key) {
   if (/^\$\{[^}]*\}$/.test(trimmed)) return void 0;
   return trimmed;
 }
-var BASE_URL = "https://ofw.ourfamilywizard.com";
-var OFW_PROTOCOL_HEADERS = {
+function fetchproxyDisabled() {
+  const raw = readEnv("OFW_DISABLE_FETCHPROXY");
+  if (raw === void 0) return false;
+  return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
+}
+async function resolveAuth() {
+  const username = readEnv("OFW_USERNAME");
+  const password = readEnv("OFW_PASSWORD");
+  if (username && password) {
+    const { token, expiresAt } = await loginWithPassword(username, password);
+    return { token, expiresAt, source: "env" };
+  }
+  if (!fetchproxyDisabled()) {
+    try {
+      const session = await bootstrap({
+        serverName: package_default.name,
+        version: package_default.version,
+        // OFW serves both ofw.ourfamilywizard.com and www.ourfamilywizard.com;
+        // the API + auth token live on the apex. The extension matches on
+        // suffix, so listing the apex covers both.
+        domains: ["ourfamilywizard.com"],
+        declare: {
+          cookies: [],
+          // The web app stores the Bearer token in localStorage["auth"] and
+          // its expiry (ISO string) in localStorage["tokenExpiry"]. Mirroring
+          // both means our 401-replay logic can be slightly smarter, and the
+          // expiry surfaces correctly in diagnostics.
+          localStorage: ["auth", "tokenExpiry"],
+          sessionStorage: [],
+          captureHeaders: []
+        }
+      });
+      const token = session.localStorage["auth"];
+      const expiryRaw = session.localStorage["tokenExpiry"];
+      if (!token) {
+        throw new Error(
+          'localStorage["auth"] missing on ourfamilywizard.com. Sign into OFW in your browser (with the fetchproxy extension installed) and retry.'
+        );
+      }
+      return {
+        token,
+        expiresAt: expiryRaw ? new Date(expiryRaw) : void 0,
+        source: "fetchproxy"
+      };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new Error(
+        `OFW auth: no OFW_USERNAME/OFW_PASSWORD set, and fetchproxy fallback failed: ${msg}`
+      );
+    }
+  }
+  throw new Error(
+    "OFW auth: set OFW_USERNAME + OFW_PASSWORD, or install the fetchproxy extension and sign into ourfamilywizard.com (unset OFW_DISABLE_FETCHPROXY if it is set)."
+  );
+}
+
+// src/client.ts
+try {
+  const { config: config2 } = await import("dotenv");
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  config2({ path: join2(__dirname, "..", ".env"), override: false, quiet: true });
+} catch {
+}
+var BASE_URL2 = "https://ofw.ourfamilywizard.com";
+var OFW_PROTOCOL_HEADERS2 = {
   "ofw-client": "WebApplication",
   "ofw-version": "1.0.0"
 };
@@ -30922,12 +36278,12 @@ var OFWClient = class {
   async fetchWithRetry(method, path, body, accept, isRetry) {
     const isFormData = body instanceof FormData;
     const headers = {
-      ...OFW_PROTOCOL_HEADERS,
+      ...OFW_PROTOCOL_HEADERS2,
       Accept: accept,
       Authorization: `Bearer ${this.token}`
     };
     if (body !== void 0 && !isFormData) headers["Content-Type"] = "application/json";
-    const response = await fetch(`${BASE_URL}${path}`, {
+    const response = await fetch(`${BASE_URL2}${path}`, {
       method,
       headers,
       ...body !== void 0 ? { body: isFormData ? body : JSON.stringify(body) } : {}
@@ -30954,44 +36310,18 @@ var OFWClient = class {
     if (!this.isTokenExpiredSoon()) return;
     await this.login();
   }
+  // Auth resolution is delegated to `./auth.ts`. This client doesn't care
+  // whether the token came from a password POST or from a one-shot
+  // fetchproxy session-snapshot — it just consumes the result.
+  //
+  // If `expiresAt` is missing (the fetchproxy path on a tab whose
+  // browser didn't persist tokenExpiry), we fall back to the same 6h
+  // estimate the password path uses. The 401-replay path covers us if
+  // the estimate is wrong.
   async login() {
-    const username = readVar("OFW_USERNAME");
-    const password = readVar("OFW_PASSWORD");
-    if (!username || !password) {
-      throw new Error("OFW_USERNAME and OFW_PASSWORD must be set");
-    }
-    const initResponse = await fetch(`${BASE_URL}/ofw/login.form`, {
-      headers: { ...OFW_PROTOCOL_HEADERS },
-      redirect: "manual"
-    });
-    const setCookie = initResponse.headers.get("set-cookie") ?? "";
-    const sessionCookie = setCookie.split(";")[0];
-    const response = await fetch(`${BASE_URL}/ofw/login`, {
-      method: "POST",
-      headers: {
-        ...OFW_PROTOCOL_HEADERS,
-        Accept: "application/json",
-        "Content-Type": "application/x-www-form-urlencoded",
-        ...sessionCookie ? { Cookie: sessionCookie } : {}
-      },
-      body: new URLSearchParams({
-        submit: "Sign In",
-        _eventId: "submit",
-        username,
-        password
-      }).toString()
-    });
-    if (!response.ok) {
-      throw new Error(`OFW login failed: ${response.status} ${response.statusText}`);
-    }
-    const contentType = response.headers.get("content-type") ?? "";
-    if (!contentType.includes("application/json")) {
-      const body = await response.text();
-      throw new Error(`OFW login returned unexpected response (${contentType}): ${body.substring(0, 200)}`);
-    }
-    const data = await response.json();
-    this.token = data.auth;
-    this.tokenExpiry = new Date(Date.now() + 6 * 60 * 60 * 1e3);
+    const { token, expiresAt } = await resolveAuth();
+    this.token = token;
+    this.tokenExpiry = expiresAt ?? new Date(Date.now() + 6 * 60 * 60 * 1e3);
   }
   isTokenExpiredSoon() {
     if (!this.token || !this.tokenExpiry) return true;
@@ -31001,7 +36331,7 @@ var OFWClient = class {
 var client = new OFWClient();
 
 // src/tools/_shared.ts
-import { isAbsolute, join as join2, resolve } from "node:path";
+import { isAbsolute, join as join3, resolve } from "node:path";
 function jsonResponse(payload) {
   return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
 }
@@ -31016,7 +36346,7 @@ function mapRecipients(items) {
   }));
 }
 function expandPath(p) {
-  const expanded = p.startsWith("~/") ? join2(process.env.HOME ?? "", p.slice(2)) : p;
+  const expanded = p.startsWith("~/") ? join3(process.env.HOME ?? "", p.slice(2)) : p;
   return isAbsolute(expanded) ? expanded : resolve(expanded);
 }
 
@@ -31045,29 +36375,29 @@ import { dirname as dirname2 } from "node:path";
 
 // src/config.ts
 import { createHash } from "node:crypto";
-import { homedir } from "node:os";
-import { join as join3 } from "node:path";
-function readUsername() {
-  const raw = process.env.OFW_USERNAME;
-  if (typeof raw !== "string" || raw.trim().length === 0) {
-    throw new Error("OFW_USERNAME must be set to derive cache path");
-  }
-  return raw.trim();
+import { homedir as homedir2 } from "node:os";
+import { join as join4 } from "node:path";
+function readCacheIdentity() {
+  const explicit = process.env.OFW_CACHE_IDENTITY;
+  if (typeof explicit === "string" && explicit.trim().length > 0) return explicit.trim();
+  const username = process.env.OFW_USERNAME;
+  if (typeof username === "string" && username.trim().length > 0) return username.trim();
+  return "_default";
 }
 function getCacheDir() {
   const override = process.env.OFW_CACHE_DIR;
   if (override && override.trim().length > 0) return override.trim();
-  return join3(homedir(), ".cache", "ofw-mcp");
+  return join4(homedir2(), ".cache", "ofw-mcp");
 }
 function getCacheDbPath() {
-  const username = readUsername();
-  const hash2 = createHash("sha256").update(username).digest("hex").slice(0, 16);
-  return join3(getCacheDir(), `${hash2}.db`);
+  const identity = readCacheIdentity();
+  const hash2 = createHash("sha256").update(identity).digest("hex").slice(0, 16);
+  return join4(getCacheDir(), `${hash2}.db`);
 }
 function getAttachmentsDir() {
   const override = process.env.OFW_ATTACHMENTS_DIR;
   if (override && override.trim().length > 0) return override.trim();
-  return join3(homedir(), "Downloads", "ofw-mcp");
+  return join4(homedir2(), "Downloads", "ofw-mcp");
 }
 function getDefaultInlineAttachments() {
   const raw = process.env.OFW_INLINE_ATTACHMENTS;
@@ -31570,7 +36900,7 @@ async function syncAll(client2, opts) {
 
 // src/tools/messages.ts
 import { mkdirSync as mkdirSync2, readFileSync, statSync, writeFileSync } from "node:fs";
-import { basename, dirname as dirname3, extname, join as join4 } from "node:path";
+import { basename, dirname as dirname3, extname, join as join5 } from "node:path";
 var MIME_BY_EXT = {
   ".pdf": "application/pdf",
   ".png": "image/png",
@@ -31963,9 +37293,9 @@ ${text}` : text);
     if (args.saveTo) {
       const isDirArg = args.saveTo.endsWith("/") || args.saveTo.endsWith("\\");
       const abs = expandPath(args.saveTo);
-      dest = isDirArg ? join4(abs, `${fileId}-${cached2.fileName}`) : abs;
+      dest = isDirArg ? join5(abs, `${fileId}-${cached2.fileName}`) : abs;
     } else {
-      dest = join4(getAttachmentsDir(), `${fileId}-${cached2.fileName}`);
+      dest = join5(getAttachmentsDir(), `${fileId}-${cached2.fileName}`);
     }
     if (!args.force && cached2.downloadedPath === dest) {
       return jsonResponse({

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ofw-mcp",
       "version": "2.0.14",
       "dependencies": {
+        "@fetchproxy/bootstrap": "^0.3.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.0",
         "zod": "^4.4.2"
@@ -557,6 +558,32 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fetchproxy/bootstrap": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-0.3.0.tgz",
+      "integrity": "sha512-e+hsUL95iDl1MpiaVGLJl1Wl3ZsAPHp2YrugjjYpRtJwcGrS6tCBNAT0Zsrnc7yEqzWqpaH+eTLfR3XMEHoLyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fetchproxy/protocol": "^0.3.0",
+        "@fetchproxy/server": "^0.3.0"
+      }
+    },
+    "node_modules/@fetchproxy/protocol": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-0.3.0.tgz",
+      "integrity": "sha512-mCqbAywi2BC31Dd5Gv3awThWf8AEkVpPyyNtg7juL0Lt6Zd+T6jBdrYoKK16fghgqzYWLoMXUICvZ+ld6M0Vew==",
+      "license": "MIT"
+    },
+    "node_modules/@fetchproxy/server": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-0.3.0.tgz",
+      "integrity": "sha512-OgaAFxQj2iritgKpSqtjDHLPC1bpoTFlMStclcn0QWEn3X7n5UtAgAE0QJm3db952NNWUx9VdhcWyr920XvA7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fetchproxy/protocol": "^0.3.0",
+        "ws": "^8.20.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -3141,6 +3168,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fetchproxy/bootstrap": "^0.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.0",
     "zod": "^4.4.2"

--- a/src/auth-password.ts
+++ b/src/auth-password.ts
@@ -1,0 +1,77 @@
+// OFW's existing password-login path.
+//
+// `POST /ofw/login` is Spring Security form-urlencoded; it requires a SESSION
+// cookie that we capture from `GET /ofw/login.form` first. The response body
+// is JSON `{ auth: "<Bearer token>", redirectUrl: "..." }`. OFW does not return
+// a token expiry, so we synthesize a 6h lifetime — long enough to be useful,
+// short enough that a 401 re-auth replay is rare.
+//
+// This file exists as a standalone helper (not a method on `OFWClient`) so
+// `resolveAuth()` in `./auth.ts` can call it without a Client instance, and
+// so tests can mock it at the module boundary.
+
+const BASE_URL = 'https://ofw.ourfamilywizard.com';
+
+const OFW_PROTOCOL_HEADERS = {
+  'ofw-client': 'WebApplication',
+  'ofw-version': '1.0.0',
+} as const;
+
+interface LoginResponse {
+  auth: string;
+  redirectUrl: string;
+}
+
+export interface PasswordLoginResult {
+  token: string;
+  expiresAt: Date;
+}
+
+export async function loginWithPassword(
+  username: string,
+  password: string,
+): Promise<PasswordLoginResult> {
+  // Step 1: get a SESSION cookie (Spring Security refuses the POST without it).
+  const initResponse = await fetch(`${BASE_URL}/ofw/login.form`, {
+    headers: { ...OFW_PROTOCOL_HEADERS },
+    redirect: 'manual',
+  });
+  const setCookie = initResponse.headers.get('set-cookie') ?? '';
+  const sessionCookie = setCookie.split(';')[0];
+
+  // Step 2: submit the form.
+  const response = await fetch(`${BASE_URL}/ofw/login`, {
+    method: 'POST',
+    headers: {
+      ...OFW_PROTOCOL_HEADERS,
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      ...(sessionCookie ? { Cookie: sessionCookie } : {}),
+    },
+    body: new URLSearchParams({
+      submit: 'Sign In',
+      _eventId: 'submit',
+      username,
+      password,
+    }).toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`OFW login failed: ${response.status} ${response.statusText}`);
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    const body = await response.text();
+    throw new Error(`OFW login returned unexpected response (${contentType}): ${body.substring(0, 200)}`);
+  }
+
+  const data = (await response.json()) as LoginResponse;
+  return {
+    token: data.auth,
+    // OFW's login endpoint omits expiry. 6h is the empirical TTL and matches
+    // the historical behavior of this client (a single 401 → re-auth + replay
+    // covers the edge case where this estimate is wrong).
+    expiresAt: new Date(Date.now() + 6 * 60 * 60 * 1000),
+  };
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,152 @@
+// ────────────────────────────────────────────────────────────────────────────
+// Auth resolution — Pattern A template
+// ────────────────────────────────────────────────────────────────────────────
+//
+// This file is the canonical shape for "browser-bootstrap + Node-direct"
+// auth used across our MCP servers. The other six MCPs in this family
+// (resy-mcp, opentable-mcp, splitwise-mcp, …) will model their auth
+// resolution after this one — keep the structure flat, the path-selection
+// explicit, and the error messages actionable.
+//
+// THE THREE PATHS, in priority order:
+//
+//   1. Env-var credentials (existing behavior)
+//      OFW_USERNAME + OFW_PASSWORD set → POST the login form, get a token.
+//      This is the legacy path. It runs unchanged when both vars are set
+//      so existing users (Claude Desktop with mcpb env config, etc.) are
+//      not disrupted.
+//
+//   2. fetchproxy fallback (new)
+//      When credentials are absent, we try to lift the user's session
+//      out of their signed-in browser tab via the fetchproxy extension.
+//      The `@fetchproxy/bootstrap` helper spins up a one-shot WebSocket
+//      bridge, asks the extension for `localStorage["auth"]` and
+//      `localStorage["tokenExpiry"]` from any ourfamilywizard.com tab,
+//      then closes the bridge. From here on, all OFW API calls go out
+//      via plain Node `fetch()` — fetchproxy is NOT in the hot path.
+//
+//      Users opt out with OFW_DISABLE_FETCHPROXY=1 (anyone who wants the
+//      old behavior of "fail loudly when creds are missing").
+//
+//   3. Error
+//      Nothing to authenticate with. We throw a message that tells the
+//      user exactly what to do: set creds, OR install the extension and
+//      sign in.
+//
+// Why fetchproxy is only a one-shot read:
+//   The bootstrap call snapshots the session blob and returns. The MCP
+//   then operates from Node with direct fetch + Authorization header,
+//   so latency and reliability are not coupled to the browser bridge
+//   for normal tool calls. Pre-PR mcp-chrome and tab-routing concerns
+//   (see opentable-mcp/CLAUDE.md "Bridge selection") do not apply here.
+//
+// Testability:
+//   - `@fetchproxy/bootstrap` is mocked at the module boundary in tests.
+//   - `./auth-password.js` (loginWithPassword) is a separate module
+//     specifically so it can be mocked here too. This keeps the
+//     selection logic independent of either implementation.
+
+import { bootstrap } from '@fetchproxy/bootstrap';
+import { loginWithPassword } from './auth-password.js';
+import pkg from '../package.json' with { type: 'json' };
+
+/** Result of resolving auth, regardless of which path was taken. */
+export interface ResolvedAuth {
+  /** Bearer token for OFW API requests. */
+  token: string;
+  /** Best-effort expiry. Absent on the fetchproxy path when the browser tab didn't store one. */
+  expiresAt?: Date;
+  /** Which path produced the token. Used for diagnostics + future cache keying. */
+  source: 'env' | 'fetchproxy';
+}
+
+/**
+ * Read an env var, trim, and treat blank / `${UNEXPANDED}` placeholders as
+ * unset. Defends against MCP hosts that pass `.mcp.json` env blocks through
+ * without variable expansion.
+ */
+function readEnv(key: string): string | undefined {
+  const raw = process.env[key];
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  if (trimmed === 'undefined' || trimmed === 'null') return undefined;
+  if (/^\$\{[^}]*\}$/.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+/** True if the user has explicitly disabled the fetchproxy fallback. */
+function fetchproxyDisabled(): boolean {
+  const raw = readEnv('OFW_DISABLE_FETCHPROXY');
+  if (raw === undefined) return false;
+  return ['1', 'true', 'yes', 'on'].includes(raw.toLowerCase());
+}
+
+/**
+ * Resolve OFW auth using the three-path priority described at the top of
+ * this file. Throws with an actionable error message when no path succeeds.
+ *
+ * Callers (i.e. `OFWClient.login()`) treat the return value as opaque
+ * credentials — they should not branch on `source`. The field exists for
+ * logging / future cache-keying only.
+ */
+export async function resolveAuth(): Promise<ResolvedAuth> {
+  // ── Path 1: env-var credentials (unchanged from pre-fetchproxy behavior).
+  const username = readEnv('OFW_USERNAME');
+  const password = readEnv('OFW_PASSWORD');
+  if (username && password) {
+    const { token, expiresAt } = await loginWithPassword(username, password);
+    return { token, expiresAt, source: 'env' };
+  }
+
+  // ── Path 2: fetchproxy fallback (new).
+  if (!fetchproxyDisabled()) {
+    try {
+      const session = await bootstrap({
+        serverName: pkg.name,
+        version: pkg.version,
+        // OFW serves both ofw.ourfamilywizard.com and www.ourfamilywizard.com;
+        // the API + auth token live on the apex. The extension matches on
+        // suffix, so listing the apex covers both.
+        domains: ['ourfamilywizard.com'],
+        declare: {
+          cookies: [],
+          // The web app stores the Bearer token in localStorage["auth"] and
+          // its expiry (ISO string) in localStorage["tokenExpiry"]. Mirroring
+          // both means our 401-replay logic can be slightly smarter, and the
+          // expiry surfaces correctly in diagnostics.
+          localStorage: ['auth', 'tokenExpiry'],
+          sessionStorage: [],
+          captureHeaders: [],
+        },
+      });
+
+      const token = session.localStorage['auth'];
+      const expiryRaw = session.localStorage['tokenExpiry'];
+      if (!token) {
+        throw new Error(
+          'localStorage["auth"] missing on ourfamilywizard.com. ' +
+            'Sign into OFW in your browser (with the fetchproxy extension installed) and retry.',
+        );
+      }
+      return {
+        token,
+        expiresAt: expiryRaw ? new Date(expiryRaw) : undefined,
+        source: 'fetchproxy',
+      };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new Error(
+        `OFW auth: no OFW_USERNAME/OFW_PASSWORD set, and fetchproxy fallback failed: ${msg}`,
+      );
+    }
+  }
+
+  // ── Path 3: nothing configured. Surface both fixes side-by-side so the
+  //    user can pick whichever fits their setup.
+  throw new Error(
+    'OFW auth: set OFW_USERNAME + OFW_PASSWORD, ' +
+      'or install the fetchproxy extension and sign into ourfamilywizard.com ' +
+      '(unset OFW_DISABLE_FETCHPROXY if it is set).',
+  );
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { resolveAuth } from './auth.js';
 
 // Load .env for local dev; silently skip if dotenv is unavailable (e.g. mcpb bundle)
 try {
@@ -10,32 +11,12 @@ try {
   // not available — rely on process.env (mcpb sets credentials via mcp_config.env)
 }
 
-/**
- * Read an env var, trim whitespace, and treat as unset if blank or if the value
- * looks like an unsubstituted shell placeholder (e.g. `${FOO}`) — defends
- * against MCP hosts that pass .mcp.json env blocks through unexpanded.
- */
-function readVar(key: string): string | undefined {
-  const raw = process.env[key];
-  if (typeof raw !== 'string') return undefined;
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) return undefined;
-  if (trimmed === 'undefined' || trimmed === 'null') return undefined;
-  if (/^\$\{[^}]*\}$/.test(trimmed)) return undefined;
-  return trimmed;
-}
-
 const BASE_URL = 'https://ofw.ourfamilywizard.com';
 
 const OFW_PROTOCOL_HEADERS = {
   'ofw-client': 'WebApplication',
   'ofw-version': '1.0.0',
 } as const;
-
-interface LoginResponse {
-  auth: string; // Bearer token for all subsequent API calls
-  redirectUrl: string;
-}
 
 export interface BinaryResponse {
   body: Buffer;
@@ -126,53 +107,18 @@ export class OFWClient {
     await this.login();
   }
 
+  // Auth resolution is delegated to `./auth.ts`. This client doesn't care
+  // whether the token came from a password POST or from a one-shot
+  // fetchproxy session-snapshot — it just consumes the result.
+  //
+  // If `expiresAt` is missing (the fetchproxy path on a tab whose
+  // browser didn't persist tokenExpiry), we fall back to the same 6h
+  // estimate the password path uses. The 401-replay path covers us if
+  // the estimate is wrong.
   private async login(): Promise<void> {
-    const username = readVar('OFW_USERNAME');
-    const password = readVar('OFW_PASSWORD');
-    if (!username || !password) {
-      throw new Error('OFW_USERNAME and OFW_PASSWORD must be set');
-    }
-
-    // Spring Security requires a SESSION cookie before accepting the login POST.
-    // GET /ofw/login.form with redirect:manual to capture the Set-Cookie from the 303 response.
-    const initResponse = await fetch(`${BASE_URL}/ofw/login.form`, {
-      headers: { ...OFW_PROTOCOL_HEADERS },
-      redirect: 'manual',
-    });
-    // Extract just the SESSION=value part (strip attributes like Path, Secure, etc.)
-    const setCookie = initResponse.headers.get('set-cookie') ?? '';
-    const sessionCookie = setCookie.split(';')[0];
-
-    const response = await fetch(`${BASE_URL}/ofw/login`, {
-      method: 'POST',
-      headers: {
-        ...OFW_PROTOCOL_HEADERS,
-        Accept: 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded',
-        ...(sessionCookie ? { Cookie: sessionCookie } : {}),
-      },
-      body: new URLSearchParams({
-        submit: 'Sign In',
-        _eventId: 'submit',
-        username,
-        password,
-      }).toString(),
-    });
-
-    if (!response.ok) {
-      throw new Error(`OFW login failed: ${response.status} ${response.statusText}`);
-    }
-
-    const contentType = response.headers.get('content-type') ?? '';
-    if (!contentType.includes('application/json')) {
-      const body = await response.text();
-      throw new Error(`OFW login returned unexpected response (${contentType}): ${body.substring(0, 200)}`);
-    }
-
-    const data = (await response.json()) as LoginResponse;
-    this.token = data.auth;
-    // Token expiry not returned by login endpoint; use 6h as a safe default
-    this.tokenExpiry = new Date(Date.now() + 6 * 60 * 60 * 1000);
+    const { token, expiresAt } = await resolveAuth();
+    this.token = token;
+    this.tokenExpiry = expiresAt ?? new Date(Date.now() + 6 * 60 * 60 * 1000);
   }
 
   private isTokenExpiredSoon(): boolean {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,12 +2,20 @@ import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-function readUsername(): string {
-  const raw = process.env.OFW_USERNAME;
-  if (typeof raw !== 'string' || raw.trim().length === 0) {
-    throw new Error('OFW_USERNAME must be set to derive cache path');
-  }
-  return raw.trim();
+// Cache identity drives the per-user SQLite DB filename. Order of preference:
+//   1. OFW_CACHE_IDENTITY — explicit override for users who want to label the
+//      cache themselves (e.g. when authing via fetchproxy and OFW_USERNAME is
+//      not set).
+//   2. OFW_USERNAME — legacy path; existing users keep their existing DB.
+//   3. "_default" — fallback for fetchproxy-only setups where neither is set.
+//      Single-user installs are fine on this; multi-account users should set
+//      OFW_CACHE_IDENTITY explicitly so their caches don't collide.
+function readCacheIdentity(): string {
+  const explicit = process.env.OFW_CACHE_IDENTITY;
+  if (typeof explicit === 'string' && explicit.trim().length > 0) return explicit.trim();
+  const username = process.env.OFW_USERNAME;
+  if (typeof username === 'string' && username.trim().length > 0) return username.trim();
+  return '_default';
 }
 
 export function getCacheDir(): string {
@@ -17,8 +25,8 @@ export function getCacheDir(): string {
 }
 
 export function getCacheDbPath(): string {
-  const username = readUsername();
-  const hash = createHash('sha256').update(username).digest('hex').slice(0, 16);
+  const identity = readCacheIdentity();
+  const hash = createHash('sha256').update(identity).digest('hex').slice(0, 16);
   return join(getCacheDir(), `${hash}.db`);
 }
 

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// resolveAuth() drives three paths:
+//   1. env vars (OFW_USERNAME + OFW_PASSWORD) → password login POST
+//   2. fetchproxy fallback (read browser session via @fetchproxy/bootstrap)
+//   3. error: tell the user to set creds or sign in via the extension
+//
+// These tests verify path selection, error shapes, and that we don't accidentally
+// preempt env-var auth when it's set.
+
+// Mock @fetchproxy/bootstrap at the module boundary — never hit a real WS.
+const bootstrapMock = vi.fn();
+vi.mock('@fetchproxy/bootstrap', () => ({
+  bootstrap: (...args: unknown[]) => bootstrapMock(...args),
+}));
+
+// And mock the password-login helper so we can assert it's called with the right creds.
+const loginWithPasswordMock = vi.fn();
+vi.mock('../src/auth-password.js', () => ({
+  loginWithPassword: (...args: unknown[]) => loginWithPasswordMock(...args),
+}));
+
+import { resolveAuth } from '../src/auth.js';
+
+describe('resolveAuth', () => {
+  let originalUsername: string | undefined;
+  let originalPassword: string | undefined;
+  let originalDisable: string | undefined;
+
+  beforeEach(() => {
+    originalUsername = process.env.OFW_USERNAME;
+    originalPassword = process.env.OFW_PASSWORD;
+    originalDisable = process.env.OFW_DISABLE_FETCHPROXY;
+    delete process.env.OFW_USERNAME;
+    delete process.env.OFW_PASSWORD;
+    delete process.env.OFW_DISABLE_FETCHPROXY;
+    bootstrapMock.mockReset();
+    loginWithPasswordMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalUsername === undefined) delete process.env.OFW_USERNAME;
+    else process.env.OFW_USERNAME = originalUsername;
+    if (originalPassword === undefined) delete process.env.OFW_PASSWORD;
+    else process.env.OFW_PASSWORD = originalPassword;
+    if (originalDisable === undefined) delete process.env.OFW_DISABLE_FETCHPROXY;
+    else process.env.OFW_DISABLE_FETCHPROXY = originalDisable;
+  });
+
+  describe('path 1: env-var credentials', () => {
+    it('uses password login when both OFW_USERNAME and OFW_PASSWORD are set', async () => {
+      process.env.OFW_USERNAME = 'me@example.com';
+      process.env.OFW_PASSWORD = 'hunter2';
+      const expiresAt = new Date(Date.now() + 6 * 60 * 60 * 1000);
+      loginWithPasswordMock.mockResolvedValue({ token: 'tok-from-pw', expiresAt });
+
+      const result = await resolveAuth();
+
+      expect(loginWithPasswordMock).toHaveBeenCalledWith('me@example.com', 'hunter2');
+      expect(bootstrapMock).not.toHaveBeenCalled();
+      expect(result).toEqual({ token: 'tok-from-pw', expiresAt, source: 'env' });
+    });
+
+    it('takes env-var precedence even when fetchproxy is enabled', async () => {
+      process.env.OFW_USERNAME = 'me@example.com';
+      process.env.OFW_PASSWORD = 'hunter2';
+      loginWithPasswordMock.mockResolvedValue({ token: 'tok-from-pw' });
+
+      await resolveAuth();
+
+      expect(bootstrapMock).not.toHaveBeenCalled();
+    });
+
+    it('does not treat username alone (no password) as env-var credentials', async () => {
+      // username is needed elsewhere for cache keying — it must NOT mean
+      // "use password login" without a password.
+      process.env.OFW_USERNAME = 'me@example.com';
+      bootstrapMock.mockResolvedValue({
+        cookies: {},
+        localStorage: { auth: 'tok-from-fp', tokenExpiry: '' },
+        sessionStorage: {},
+        capturedHeaders: {},
+      });
+
+      const result = await resolveAuth();
+
+      expect(loginWithPasswordMock).not.toHaveBeenCalled();
+      expect(bootstrapMock).toHaveBeenCalled();
+      expect(result.source).toBe('fetchproxy');
+    });
+  });
+
+  describe('path 2: fetchproxy fallback', () => {
+    it('reads auth + tokenExpiry from localStorage via bootstrap()', async () => {
+      const isoExpiry = '2027-01-01T00:00:00.000Z';
+      bootstrapMock.mockResolvedValue({
+        cookies: {},
+        localStorage: { auth: 'tok-from-fp', tokenExpiry: isoExpiry },
+        sessionStorage: {},
+        capturedHeaders: {},
+      });
+
+      const result = await resolveAuth();
+
+      expect(bootstrapMock).toHaveBeenCalledTimes(1);
+      const opts = bootstrapMock.mock.calls[0][0] as {
+        serverName: string;
+        version: string;
+        domains: string[];
+        declare: { cookies: string[]; localStorage: string[]; sessionStorage: string[]; captureHeaders: unknown[] };
+      };
+      expect(opts.serverName).toBe('ofw-mcp');
+      expect(typeof opts.version).toBe('string');
+      expect(opts.domains).toEqual(['ourfamilywizard.com']);
+      expect(opts.declare.localStorage).toEqual(['auth', 'tokenExpiry']);
+      expect(opts.declare.cookies).toEqual([]);
+      expect(opts.declare.sessionStorage).toEqual([]);
+      expect(opts.declare.captureHeaders).toEqual([]);
+
+      expect(result.token).toBe('tok-from-fp');
+      expect(result.source).toBe('fetchproxy');
+      expect(result.expiresAt?.toISOString()).toBe(isoExpiry);
+    });
+
+    it('passes through with no expiry when tokenExpiry is missing', async () => {
+      bootstrapMock.mockResolvedValue({
+        cookies: {},
+        localStorage: { auth: 'tok-from-fp' },
+        sessionStorage: {},
+        capturedHeaders: {},
+      });
+
+      const result = await resolveAuth();
+
+      expect(result.token).toBe('tok-from-fp');
+      expect(result.expiresAt).toBeUndefined();
+    });
+
+    it('throws with a helpful message when localStorage["auth"] is missing', async () => {
+      bootstrapMock.mockResolvedValue({
+        cookies: {},
+        localStorage: {},
+        sessionStorage: {},
+        capturedHeaders: {},
+      });
+
+      await expect(resolveAuth()).rejects.toThrow(/fetchproxy fallback failed/);
+      await expect(resolveAuth()).rejects.toThrow(/Sign into OFW in your browser/);
+    });
+
+    it('wraps bootstrap() errors with actionable context', async () => {
+      bootstrapMock.mockRejectedValue(new Error('extension offline'));
+
+      await expect(resolveAuth()).rejects.toThrow(/fetchproxy fallback failed: extension offline/);
+    });
+  });
+
+  describe('env-var sanitization', () => {
+    // Matches the readVar() helper hardening that used to live in client.ts:
+    // defenses against MCP hosts that pass through unexpanded `${VAR}` or
+    // serialize undefined/null as a string.
+    it.each(['undefined', 'null', '${OFW_PASSWORD}', '   ', ''])(
+      'treats OFW_PASSWORD=%j as unset and falls through to fetchproxy',
+      async (val) => {
+        process.env.OFW_USERNAME = 'me@example.com';
+        process.env.OFW_PASSWORD = val;
+        bootstrapMock.mockResolvedValue({
+          cookies: {},
+          localStorage: { auth: 'tok' },
+          sessionStorage: {},
+          capturedHeaders: {},
+        });
+
+        const result = await resolveAuth();
+
+        expect(loginWithPasswordMock).not.toHaveBeenCalled();
+        expect(result.source).toBe('fetchproxy');
+      },
+    );
+  });
+
+  describe('error handling', () => {
+    it('handles non-Error rejections from bootstrap()', async () => {
+      bootstrapMock.mockRejectedValue('plain string failure');
+
+      await expect(resolveAuth()).rejects.toThrow(/fetchproxy fallback failed: plain string failure/);
+    });
+  });
+
+  describe('path 3: nothing configured', () => {
+    it('skips fetchproxy when OFW_DISABLE_FETCHPROXY=1 is set', async () => {
+      process.env.OFW_DISABLE_FETCHPROXY = '1';
+
+      await expect(resolveAuth()).rejects.toThrow(/OFW_USERNAME \+ OFW_PASSWORD/);
+      expect(bootstrapMock).not.toHaveBeenCalled();
+    });
+
+    it.each(['1', 'true', 'yes', 'on', 'TRUE'])(
+      'treats OFW_DISABLE_FETCHPROXY=%j as disabled',
+      async (val) => {
+        process.env.OFW_DISABLE_FETCHPROXY = val;
+        await expect(resolveAuth()).rejects.toThrow(/OFW_USERNAME/);
+        expect(bootstrapMock).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each(['0', 'false', 'no', '', 'off'])(
+      'treats OFW_DISABLE_FETCHPROXY=%j as enabled (default)',
+      async (val) => {
+        process.env.OFW_DISABLE_FETCHPROXY = val;
+        bootstrapMock.mockResolvedValue({
+          cookies: {},
+          localStorage: { auth: 'tok' },
+          sessionStorage: {},
+          capturedHeaders: {},
+        });
+        await resolveAuth();
+        expect(bootstrapMock).toHaveBeenCalled();
+      },
+    );
+  });
+});

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -147,10 +147,13 @@ describe('OFWClient', () => {
     vi.useRealTimers();
   });
 
-  it('throws if credentials are missing', async () => {
+  it('throws if credentials are missing and fetchproxy is disabled', async () => {
     delete process.env.OFW_USERNAME;
+    delete process.env.OFW_PASSWORD;
+    process.env.OFW_DISABLE_FETCHPROXY = '1';
     const client = new OFWClient();
     await expect(client.request('GET', '/pub/v1/test')).rejects.toThrow('OFW_USERNAME');
+    delete process.env.OFW_DISABLE_FETCHPROXY;
   });
 
   it('throws if login POST returns non-2xx', async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -8,13 +8,16 @@ describe('getCacheDbPath', () => {
   let tmp: string;
   let originalCacheDir: string | undefined;
   let originalUsername: string | undefined;
+  let originalIdentity: string | undefined;
 
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), 'ofw-cache-'));
     originalCacheDir = process.env.OFW_CACHE_DIR;
     originalUsername = process.env.OFW_USERNAME;
+    originalIdentity = process.env.OFW_CACHE_IDENTITY;
     process.env.OFW_CACHE_DIR = tmp;
     process.env.OFW_USERNAME = 'test@example.com';
+    delete process.env.OFW_CACHE_IDENTITY;
   });
 
   afterEach(() => {
@@ -22,6 +25,8 @@ describe('getCacheDbPath', () => {
     else process.env.OFW_CACHE_DIR = originalCacheDir;
     if (originalUsername === undefined) delete process.env.OFW_USERNAME;
     else process.env.OFW_USERNAME = originalUsername;
+    if (originalIdentity === undefined) delete process.env.OFW_CACHE_IDENTITY;
+    else process.env.OFW_CACHE_IDENTITY = originalIdentity;
     rmSync(tmp, { recursive: true, force: true });
   });
 
@@ -43,9 +48,30 @@ describe('getCacheDbPath', () => {
     expect(a).not.toBe(b);
   });
 
-  it('throws if OFW_USERNAME is not set', () => {
+  it('uses OFW_CACHE_IDENTITY when set (fetchproxy-only auth, no username)', () => {
     delete process.env.OFW_USERNAME;
-    expect(() => getCacheDbPath()).toThrow(/OFW_USERNAME/);
+    process.env.OFW_CACHE_IDENTITY = 'browser-session';
+    const path = getCacheDbPath();
+    const filename = path.slice(tmp.length + 1);
+    expect(filename).toMatch(/^[0-9a-f]{16}\.db$/);
+  });
+
+  it('prefers OFW_CACHE_IDENTITY over OFW_USERNAME when both are set', () => {
+    process.env.OFW_USERNAME = 'me@example.com';
+    process.env.OFW_CACHE_IDENTITY = 'override';
+    const a = getCacheDbPath();
+    delete process.env.OFW_CACHE_IDENTITY;
+    const b = getCacheDbPath();
+    expect(a).not.toBe(b);
+  });
+
+  it('falls back to "_default" when neither OFW_USERNAME nor OFW_CACHE_IDENTITY is set', () => {
+    delete process.env.OFW_USERNAME;
+    // Single-user fetchproxy install: cache is keyed on the placeholder.
+    // Multi-account users should set OFW_CACHE_IDENTITY explicitly.
+    expect(() => getCacheDbPath()).not.toThrow();
+    const path = getCacheDbPath();
+    expect(path.startsWith(tmp)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `@fetchproxy/bootstrap@^0.3.0` as a third auth resolution path.
- Env-var path (`OFW_USERNAME` + `OFW_PASSWORD`) is unchanged and takes priority — legacy users keep working without action.
- When no env vars are set, the MCP reads `localStorage["auth"]` once at startup from the user's signed-in `ourfamilywizard.com` tab via the fetchproxy 0.3.0 browser extension, then operates from Node with direct `fetch()` — fetchproxy is **NOT** in the hot path.
- Single `localStorage` extraction at startup; all subsequent API calls are direct.
- `OFW_DISABLE_FETCHPROXY=1` opts out of the fallback (headless / CI use).
- Requires the fetchproxy 0.3.0 Chrome / Safari extension installed (declares `read_local_storage` capability with `localStorage: ['auth', 'tokenExpiry']` scope).

## Why this layout

`src/auth.ts` is the canonical "browser-bootstrap + Node-direct" shape that the other six sibling MCPs (resy-mcp, opentable-mcp, …) will model their auth on. It's split into:

- `src/auth.ts` — `resolveAuth()`: three-path priority, exhaustively commented as the template.
- `src/auth-password.ts` — `loginWithPassword()`: legacy form-POST, isolated so tests can mock it at the module boundary.

`src/config.ts` learns `OFW_CACHE_IDENTITY` so fetchproxy-only multi-account installs can label each cache without an `OFW_USERNAME` (single-user installs fall back to `"_default"`).

## Test plan

- [x] `npm test` — 205/205 pass (was 179; +26 new tests, including 22 driving the three-path selection logic and 4 new cache-identity cases)
- [x] `npm run build` — clean
- [ ] Live smoke (user): install fetchproxy 0.3.0 extension, remove `OFW_USERNAME` / `OFW_PASSWORD`, sign into `ourfamilywizard.com`, run an MCP tool call → verify auth bootstrap works and the tool returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)