### PR TITLE
fix(pr-auto-review): drop id-token:write to fix OIDC 401

### DIFF
--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -35,8 +35,14 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
-  id-token: write
   actions: read
+  # Intentionally NOT granting `id-token: write`. On `pull_request_target`
+  # claude-code-action auto-detects "agent mode" and, if `id-token: write`
+  # is available, attempts an OIDC token exchange against Anthropic's
+  # federation endpoint — which 401s for this repo (no federation rule
+  # configured) and fails the step instead of falling back to
+  # ANTHROPIC_API_KEY. Without `id-token: write` the action proceeds
+  # straight to API-key auth, which is what we want.
 
 concurrency:
   group: pr-auto-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

PR #28's \`review\` job failed with \`App token exchange failed: 401 Unauthorized — Invalid OIDC token\`. Root cause: on \`pull_request_target\` events \`claude-code-action\` auto-detects "agent mode," and when \`id-token: write\` is granted in that mode the action tries to exchange a GitHub OIDC token for an Anthropic app token via the federation endpoint. This repo has no federation rule, so the exchange 401s and the step fails outright — it never falls back to \`ANTHROPIC_API_KEY\` even though one is provided.

The fix is to **not** grant \`id-token: write\` to this workflow. Without that permission the action skips the OIDC attempt and uses API-key auth directly.

\`claude.yml\` keeps \`id-token: write\` and works because it runs on \`issue_comment\`/\`pull_request_review_comment\` events where the action picks "mention mode" and never tries OIDC.

### Self-test caveat

This fix-PR will trigger the *current* (broken) \`pr-auto-review.yml\` from main, so the review step will fail on this PR too. CI will still gate merge. Add \`ready-to-merge\` manually to land it; once merged, subsequent PRs will exercise the fixed flow.

## Test plan

- [ ] Land this PR (manual ready-to-merge override)
- [ ] Open a follow-up trivial PR and verify the review step succeeds (no OIDC 401), Claude posts a comment, verdict is emitted
- [ ] If verdict=pass and same-repo, confirm \`ready-to-merge\` is auto-added and auto-merge arms