### PR TITLE
ci: source-aware PR handling (owner / human / dependabot)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,18 +1,27 @@
 name: Auto-merge PRs
 
-# Arm auto-merge on every non-draft PR from the repo owner or dependabot.
-# The actual merge still waits for branch protection's required status
-# check, so this is "merge as soon as CI is green," not "merge without
+# Source-aware auto-merge:
+#
+#  - dependabot[bot] PRs: arm `--auto --merge` as soon as the PR is non-
+#    draft. Merges as soon as CI is green; no review gating.
+#  - owner PRs: arm `--auto --merge` when the owner adds the `ready-to-
+#    merge` label. That label is the owner's deliberate "I've read the
+#    @claude comment and the Copilot review and I'm satisfied" signal.
+#  - everyone else (other humans, forks): never auto-armed. The owner
+#    merges those by hand after reviewing.
+#
+# The merge still waits for branch protection's required status check
+# (`ci`), so this is "merge as soon as CI is green," not "merge without
 # CI."
 #
 # pull_request_target is used (not pull_request) so dependabot PRs can
-# also enable auto-merge — dependabot's pull_request token is restricted.
-# Safe because we never check out or execute PR code; we only call the
-# GitHub API via the gh CLI.
+# arm — dependabot's pull_request token is restricted. Safe because we
+# never check out or execute PR code; we only call the GitHub API via
+# the gh CLI.
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [opened, reopened, ready_for_review, synchronize, labeled]
 
 permissions:
   contents: write
@@ -20,17 +29,34 @@ permissions:
 
 concurrency:
   group: auto-merge-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  enable-auto-merge:
+  arm-dependabot:
+    runs-on: ubuntu-latest
+    # Fire on the lifecycle events but NOT on `labeled` — that's the
+    # owner-PR path. Without this guard, adding any label to a
+    # dependabot PR would re-arm (harmless but noisy).
+    if: |
+      github.event.action != 'labeled' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Arm auto-merge for dependabot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --merge "$PR_URL"
+
+  arm-owner-on-ready-label:
     runs-on: ubuntu-latest
     if: |
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'ready-to-merge' &&
       github.event.pull_request.draft == false &&
-      (github.event.pull_request.user.login == github.repository_owner ||
-       github.event.pull_request.user.login == 'dependabot[bot]')
+      github.event.pull_request.user.login == github.repository_owner
     steps:
-      - name: Enable auto-merge via gh
+      - name: Arm auto-merge after owner adds ready-to-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -1,13 +1,15 @@
 name: PR auto-review
 
-# On every non-draft PR from the repo owner, apply the `auto-review` label
-# and trigger automated review from Claude (via @claude mention) and from
-# GitHub Copilot (via the reviewer-request API).
+# On every non-draft PR from a human (owner OR other collaborators), apply
+# the `auto-review` label and trigger automated review from Claude (via
+# @claude mention) and from GitHub Copilot (via the reviewer-request API).
 #
-# Mirrors auto-merge.yml's scope: owner PRs only, so dependabot/renovate
-# PRs aren't pinged. pull_request_target is used (not pull_request) so the
-# workflow has write permissions on the repo even when a future fork PR
-# slips through — we never check out PR code, only call the API.
+# Bot-authored PRs (dependabot/renovate/etc.) are skipped — those go
+# straight to CI + auto-merge without per-PR review noise.
+#
+# pull_request_target is used (not pull_request) so the workflow has
+# write permissions on the repo even when a future fork PR slips
+# through — we never check out PR code, only call the API.
 
 on:
   pull_request_target:
@@ -27,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.draft == false &&
-      github.event.pull_request.user.login == github.repository_owner
+      github.event.pull_request.user.type == 'User'
     steps:
       - name: Apply auto-review label
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,17 @@ The branch-and-PR shape is required because `main` is protected: direct pushes a
 
 **Default workflow: branch + PR. Direct pushes to `main` are blocked by branch protection** (required status check `ci`, required PR flow, admin enforcement on). The PR mechanism is also the only way release notes get generated — `generate_release_notes` (configured in `.github/release.yml`) picks up merged PRs.
 
-Every owner PR is auto-labeled `auto-review` by `pr-auto-review.yml`, which also posts an `@claude` review comment and requests GitHub Copilot as a reviewer. Reviews are informational — the auto-merge path (`auto-merge.yml`) lands the PR as soon as CI is green, without waiting for review approvals.
+PR handling is **source-aware**:
+
+| PR author              | `auto-review` (label, @claude, Copilot) | Auto-merge                                              |
+|------------------------|------------------------------------------|---------------------------------------------------------|
+| **You (owner)**        | Yes                                      | Only after you add the **`ready-to-merge`** label       |
+| **Other humans**       | Yes                                      | No — you merge manually after reviewing                 |
+| **Dependabot / bots**  | No (skipped to keep noise down)          | Yes, armed immediately; merges when CI is green         |
+
+`pr-auto-review.yml` fires on any PR whose author is type `User` (so it includes both you and any future collaborators). `auto-merge.yml` is split into two jobs: one arms on dependabot PR open, the other arms on owner PRs only when the `ready-to-merge` label is added. Other-human PRs never auto-arm — you decide when to land them.
+
+Workflow for your own PRs: open the PR → it gets auto-labeled and reviewed → skim the `@claude` comment and the Copilot review → add `ready-to-merge` when you're satisfied → CI green → merges. If reviewers flag something, push fixes; CI restarts; once you re-add `ready-to-merge` (if it was dismissed) auto-merge re-arms.
 
 For every PR, apply exactly one label so it lands in the right release-notes section:
 
@@ -137,7 +147,7 @@ For every PR, apply exactly one label so it lands in the right release-notes sec
 
 The **PR title** becomes the bullet — write it like a user-facing changelog entry (`ofw_sync_messages: resume from saved cursor`), not internal shorthand (`sync tweaks`). Conventional-commit prefixes (`feat:`, `fix:`, `chore:`) are still fine in commit messages, but the PR title should read clean.
 
-Open with `gh pr create --label <label>` (or `--label ignore-for-release` for chores not worth a line). `auto-merge.yml` arms `--auto --merge` on every owner / dependabot PR automatically, so you don't need to run `gh pr merge` yourself. The repo allows merge commits only (no squash, no rebase) — if you ever do call `gh pr merge` manually, don't pass `--squash`/`--rebase` or the call will fail.
+Open with `gh pr create --label <label>` (or `--label ignore-for-release` for chores not worth a line). For your own PRs, add `--label ready-to-merge` if you already want it to auto-merge as soon as CI passes — otherwise add the label later through the GitHub UI once you've read the auto-review feedback. Dependabot PRs auto-arm without `ready-to-merge`. The repo allows merge commits only (no squash, no rebase) — if you ever do call `gh pr merge` manually, don't pass `--squash`/`--rebase` or the call will fail.
 
 ## Plugin / Distribution
 


### PR DESCRIPTION
## Summary

Splits PR handling by author so each PR source gets the treatment it actually warrants:

| PR author | `auto-review` (label, @claude, Copilot) | Auto-merge |
|---|---|---|
| **Me (owner)** | Yes | Only after I add `ready-to-merge` |
| **Other humans** | Yes | No — I merge manually |
| **Dependabot / bots** | No | Yes, armed on PR open; merges when CI green |

### What changed

- **`.github/workflows/pr-auto-review.yml`** — trigger condition broadened from `user.login == repository_owner` to `user.type == 'User'`. Now fires on owner PRs *and* any future collaborator PRs, but still skips bot-authored PRs to keep dep-bump noise down.
- **`.github/workflows/auto-merge.yml`** — split into two jobs:
  1. `arm-dependabot` — fires on dependabot PR open/reopen/synchronize/ready-for-review (but not `labeled`, to avoid re-arming when labels are added later). Behavior unchanged.
  2. `arm-owner-on-ready-label` — fires when the owner adds the `ready-to-merge` label to one of their own PRs. That's the deliberate "I've read the @claude comment + Copilot review and I'm satisfied" signal.
- **`ready-to-merge` label** — created in the repo (gold, `#FFD700`) so the workflow's `--add-label` and the manual UI click both work.
- **`CLAUDE.md`** — documents the new source-aware table and the `ready-to-merge` handshake.

### Why a label instead of detecting "review approved"

Two reasons:

1. **Reliability** — Claude's `@claude` action posts a *comment*, not a formal PR review, so a review-event listener wouldn't catch it. Detection would have to be heuristic (e.g. "any `github-actions[bot]` comment on a PR with the `auto-review` label") which is brittle and easy to false-trigger.
2. **Owner control** — the label is a single click in the UI, makes the gate visible/auditable in the PR sidebar, and works the same whether reviews approve, comment, or request changes. You read the reviews, decide if the changes are needed, and either push fixes (CI restarts, re-add the label) or click the label to land.

### Workflow for your own PRs going forward

1. Open PR (with the right release-notes label per CLAUDE.md)
2. `pr-auto-review.yml` adds `auto-review` label, posts `@claude please review`, requests Copilot
3. CI runs; Claude and Copilot post their feedback
4. You skim — if happy, add `ready-to-merge` label (UI click or `gh pr edit … --add-label ready-to-merge`)
5. Auto-merge arms; merges when CI is green

If you want a PR to merge immediately (no review wait), you can add `ready-to-merge` at PR-create time via `gh pr create --label ready-to-merge --label <release-notes-label>`.

## Test plan

- [x] Both workflow YAML files parse (`js-yaml`)
- [x] `ready-to-merge` label exists in the repo
- [ ] First verification: this PR itself — should *not* auto-arm on open. I should add `ready-to-merge` after the reviews come in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)