### PR TITLE
ci(tag-and-bump): auto-arm release PR with ready-to-merge

### DIFF
--- a/.github/workflows/tag-and-bump.yml
+++ b/.github/workflows/tag-and-bump.yml
@@ -93,7 +93,7 @@ jobs:
           CURRENT: ${{ steps.versions.outputs.current }}
           NEXT: ${{ steps.versions.outputs.next }}
         run: |
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base main \
             --head "release/v${NEXT}" \
             --label "ignore-for-release" \
@@ -112,4 +112,13 @@ jobs:
           Labeled \`ignore-for-release\` so this PR does not appear in
           the v${CURRENT} release notes.
           EOF
-          )"
+          )")
+          echo "Opened $PR_URL"
+
+          # Follow-up add of `ready-to-merge` so auto-merge.yml arms.
+          # Labels passed to `gh pr create` are bundled into the `opened`
+          # event and DON'T fire a separate `labeled` event — only a
+          # post-create label add does. So this is a deliberate second
+          # call to make `arm-owner-on-ready-label` actually trigger.
+          gh pr edit "$PR_URL" --add-label ready-to-merge
+          echo "Added ready-to-merge to $PR_URL"


### PR DESCRIPTION
Follow `gh pr create` with `gh pr edit --add-label ready-to-merge` on the URL it prints. GitHub doesn't emit a `pull_request: labeled` event for labels passed to `gh pr create` — they're folded into the `opened` payload — so a release PR opened with `--label ready-to-merge` would never trigger `arm-owner-on-ready-label`. The follow-up `gh pr edit` call DOES fire the labeled event, so the next Tag & Bump release auto-merges on CI green without me having to click the label.

This bridges the last manual step in the release loop: trigger Tag & Bump → release PR auto-flows through CI + auto-merge + tag + publish.

## Test plan

- [x] YAML parses
- [ ] After this merges, the next Tag & Bump run should auto-arm and merge with no manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)