### PR TITLE
fix(bundle): add createRequire shim so ws works in ESM bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ofw-mcp",
   "version": "2.0.14",
   "mcpName": "io.github.chrischall/ofw-mcp",
-  "description": "OurFamilyWizard MCP server for Claude — developed and maintained by AI (Claude Code)",
+  "description": "OurFamilyWizard MCP server for Claude \u2014 developed and maintained by AI (Claude Code)",
   "author": "Claude Code (AI) <https://www.anthropic.com/claude>",
   "repository": {
     "type": "git",
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "tsc && npm run bundle",
-    "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --external:dotenv --outfile=dist/bundle.js",
+    "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --external:dotenv --banner:js='import { createRequire as __createRequire } from \"module\"; const require = __createRequire(import.meta.url);' --outfile=dist/bundle.js",
     "dev": "node --env-file=.env dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest"


### PR DESCRIPTION
## Summary

Add `--banner:js` to the bundle script so dynamic `require()` calls inside the ESM-bundled output resolve to Node's CJS loader. Mirror of opentable-mcp's `bundle` script.

## Why

`@fetchproxy/bootstrap` / `@fetchproxy/server` pull in `ws`, which calls `require('events')` at load time. Without the shim, esbuild's `--format=esm` output crashes on first run:

```
Error: Dynamic require of "events" is not supported
    at node_modules/ws/lib/websocket.js
```

This is the same crash that took down honeybook-mcp once it shipped its fetchproxy migration to npm — see chrischall/honeybook-mcp#19 for the matching fix.

## Test plan

- [x] `npm test` — still green
- [x] `npm run bundle` — `dist/bundle.js` now starts with the `createRequire` shim
- [ ] Post-merge: Tag & Bump → npm publish → reinstall in Claude Desktop → exercise tools end-to-end through fetchproxy 0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)