### PR TITLE
fix(pr-auto-review): pass github_token to skip OIDC App exchange

### DIFF
--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -36,13 +36,11 @@ permissions:
   pull-requests: write
   issues: write
   actions: read
-  # Intentionally NOT granting `id-token: write`. On `pull_request_target`
-  # claude-code-action auto-detects "agent mode" and, if `id-token: write`
-  # is available, attempts an OIDC token exchange against Anthropic's
-  # federation endpoint — which 401s for this repo (no federation rule
-  # configured) and fails the step instead of falling back to
-  # ANTHROPIC_API_KEY. Without `id-token: write` the action proceeds
-  # straight to API-key auth, which is what we want.
+  # No `id-token: write` — see the `github_token:` override on the
+  # claude-code-action step below. With that override the action skips
+  # the GitHub-App OIDC exchange entirely (which 401s for us because
+  # the `claude[bot]` App is not authorized for our pull_request_target
+  # events), so id-token permission is unnecessary.
 
 concurrency:
   group: pr-auto-review-${{ github.event.pull_request.number }}
@@ -97,6 +95,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Short-circuits setupGitHubToken() in the action so it skips the
+          # OIDC → claude[bot] App-token exchange and uses the supplied
+          # token directly. PR comments will be authored by
+          # `github-actions[bot]`, not `claude[bot]` — content unchanged.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --json-schema '{"type":"object","required":["verdict","summary","important_findings"],"properties":{"verdict":{"enum":["pass","warn","fail"]},"summary":{"type":"string"},"important_findings":{"type":"array","items":{"type":"string"}}}}'
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(cat:*),Bash(rg:*),Bash(jq:*),Bash(ls:*),Bash(find:*),mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## Summary

Supersedes the partial fix in #29. The previous attempt (dropping \`id-token: write\`) only changed the *error message* — the action's \`setupGitHubToken()\` still tries OIDC in agent mode unconditionally; without the perm it just throws "no id-token perm" earlier instead of falling back to API key.

The actual escape hatch is the \`github_token\` input. From [\`anthropics/claude-code-action/src/github/token.ts\`](https://github.com/anthropics/claude-code-action/blob/main/src/github/token.ts):

\`\`\`ts
export async function setupGitHubToken(): Promise<string> {
  const providedToken = process.env.OVERRIDE_GITHUB_TOKEN;
  if (providedToken) {
    console.log("Using provided GITHUB_TOKEN for authentication");
    return providedToken;
  }
  // …else OIDC path…
}
\`\`\`

And from the action's \`action.yml\`: \`OVERRIDE_GITHUB_TOKEN: \${{ inputs.github_token }}\`. So passing \`github_token: \${{ secrets.GITHUB_TOKEN }}\` short-circuits the OIDC → \`claude[bot]\` App-token exchange entirely.

### Tradeoffs

- PR comments authored by \`github-actions[bot]\` instead of \`claude[bot]\`. The comment content (Claude's review) is unchanged; only the GitHub-UI author label differs.
- \`id-token: write\` permission is no longer needed and is not granted.
- Cost: still uses ANTHROPIC_API_KEY, same as before. No additional spend.

### Why this is the latest issue you'd find

After #29 merged, PR #28's review re-ran on \`synchronize\` and failed with \`Could not fetch an OIDC token. Did you remember to add id-token: write?\` — confirming the action requires the OIDC path in agent mode unless explicitly overridden.

## Test plan

- [ ] Land this PR (manual \`ready-to-merge\`, the broken-on-main flow still applies)
- [ ] Open a follow-up trivial PR, observe the review step succeeds: Claude posts a comment as \`github-actions[bot]\`, emits the verdict, and on \`pass\` the workflow adds \`ready-to-merge\`
- [ ] If the run still fails, capture the new log and post-mortem