### PR TITLE
fix: re-fetch after save_draft/send_message; drop unreliable draft sync staleness check

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -37,6 +37,20 @@ function parseContentDispositionFilename(cd: string): string | null {
   return m ? m[1] : null;
 }
 
+// Set OFW_DEBUG_LOG=1 (or true/yes/on) to log every OFW request/response to
+// stderr. Authorization is redacted. Bodies are logged in full — set this
+// only when debugging, never in normal use.
+function debugLogEnabled(): boolean {
+  const v = process.env.OFW_DEBUG_LOG;
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
+function redactHeaders(h: Record<string, string>): Record<string, string> {
+  const out = { ...h };
+  if (out.Authorization) out.Authorization = `Bearer ${out.Authorization.slice(7, 17)}…`;
+  return out;
+}
+
 export class OFWClient {
   private token: string | null = null;
   private tokenExpiry: Date | null = null;
@@ -45,6 +59,9 @@ export class OFWClient {
     await this.ensureAuthenticated();
     const response = await this.fetchWithRetry(method, path, body, 'application/json', false);
     const text = await response.text();
+    if (debugLogEnabled()) {
+      console.error(`[ofw-debug] response body: ${text || '<empty>'}`);
+    }
     return (text ? JSON.parse(text) : null) as T;
   }
 
@@ -77,11 +94,27 @@ export class OFWClient {
     };
     if (body !== undefined && !isFormData) headers['Content-Type'] = 'application/json';
 
-    const response = await fetch(`${BASE_URL}${path}`, {
+    const url = `${BASE_URL}${path}`;
+    if (debugLogEnabled()) {
+      const bodyPreview = body === undefined
+        ? '<none>'
+        : isFormData
+          ? `<FormData entries=${Array.from((body as FormData).keys()).join(',')}>`
+          : JSON.stringify(body);
+      console.error(`[ofw-debug] → ${method} ${url}${isRetry ? ' (retry)' : ''}`);
+      console.error(`[ofw-debug]   headers: ${JSON.stringify(redactHeaders(headers))}`);
+      console.error(`[ofw-debug]   body: ${bodyPreview}`);
+    }
+
+    const response = await fetch(url, {
       method,
       headers,
       ...(body !== undefined ? { body: isFormData ? body : JSON.stringify(body) } : {}),
     });
+
+    if (debugLogEnabled()) {
+      console.error(`[ofw-debug] ← ${response.status} ${response.statusText}`);
+    }
 
     if (response.status === 401 && !isRetry) {
       this.token = null;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -221,10 +221,10 @@ export async function syncDrafts(client: OFWClient, draftsFolderId: string): Pro
   for (const item of items) {
     seenIds.add(item.id);
     const modifiedAt = item.date?.dateTime ?? new Date().toISOString();
+    // OFW's list endpoint's `date.dateTime` is NOT a reliable modification
+    // timestamp for drafts — direct UI edits don't bump it — so we can't
+    // use it to skip the detail fetch. Always re-fetch; drafts are few.
     const existing = getDraft(item.id);
-    if (existing && existing.modifiedAt === modifiedAt) {
-      continue;
-    }
     const detail = await client.request<DraftDetailResponse>('GET', `/pub/v3/messages/${item.id}`);
     const row: DraftRow = {
       id: item.id,
@@ -236,7 +236,12 @@ export async function syncDrafts(client: OFWClient, draftsFolderId: string): Pro
       listData: item,
     };
     upsertDraft(row);
-    synced++;
+    if (!existing
+        || existing.body !== row.body
+        || existing.subject !== row.subject
+        || existing.replyToId !== row.replyToId) {
+      synced++;
+    }
   }
 
   for (const id of listDraftIds()) {

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -165,7 +165,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
   });
 
   server.registerTool('ofw_send_message', {
-    description: 'Send a message via OurFamilyWizard. If sending from a draft, pass draftId to delete the draft after sending. If replyToId is provided, the cache may rewrite it to the latest reply in the same thread (a note is included in the response when this happens). Attach files by passing their fileIds (from ofw_upload_attachment) in myFileIDs.',
+    description: 'Send a message via OurFamilyWizard. If sending from a draft, pass draftId to delete the draft after sending. If replyToId is provided, the cache may rewrite it to the latest reply in the same thread (a note is included in the response when this happens). Attach files by passing their fileIds (from ofw_upload_attachment) in myFileIDs. After sending, the tool re-fetches the message from OFW to populate the local cache and link attachments to the new message id.',
     annotations: { destructiveHint: true },
     inputSchema: {
       subject: z.string().describe('Message subject'),
@@ -191,11 +191,12 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     }
 
     const myFileIDs = args.myFileIDs ?? [];
+    // OFW's POST /pub/v3/messages response is minimal — typically just
+    // `{entityId: <id>}` — so the cache write needs to fetch detail
+    // afterwards (same shape as ofw_save_draft).
     const data = await client.request<{
-      id?: number; subject?: string; body?: string;
-      date?: { dateTime: string }; from?: { name?: string };
-      recipients?: Array<{ user: { id: number; name: string }; viewed?: { dateTime: string } | null }>;
-    }>('POST', '/pub/v3/messages', {
+      id?: number; entityId?: number;
+    } & Record<string, unknown>>('POST', '/pub/v3/messages', {
       subject: args.subject,
       body: args.body,
       recipientIds: args.recipientIds,
@@ -205,21 +206,33 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       replyToId: resolvedReplyTo,
     });
 
-    if (data && typeof data.id === 'number') {
-      const row: MessageRow = {
-        id: data.id,
+    const newId: number | null =
+      typeof data?.id === 'number' ? data.id
+      : typeof data?.entityId === 'number' ? data.entityId
+      : null;
+
+    let persisted: MessageRow | null = null;
+    if (newId !== null) {
+      const detail = await client.request<{
+        id: number; subject?: string; body?: string;
+        date?: { dateTime: string }; from?: { name?: string };
+        recipients?: Array<{ user: { id: number; name: string }; viewed?: { dateTime: string } | null }>;
+      }>('GET', `/pub/v3/messages/${newId}`);
+
+      persisted = {
+        id: newId,
         folder: 'sent',
-        subject: data.subject ?? args.subject,
-        fromUser: data.from?.name ?? '',
-        sentAt: data.date?.dateTime ?? new Date().toISOString(),
-        recipients: mapRecipients(data.recipients),
-        body: data.body ?? args.body,
+        subject: detail.subject ?? args.subject,
+        fromUser: detail.from?.name ?? '',
+        sentAt: detail.date?.dateTime ?? new Date().toISOString(),
+        recipients: mapRecipients(detail.recipients),
+        body: detail.body ?? args.body,
         fetchedBodyAt: new Date().toISOString(),
         replyToId: resolvedReplyTo,
         chainRootId,
-        listData: data,
+        listData: detail,
       };
-      upsertMessage(row);
+      upsertMessage(persisted);
       // Link attached files to the new message in the attachments cache.
       // We may not have full metadata if the upload happened in a prior
       // session — fall back to what we know.
@@ -232,7 +245,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
           mimeType: existing?.mimeType ?? 'application/octet-stream',
           sizeBytes: existing?.sizeBytes ?? null,
           metadata: existing?.metadata ?? {},
-          messageId: data.id,
+          messageId: newId,
         });
       }
     }
@@ -242,7 +255,8 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       deleteDraft(args.draftId);
     }
 
-    const text = data ? JSON.stringify(data, null, 2) : 'Message sent successfully.';
+    const responseObj = persisted ?? data;
+    const text = responseObj ? JSON.stringify(responseObj, null, 2) : 'Message sent successfully.';
     return textResponse(rewriteNote ? `${rewriteNote}\n\n${text}` : text);
   });
 
@@ -264,7 +278,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
   });
 
   server.registerTool('ofw_save_draft', {
-    description: 'Save a message as a draft in OurFamilyWizard. Recipients are optional. To update an existing draft, provide its messageId. If replyToId is provided, the cache may rewrite it to the latest reply in the thread (note included in response). Attach files by passing their fileIds (from ofw_upload_attachment) in myFileIDs.',
+    description: 'Save a message as a draft in OurFamilyWizard. Recipients are optional. To update an existing draft, provide its messageId. If replyToId is provided, the cache may rewrite it to the latest reply in the thread (note included in response). Attach files by passing their fileIds (from ofw_upload_attachment) in myFileIDs. After saving, the tool re-fetches the draft from OFW to populate the local cache and verify what was actually persisted; if OFW silently no-ops an update (a known issue with repeated updates to the same draft), the response includes a WARNING note with a workaround.',
     annotations: { readOnlyHint: false },
     inputSchema: {
       subject: z.string().describe('Message subject'),
@@ -298,28 +312,56 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     };
     if (args.messageId !== undefined) payload.messageId = args.messageId;
 
+    // OFW's POST /pub/v3/messages response for drafts is minimal — typically
+    // just `{entityId: <id>}` — and worse, it returns the same success shape
+    // even when the server silently no-ops on a subsequent update to the
+    // same draft. Don't trust the POST response: extract the id from it,
+    // then GET the detail endpoint to repopulate the cache from
+    // authoritative server state.
     const data = await client.request<{
-      id?: number; subject?: string; body?: string;
-      date?: { dateTime: string };
-      replyToId?: number | null;
-      recipients?: Array<{ user: { id: number; name: string }; viewed?: { dateTime: string } | null }>;
-    }>('POST', '/pub/v3/messages', payload);
+      id?: number; entityId?: number;
+    } & Record<string, unknown>>('POST', '/pub/v3/messages', payload);
 
-    if (data && typeof data.id === 'number') {
-      const draft: DraftRow = {
-        id: data.id,
-        subject: data.subject ?? args.subject,
-        body: data.body ?? args.body,
-        recipients: mapRecipients(data.recipients),
-        replyToId: data.replyToId ?? resolvedReplyTo,
-        modifiedAt: data.date?.dateTime ?? new Date().toISOString(),
-        listData: data,
+    const newId: number | null =
+      typeof data?.id === 'number' ? data.id
+      : typeof data?.entityId === 'number' ? data.entityId
+      : null;
+
+    let persisted: DraftRow | null = null;
+    let noOpWarning: string | null = null;
+
+    if (newId !== null) {
+      const detail = await client.request<{
+        id: number; subject?: string; body?: string;
+        date?: { dateTime: string };
+        replyToId?: number | null;
+        recipients?: Array<{ user: { id: number; name: string }; viewed?: { dateTime: string } | null }>;
+      }>('GET', `/pub/v3/messages/${newId}`);
+
+      persisted = {
+        id: newId,
+        subject: detail.subject ?? args.subject,
+        body: detail.body ?? '',
+        recipients: mapRecipients(detail.recipients),
+        replyToId: detail.replyToId ?? resolvedReplyTo,
+        modifiedAt: detail.date?.dateTime ?? new Date().toISOString(),
+        listData: detail,
       };
-      upsertDraft(draft);
+      upsertDraft(persisted);
+
+      // If this was an update (messageId provided) and OFW's reported body
+      // doesn't match what we asked it to save, the server silently
+      // dropped the change. Warn the caller so the model can take the
+      // create-then-delete fallback.
+      if (args.messageId !== undefined && persisted.body !== args.body) {
+        noOpWarning = 'WARNING: OFW reported success but the draft body it returned does not match the requested update. The OFW POST /pub/v3/messages endpoint can silently no-op on subsequent updates to the same draft. Workaround: delete this draft (ofw_delete_draft) and create a new one (ofw_save_draft without messageId).';
+      }
     }
 
-    const text = data ? JSON.stringify(data, null, 2) : 'Draft saved.';
-    return textResponse(rewriteNote ? `${rewriteNote}\n\n${text}` : text);
+    const responseObj = persisted ?? data;
+    const text = responseObj ? JSON.stringify(responseObj, null, 2) : 'Draft saved.';
+    const notes = [rewriteNote, noOpWarning].filter((n): n is string => n !== null).join('\n\n');
+    return textResponse(notes ? `${notes}\n\n${text}` : text);
   });
 
   server.registerTool('ofw_delete_draft', {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -266,6 +266,98 @@ describe('OFWClient', () => {
     expect(h['ofw-client']).toBe('WebApplication');
     expect(h['ofw-version']).toBe('1.0.0');
   });
+
+  describe('OFW_DEBUG_LOG', () => {
+    let originalDebug: string | undefined;
+    let errSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      originalDebug = process.env.OFW_DEBUG_LOG;
+      process.env.OFW_DEBUG_LOG = '1';
+      errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      if (originalDebug === undefined) delete process.env.OFW_DEBUG_LOG;
+      else process.env.OFW_DEBUG_LOG = originalDebug;
+    });
+
+    it('logs request method/url/headers/body and response status+body when enabled', async () => {
+      mockFetch([
+        LOGIN_INIT,
+        LOGIN_SUCCESS,
+        { status: 200, body: { ok: true } },
+      ]);
+      const client = new OFWClient();
+      await client.request('POST', '/pub/v3/messages', { foo: 'bar' });
+
+      const lines = errSpy.mock.calls.map((c) => String(c[0]));
+      const debugLines = lines.filter((l) => l.startsWith('[ofw-debug]'));
+      expect(debugLines.some((l) => l.includes('→ POST'))).toBe(true);
+      expect(debugLines.some((l) => l.includes('"foo":"bar"'))).toBe(true);
+      // Authorization header is redacted (only the prefix is logged).
+      expect(debugLines.some((l) => l.includes('"Authorization":"Bearer ') && l.includes('…"'))).toBe(true);
+      expect(debugLines.some((l) => l.includes('← 200'))).toBe(true);
+      expect(debugLines.some((l) => l.includes('response body:'))).toBe(true);
+    });
+
+    it('logs FormData payloads as a key summary, not the full multipart contents', async () => {
+      mockFetch([
+        LOGIN_INIT,
+        LOGIN_SUCCESS,
+        { status: 200, body: {} },
+      ]);
+      const form = new FormData();
+      form.append('messageIds', '42');
+      form.append('messageIds', '43');
+      const client = new OFWClient();
+      await client.request('DELETE', '/pub/v1/messages', form);
+
+      const lines = errSpy.mock.calls.map((c) => String(c[0]));
+      expect(lines.some((l) => l.includes('<FormData entries=messageIds,messageIds>'))).toBe(true);
+    });
+
+    it('logs <none> for a bodyless request', async () => {
+      mockFetch([
+        LOGIN_INIT,
+        LOGIN_SUCCESS,
+        { status: 200, body: {} },
+      ]);
+      const client = new OFWClient();
+      await client.request('GET', '/pub/v1/test');
+
+      const lines = errSpy.mock.calls.map((c) => String(c[0]));
+      expect(lines.some((l) => l.includes('body: <none>'))).toBe(true);
+    });
+
+    it('marks retried requests in the log', async () => {
+      mockFetch([
+        LOGIN_INIT,
+        LOGIN_SUCCESS,
+        { status: 401, body: {} },
+        LOGIN_INIT,
+        LOGIN_SUCCESS,
+        { status: 200, body: { ok: true } },
+      ]);
+      const client = new OFWClient();
+      await client.request('GET', '/pub/v1/test');
+      const lines = errSpy.mock.calls.map((c) => String(c[0]));
+      expect(lines.some((l) => l.includes('(retry)'))).toBe(true);
+    });
+
+    it('logs <empty> when response body is empty', async () => {
+      mockFetch([
+        LOGIN_INIT,
+        LOGIN_SUCCESS,
+        { status: 200, body: '' },
+      ]);
+      const client = new OFWClient();
+      await client.request('GET', '/pub/v1/test');
+      const lines = errSpy.mock.calls.map((c) => String(c[0]));
+      // mockFetch JSON.stringifies undefined-ish body to '""'; force an explicit empty.
+      expect(lines.some((l) => l.startsWith('[ofw-debug] response body:'))).toBe(true);
+    });
+  });
 });
 
 describe('OFWClient.requestBinary', () => {

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -414,7 +414,28 @@ describe('syncDrafts', () => {
     expect(getDraft(1)?.modifiedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
-  it('skips refetching a draft whose modifiedAt is unchanged', async () => {
+  it('always refetches detail even when the list modifiedAt is unchanged (OFW list date.dateTime does not reflect UI edits)', async () => {
+    upsertDraft({
+      id: 1, subject: 'Same', body: 'stale-body',
+      recipients: [], replyToId: null,
+      modifiedAt: '2026-05-04T00:00:00Z', listData: {},
+    });
+
+    const client = new OFWClient();
+    const spy = vi.spyOn(client, 'request')
+      .mockResolvedValueOnce(draftListResponse([{ id: 1, subject: 'Same', modifiedAt: '2026-05-04T00:00:00Z' }]))
+      .mockResolvedValueOnce({ body: 'fresh-body', subject: 'Same', recipientIds: [] });
+
+    const result = await syncDrafts(client, '333');
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.mock.calls[1]).toEqual(['GET', '/pub/v3/messages/1']);
+    expect(getDraft(1)?.body).toBe('fresh-body');
+    // synced counts as 1 because the body actually changed
+    expect(result.synced).toBe(1);
+  });
+
+  it('does not count unchanged drafts toward synced even though it refetches them', async () => {
     upsertDraft({
       id: 1, subject: 'Same', body: 'same-body',
       recipients: [], replyToId: null,
@@ -422,13 +443,12 @@ describe('syncDrafts', () => {
     });
 
     const client = new OFWClient();
-    const spy = vi.spyOn(client, 'request')
-      .mockResolvedValueOnce(draftListResponse([{ id: 1, subject: 'Same', modifiedAt: '2026-05-04T00:00:00Z' }]));
+    vi.spyOn(client, 'request')
+      .mockResolvedValueOnce(draftListResponse([{ id: 1, subject: 'Same', modifiedAt: '2026-05-04T00:00:00Z' }]))
+      .mockResolvedValueOnce({ body: 'same-body', subject: 'Same', recipientIds: [] });
 
-    await syncDrafts(client, '333');
-
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(getDraft(1)?.body).toBe('same-body');
+    const result = await syncDrafts(client, '333');
+    expect(result.synced).toBe(0);
   });
 });
 

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -275,9 +275,33 @@ describe('ofw_get_message (cache-first)', () => {
   });
 });
 
+// Helper: real OFW POST /pub/v3/messages returns a minimal `{entityId}`; the
+// follow-up GET is what actually populates the cache. Most send_message tests
+// just need a generic detail response to chain after the POST mock.
+function sendMessageMocks(client: OFWClient, opts: {
+  entityId: number;
+  detail?: Partial<{
+    subject: string; body: string;
+    date: { dateTime: string }; from: { name: string };
+    recipients: Array<{ user: { id: number; name: string }; viewed?: { dateTime: string } | null }>;
+  }>;
+}) {
+  return vi.spyOn(client, 'request')
+    .mockResolvedValueOnce({ entityId: opts.entityId })
+    .mockResolvedValueOnce({
+      id: opts.entityId,
+      subject: opts.detail?.subject ?? 'subject',
+      body: opts.detail?.body ?? 'body',
+      date: opts.detail?.date ?? { dateTime: '2026-05-04T00:00:00Z' },
+      from: opts.detail?.from ?? { name: 'Me' },
+      recipients: opts.detail?.recipients ?? [],
+    });
+}
+
 describe('ofw_send_message', () => {
   it('posts to /pub/v3/messages with correct payload', async () => {
-    const client = makeClient({ id: 200, status: 'sent' });
+    const client = new OFWClient();
+    const spy = sendMessageMocks(client, { entityId: 200 });
     setup(client);
 
     const result = await handlers.get('ofw_send_message')!({
@@ -286,7 +310,7 @@ describe('ofw_send_message', () => {
       recipientIds: [123],
     });
 
-    expect(client.request).toHaveBeenCalledWith('POST', '/pub/v3/messages', {
+    expect(spy).toHaveBeenCalledWith('POST', '/pub/v3/messages', {
       subject: 'Re: pickup',
       body: 'I will be there at 3pm',
       recipientIds: [123],
@@ -295,12 +319,16 @@ describe('ofw_send_message', () => {
       includeOriginal: false,
       replyToId: null,
     });
+    // After POST, we GET to populate the cache from authoritative state.
+    expect(spy).toHaveBeenCalledWith('GET', '/pub/v3/messages/200');
+    expect(getMessage(200)?.folder).toBe('sent');
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe('text');
   });
 
   it('does not delete a draft when draftId is not provided', async () => {
-    const client = makeClient({ id: 200, status: 'sent' });
+    const client = new OFWClient();
+    const spy = sendMessageMocks(client, { entityId: 200 });
     setup(client);
 
     await handlers.get('ofw_send_message')!({
@@ -309,12 +337,14 @@ describe('ofw_send_message', () => {
       recipientIds: [123],
     });
 
-    expect(client.request).toHaveBeenCalledTimes(1);
-    expect(client.request).not.toHaveBeenCalledWith('DELETE', expect.anything(), expect.anything());
+    // POST + GET, no DELETE.
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).not.toHaveBeenCalledWith('DELETE', expect.anything(), expect.anything());
   });
 
   it('sends reply with replyToId and includeOriginal true to thread message history', async () => {
-    const client = makeClient({ id: 201, status: 'sent' });
+    const client = new OFWClient();
+    const spy = sendMessageMocks(client, { entityId: 201 });
     setup(client);
 
     await handlers.get('ofw_send_message')!({
@@ -324,7 +354,7 @@ describe('ofw_send_message', () => {
       replyToId: 55,
     });
 
-    expect(client.request).toHaveBeenCalledWith('POST', '/pub/v3/messages', {
+    expect(spy).toHaveBeenCalledWith('POST', '/pub/v3/messages', {
       subject: 'Re: pickup',
       body: 'I will be there at 3pm',
       recipientIds: [123],
@@ -338,7 +368,11 @@ describe('ofw_send_message', () => {
   it('deletes the draft after sending when draftId is provided', async () => {
     const c = new OFWClient();
     const spy = vi.spyOn(c, 'request')
-      .mockResolvedValueOnce({ id: 200, status: 'sent' })
+      .mockResolvedValueOnce({ entityId: 200 })
+      .mockResolvedValueOnce({
+        id: 200, subject: 'Hello', body: 'World',
+        date: { dateTime: '2026-05-04T00:00:00Z' }, from: { name: 'Me' }, recipients: [],
+      })
       .mockResolvedValueOnce({});
 
     const localHandlers = setupWithClient(c);
@@ -350,7 +384,8 @@ describe('ofw_send_message', () => {
       draftId: 42,
     });
 
-    expect(spy).toHaveBeenCalledTimes(2);
+    // POST + GET + DELETE
+    expect(spy).toHaveBeenCalledTimes(3);
     expect(spy).toHaveBeenNthCalledWith(1, 'POST', '/pub/v3/messages', {
       subject: 'Hello',
       body: 'World',
@@ -360,8 +395,9 @@ describe('ofw_send_message', () => {
       includeOriginal: false,
       replyToId: null,
     });
-    expect(spy).toHaveBeenNthCalledWith(2, 'DELETE', '/pub/v1/messages', expect.any(FormData));
-    const deleteForm = spy.mock.calls[1][2] as FormData;
+    expect(spy).toHaveBeenNthCalledWith(2, 'GET', '/pub/v3/messages/200');
+    expect(spy).toHaveBeenNthCalledWith(3, 'DELETE', '/pub/v1/messages', expect.any(FormData));
+    const deleteForm = spy.mock.calls[2][2] as FormData;
     expect(deleteForm.get('messageIds')).toBe('42');
     expect(result.content[0].text).toContain('"id": 200');
   });
@@ -382,11 +418,13 @@ describe('ofw_send_message (thread-tip + cache write)', () => {
     });
 
     const client = new OFWClient();
-    const spy = vi.spyOn(client, 'request').mockResolvedValueOnce({
-      id: 200, subject: 'Re: Original', body: 'second reply',
-      date: { dateTime: '2026-05-03T00:00:00Z' }, from: { name: 'Me' },
-      recipients: [{ user: { id: 1, name: 'Alice' }, viewed: null }],
-    });
+    const spy = vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ entityId: 200 })
+      .mockResolvedValueOnce({
+        id: 200, subject: 'Re: Original', body: 'second reply',
+        date: { dateTime: '2026-05-03T00:00:00Z' }, from: { name: 'Me' },
+        recipients: [{ user: { id: 1, name: 'Alice' }, viewed: null }],
+      });
     setup(client);
 
     const result = await handlers.get('ofw_send_message')!({
@@ -405,6 +443,7 @@ describe('ofw_send_message (thread-tip + cache write)', () => {
     expect(newRow?.chainRootId).toBe(100);
     expect(newRow?.replyToId).toBe(142);
     expect(newRow?.folder).toBe('sent');
+    expect(newRow?.body).toBe('second reply');
   });
 
   it('does not rewrite when replyToId is the chain tip', async () => {
@@ -415,10 +454,12 @@ describe('ofw_send_message (thread-tip + cache write)', () => {
     });
 
     const client = new OFWClient();
-    const spy = vi.spyOn(client, 'request').mockResolvedValueOnce({
-      id: 200, subject: 'Re: Original', body: 'reply',
-      date: { dateTime: '2026-05-03T00:00:00Z' }, from: { name: 'Me' }, recipients: [],
-    });
+    const spy = vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ entityId: 200 })
+      .mockResolvedValueOnce({
+        id: 200, subject: 'Re: Original', body: 'reply',
+        date: { dateTime: '2026-05-03T00:00:00Z' }, from: { name: 'Me' }, recipients: [],
+      });
     setup(client);
 
     const result = await handlers.get('ofw_send_message')!({
@@ -432,10 +473,12 @@ describe('ofw_send_message (thread-tip + cache write)', () => {
 
   it('passes through replyToId unchanged when parent not in cache', async () => {
     const client = new OFWClient();
-    const spy = vi.spyOn(client, 'request').mockResolvedValueOnce({
-      id: 200, subject: 'Re: Unknown', body: 'reply',
-      date: { dateTime: '2026-05-03T00:00:00Z' }, from: { name: 'Me' }, recipients: [],
-    });
+    const spy = vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ entityId: 200 })
+      .mockResolvedValueOnce({
+        id: 200, subject: 'Re: Unknown', body: 'reply',
+        date: { dateTime: '2026-05-03T00:00:00Z' }, from: { name: 'Me' }, recipients: [],
+      });
     setup(client);
 
     await handlers.get('ofw_send_message')!({
@@ -449,6 +492,7 @@ describe('ofw_send_message (thread-tip + cache write)', () => {
   it('removes draft from cache when draftId is provided', async () => {
     const client = new OFWClient();
     vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ entityId: 200 })
       .mockResolvedValueOnce({
         id: 200, subject: 'Re', body: 'b', date: { dateTime: '2026-05-03T00:00:00Z' },
         from: { name: 'Me' }, recipients: [],
@@ -466,6 +510,28 @@ describe('ofw_send_message (thread-tip + cache write)', () => {
     });
 
     expect(getDraft(50)).toBeNull();
+  });
+
+  it('falls back to data.id when OFW returns the legacy {id} shape on the POST response', async () => {
+    const client = new OFWClient();
+    vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ id: 200 })
+      .mockResolvedValueOnce({
+        id: 200, subject: 's', body: 'b',
+        date: { dateTime: '2026-05-03T00:00:00Z' }, from: { name: 'Me' }, recipients: [],
+      });
+    setup(client);
+    await handlers.get('ofw_send_message')!({ subject: 's', body: 'b', recipientIds: [1] });
+    expect(getMessage(200)?.folder).toBe('sent');
+  });
+
+  it('does not refetch or write cache when POST returns neither id nor entityId', async () => {
+    const client = new OFWClient();
+    const spy = vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ error: 'boom' });
+    setup(client);
+    await handlers.get('ofw_send_message')!({ subject: 's', body: 'b', recipientIds: [1] });
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -537,7 +603,7 @@ describe('ofw_save_draft', () => {
 });
 
 describe('ofw_save_draft (thread-tip + cache upsert)', () => {
-  it('rewrites replyToId to the chain tip and upserts cache', async () => {
+  it('rewrites replyToId to the chain tip and upserts cache from GET detail (not from POST response)', async () => {
     upsertMessage({
       id: 100, folder: 'inbox', subject: 'Original', fromUser: 'Alice',
       sentAt: '2026-05-01T00:00:00Z', recipients: [], body: 'orig',
@@ -550,11 +616,15 @@ describe('ofw_save_draft (thread-tip + cache upsert)', () => {
     });
 
     const client = new OFWClient();
-    const spy = vi.spyOn(client, 'request').mockResolvedValueOnce({
-      id: 50, subject: 'Re: Original', body: 'draft body',
-      date: { dateTime: '2026-05-04T00:00:00Z' },
-      replyToId: 142,
-    });
+    // OFW's real POST shape is minimal (`{entityId: X}`); the body comes
+    // from the follow-up GET on the detail endpoint.
+    const spy = vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ entityId: 50 })
+      .mockResolvedValueOnce({
+        id: 50, subject: 'Re: Original', body: 'draft body',
+        date: { dateTime: '2026-05-04T00:00:00Z' },
+        replyToId: 142,
+      });
     setup(client);
 
     const result = await handlers.get('ofw_save_draft')!({
@@ -565,6 +635,7 @@ describe('ofw_save_draft (thread-tip + cache upsert)', () => {
 
     const postCall = spy.mock.calls.find((c) => c[0] === 'POST');
     expect((postCall![2] as { replyToId: number | null }).replyToId).toBe(142);
+    expect(spy.mock.calls[1]).toEqual(['GET', '/pub/v3/messages/50']);
     expect(result.content[0].text).toMatch(/replyToId rewritten from 100 to 142/);
 
     expect(getDraft(50)?.body).toBe('draft body');
@@ -573,15 +644,72 @@ describe('ofw_save_draft (thread-tip + cache upsert)', () => {
 
   it('passes through replyToId unchanged when nothing to rewrite', async () => {
     const client = new OFWClient();
-    const spy = vi.spyOn(client, 'request').mockResolvedValueOnce({
-      id: 50, subject: 'New', body: 'b',
-      date: { dateTime: '2026-05-04T00:00:00Z' },
-    });
+    const spy = vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ entityId: 50 })
+      .mockResolvedValueOnce({
+        id: 50, subject: 'New', body: 'b',
+        date: { dateTime: '2026-05-04T00:00:00Z' },
+      });
     setup(client);
     await handlers.get('ofw_save_draft')!({ subject: 'New', body: 'b' });
     const postCall = spy.mock.calls.find((c) => c[0] === 'POST');
     expect((postCall![2] as { replyToId: number | null }).replyToId).toBeNull();
     expect(getDraft(50)?.body).toBe('b');
+  });
+
+  it('falls back to data.id when OFW returns the legacy {id} shape instead of {entityId}', async () => {
+    const client = new OFWClient();
+    vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ id: 77 })
+      .mockResolvedValueOnce({
+        id: 77, subject: 'Legacy', body: 'legacy body',
+        date: { dateTime: '2026-05-04T00:00:00Z' },
+      });
+    setup(client);
+    await handlers.get('ofw_save_draft')!({ subject: 'Legacy', body: 'legacy body' });
+    expect(getDraft(77)?.body).toBe('legacy body');
+  });
+
+  it('emits a no-op warning when updating a draft and OFW returns a body that does not match the requested body', async () => {
+    const client = new OFWClient();
+    vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ entityId: 60 })
+      // Server returned the OLD body — the update silently no-opped.
+      .mockResolvedValueOnce({
+        id: 60, subject: 'Weekly', body: 'old-body',
+        date: { dateTime: '2026-05-04T00:00:00Z' },
+      });
+    setup(client);
+    const result = await handlers.get('ofw_save_draft')!({
+      subject: 'Weekly',
+      body: 'new-body',
+      messageId: 60,
+    });
+    expect(result.content[0].text).toMatch(/silently no-op/);
+    expect(result.content[0].text).toMatch(/ofw_delete_draft/);
+    // Cache reflects what OFW actually has, not what we asked for.
+    expect(getDraft(60)?.body).toBe('old-body');
+  });
+
+  it('does not emit the no-op warning on a brand-new draft (no messageId), even if the server body would not match', async () => {
+    const client = new OFWClient();
+    vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ entityId: 70 })
+      .mockResolvedValueOnce({ id: 70, subject: 'X', body: 'munged body' });
+    setup(client);
+    const result = await handlers.get('ofw_save_draft')!({
+      subject: 'X', body: 'sent body',
+    });
+    expect(result.content[0].text).not.toMatch(/silently no-op/);
+  });
+
+  it('does not refetch when OFW returns a non-2xx error response shape (no id and no entityId)', async () => {
+    const client = new OFWClient();
+    const spy = vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ error: 'something went wrong' });
+    setup(client);
+    await handlers.get('ofw_save_draft')!({ subject: 'X', body: 'y' });
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -745,10 +873,12 @@ describe('ofw_upload_attachment', () => {
 describe('ofw_send_message with attachments', () => {
   it('passes myFileIDs through to the OFW payload', async () => {
     const client = new OFWClient();
-    const spy = vi.spyOn(client, 'request').mockResolvedValueOnce({
-      id: 200, subject: 'with attach', body: 'see attached',
-      date: { dateTime: '2026-05-14T00:00:00Z' }, from: { name: 'Me' }, recipients: [],
-    });
+    const spy = vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ entityId: 200 })
+      .mockResolvedValueOnce({
+        id: 200, subject: 'with attach', body: 'see attached',
+        date: { dateTime: '2026-05-14T00:00:00Z' }, from: { name: 'Me' }, recipients: [],
+      });
     setup(client);
     await handlers.get('ofw_send_message')!({
       subject: 'with attach', body: 'see attached', recipientIds: [1],
@@ -758,17 +888,19 @@ describe('ofw_send_message with attachments', () => {
     expect((post![2] as { attachments: { myFileIDs: number[] } }).attachments.myFileIDs).toEqual([50015547, 99887766]);
   });
 
-  it('links attachment cache rows to the new sent message', async () => {
+  it('links attachment cache rows to the new sent message (using the id from the GET, not POST)', async () => {
     // Pre-cache the attachment metadata as if it had been uploaded earlier
     upsertAttachmentForMessage({
       fileId: 50015547, fileName: 'doc.pdf', label: 'doc', mimeType: 'application/pdf',
       sizeBytes: 1024, metadata: {}, messageId: 0,
     });
     const client = new OFWClient();
-    vi.spyOn(client, 'request').mockResolvedValueOnce({
-      id: 200, subject: 'x', body: 'y',
-      date: { dateTime: '2026-05-14T00:00:00Z' }, from: { name: 'Me' }, recipients: [],
-    });
+    vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ entityId: 200 })
+      .mockResolvedValueOnce({
+        id: 200, subject: 'x', body: 'y',
+        date: { dateTime: '2026-05-14T00:00:00Z' }, from: { name: 'Me' }, recipients: [],
+      });
     setup(client);
     await handlers.get('ofw_send_message')!({
       subject: 'x', body: 'y', recipientIds: [1], myFileIDs: [50015547],


### PR DESCRIPTION
## Summary

Three related bug fixes around drafts and sent messages, all rooted in OFW returning `{entityId: <id>}` for `POST /pub/v3/messages` while our handlers keyed cache writes on `data.id`:

- **`ofw_save_draft`**: cache write-through was dead code in production — the local cache never reflected what was saved until `ofw_sync_messages` ran. Worse, OFW silently no-ops on subsequent updates to the same draft (the user's repro: Call A updates body to bodyA ✓, Call B with bodyB returns success-shaped but doesn't actually change the body). The handler now extracts the id from `data.id ?? data.entityId`, GETs `/pub/v3/messages/{id}` to populate the cache from authoritative state, and emits a `WARNING` note when an update's persisted body diverges from the requested body (with create-then-delete workaround).
- **`ofw_send_message`**: same write-through bug — sent-row upsert and attachment linking by `data.id` never fired. Less visible because the next sync picks the row up, but during the window between send and sync the model couldn't see the sent message and attachments uploaded in the same call were never linked to the new id. Same fix shape.
- **`syncDrafts`**: was skipping body refetch when the list endpoint's `date.dateTime` matched the cached `modifiedAt`. OFW does not bump that timestamp on draft edits (UI or API), so direct UI edits never made it into the cache — even with `deep: true`. Now always fetches detail; the `synced` counter changes from "drafts seen" to "drafts whose content actually changed" so the existing semantic is preserved.

Also adds `OFW_DEBUG_LOG=1` verbose request/response logging in `OFWClient` (Authorization redacted) for future OFW API surprises.

## Why

The `{entityId}` vs `{id}` mismatch was hidden because the test suite at `tests/tools/messages.test.ts` mocked the OFW POST response as `{entityId: 42}` (the real shape) but the handler code branched on `typeof data.id === 'number'` — so the cache-write code was structurally dead but the tests still passed because they only asserted the outbound POST payload, never cache state. The thread-tip + cache upsert tests *did* exercise the cache-write path, but with a `{id: 50, …}` mock that doesn't occur in production. Switching the tests to the real shape + asserting cache outcomes locked in the actual contract.

## What a reviewer should know

- `ofw_save_draft` and `ofw_send_message` now make 2 OFW round trips per call (POST + GET) instead of 1. This is the only correctness path that handles OFW's minimal POST response.
- `syncDrafts` makes N+1 OFW round trips (list + detail per draft) instead of 1+changed. Drafts are typically a small set (<10), so the cost is negligible.
- `OFW_DEBUG_LOG` is off by default and intended for opt-in debugging. Authorization header is truncated in the log.
- The `WARNING:` note in `ofw_save_draft` only fires on updates (when `messageId` is set) and when `detail.body !== args.body`. There may be false positives if OFW server-side mungers transform the body (HTML escaping, whitespace) — soften if it gets noisy in practice.

## Test plan

- [x] `npm test` — 217 passing (was 205; +12 new: 5 debug-log, 2 syncDrafts coverage shifts, 5 save_draft no-op/legacy/error/new-draft cases, 2 send_message no-id/legacy-id cases)
- [x] `npm run build` clean (tsc + esbuild bundle)
- [ ] User reruns the live repro with `OFW_DEBUG_LOG=1` to confirm the GET refetch surfaces OFW's silent no-op via the WARNING note, and the UI-edit case is picked up by `ofw_sync_messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)