### PR TITLE
chore(deps): bump @fetchproxy/* to ^0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ofw-mcp",
       "version": "2.0.14",
       "dependencies": {
-        "@fetchproxy/bootstrap": "^0.4.0",
+        "@fetchproxy/bootstrap": "^0.4.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.0",
         "zod": "^4.4.2"
@@ -561,9 +561,9 @@
       }
     },
     "node_modules/@fetchproxy/bootstrap": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-0.4.0.tgz",
-      "integrity": "sha512-CBqLzoWNadW5xE9DWRci/Z1QiWdx6wul/MqmDSPgizbJpyNpuILiK0rrGlUd2Y3eJGrLeVj3b6nykbbvSLtCFw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-0.4.2.tgz",
+      "integrity": "sha512-rM1lT0d9ZUZIQA7jkccdppMEAIJIoLDeGzq6Fjxn7DYa3+e+v69SNpmj9yKDUIvwusYgoSETBhFLpDhoW1xNVQ==",
       "license": "MIT",
       "dependencies": {
         "@fetchproxy/protocol": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@fetchproxy/bootstrap": "^0.4.0",
+    "@fetchproxy/bootstrap": "^0.4.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.0",
     "zod": "^4.4.2"


### PR DESCRIPTION
## Summary

Bump `@fetchproxy/*` dep range to `^0.4.2` and refresh `package-lock.json`. `^0.4.0` would allow 0.4.2 on a fresh install, but `npm ci` in CI uses the lock strictly and would still pull 0.4.0.

## What's in 0.4.2 (cumulative since 0.4.0)

- `@fetchproxy/bootstrap` — `storageDomain` / `storageSubdomain` selectors on `BootstrapOpts`, threaded through to per-tab cookie / localStorage / sessionStorage / indexedDb reads. Required for multi-domain MCPs (HoneyBook spans `honeybook.com` + `hbportal.co`).
- `@fetchproxy/server` — no API changes; bumped in lockstep.
- `@fetchproxy/protocol` — no API changes; bumped in lockstep.

This MCP doesn't currently exercise `storageDomain`, but the refresh keeps the cohort in step and prevents future "your local works but CI doesn't" lockfile-skew bugs.

## Test plan

- [x] `npm test` — green
- [x] `npm run build` — clean
- [x] `package-lock.json` resolves `@fetchproxy/*` to 0.4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)