### PR TITLE
chore: release v2.0.15 (bump main to v2.0.16)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "OurFamilyWizard tools for Claude Code",
-    "version": "2.0.15"
+    "version": "2.0.16"
   },
   "plugins": [
     {
@@ -14,7 +14,7 @@
       "displayName": "OurFamilyWizard",
       "source": "./",
       "description": "OurFamilyWizard co-parenting tools for Claude — messages, calendar, expenses, and journal via MCP",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "author": {
         "name": "Chris Chall"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ofw",
   "displayName": "OurFamilyWizard",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "OurFamilyWizard co-parenting tools for Claude — messages, calendar, expenses, and journal via MCP",
   "author": {
     "name": "Chris Chall"

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.3",
   "name": "ofw-mcp",
   "display_name": "OurFamilyWizard",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "OurFamilyWizard co-parenting tools for Claude — messages, calendar, expenses, and journal",
   "author": {
     "name": "Chris Chall",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ofw-mcp",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ofw-mcp",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "dependencies": {
         "@fetchproxy/bootstrap": "^0.4.2",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ofw-mcp",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "mcpName": "io.github.chrischall/ofw-mcp",
   "description": "OurFamilyWizard MCP server for Claude — developed and maintained by AI (Claude Code)",
   "author": "Claude Code (AI) <https://www.anthropic.com/claude>",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/chrischall/ofw-mcp",
     "source": "github"
   },
-  "version": "2.0.15",
+  "version": "2.0.16",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ofw-mcp",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { registerCalendarTools } from './tools/calendar.js';
 import { registerExpenseTools } from './tools/expenses.js';
 import { registerJournalTools } from './tools/journal.js';
 
-const server = new McpServer({ name: 'ofw', version: '2.0.15' });
+const server = new McpServer({ name: 'ofw', version: '2.0.16' });
 
 registerUserTools(server, client);
 registerMessageTools(server, client);


### PR DESCRIPTION
Releases **v2.0.15** and bumps main to **v2.0.16**.

When this PR merges, [tag-on-release-merge.yml](.github/workflows/tag-on-release-merge.yml)
tags the parent of the merge commit with `v2.0.15` — that's the
content on main *before* this bump, i.e. the released version.
That tag push triggers [release.yml](.github/workflows/release.yml)
which publishes to npm + the MCP Registry + ClawHub and creates
the GitHub Release.

Auto-generated by [Tag & Bump](.github/workflows/tag-and-bump.yml).
Labeled `ignore-for-release` so this PR does not appear in
the v2.0.15 release notes.

> **Note:** opened manually because `RELEASE_PAT` lacks
> `pull_requests:write` — see the follow-up fix in CLAUDE.md / the
> tag-and-bump workflow.