### PR TITLE
chore(deps): refresh lockfile for @fetchproxy/{protocol,server} 0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -571,18 +571,18 @@
       }
     },
     "node_modules/@fetchproxy/protocol": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-0.4.0.tgz",
-      "integrity": "sha512-CDEpn1dIbUZ6C4c3LNe+7zcHfst0kbAK0Dc9tS3fRyfixlxV4t2LEEOSBp1Iz7e1bEF6jxOVJ+O96qKDqEZaRQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-0.4.2.tgz",
+      "integrity": "sha512-cPNhc+dxTK9FuS/SjvJDxjrkiYbT5v+/pnU3b9XHoyW4hGMGdibFrpiBpHInlOl8NVm+tFYws8O0jEa2hGgAqg==",
       "license": "MIT"
     },
     "node_modules/@fetchproxy/server": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-0.4.0.tgz",
-      "integrity": "sha512-ZoO1+uovShBPldoB532s7YgjaGT/yT+AKtGBQswAYVj7S46qVYvJBQFGt4poAoKOtEjzUbEHrcg4vTK12qisLw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-0.4.2.tgz",
+      "integrity": "sha512-OsJ0IMJi3HdqgzhIP511e+6w3nPkWp1yNW+vfbR6jIJOkh0dahgYhuGFEXQCpZKxYXSAHKNPoye2KXV43/1UaQ==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^0.4.0",
+        "@fetchproxy/protocol": "^0.4.2",
         "ws": "^8.20.0"
       }
     },


### PR DESCRIPTION
## Summary

Refresh `package-lock.json` so transitive `@fetchproxy/protocol` and `@fetchproxy/server` versions resolve to 0.4.2 alongside `bootstrap@0.4.2`. Pure lockfile-only change.

## Why

Bootstrap@0.4.2 declares its protocol/server deps as `^0.4.0`. When we bumped this MCP's direct `bootstrap` dep to `^0.4.2`, `npm install` picked up bootstrap@0.4.2 but left protocol+server pinned at the 0.4.0 they'd already resolved to in the existing lockfile. The result was a mixed `0.4.0,0.4.2` lockfile that's functionally fine (API surface is identical between 0.4.0 and 0.4.2 in protocol/server) but visually inconsistent.

`npm update @fetchproxy/protocol @fetchproxy/server` walks the existing tree, allows 0.4.2 within the `^0.4.0` range, and rewrites the lock.

## Test plan

- [x] `npm test` — green
- [x] `npm run build` — clean
- [x] `package-lock.json` resolves all `@fetchproxy/*` entries to 0.4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)