### PR TITLE
ci(pr-auto-review): use pull_request event with installed Claude App auth

### DIFF
--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -97,6 +97,12 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # No `github_token:` — let the action use the installed Claude
           # App via OIDC so comments are authored by `claude[bot]`.
+          # `track_progress: true` posts a live progress comment as Claude
+          # works (recommended by the action's pr-review-comprehensive.yml
+          # example). In automation mode this is off by default; we enable
+          # it so reviews are visibly "in flight" rather than appearing all
+          # at once at the end.
+          track_progress: true
           claude_args: |
             --json-schema '{"type":"object","required":["verdict","summary","important_findings"],"properties":{"verdict":{"enum":["pass","warn","fail"]},"summary":{"type":"string"},"important_findings":{"type":"array","items":{"type":"string"}}}}'
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(cat:*),Bash(rg:*),Bash(jq:*),Bash(ls:*),Bash(find:*)"

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -1,46 +1,50 @@
 name: PR auto-review
 
-# On every non-draft PR from a human (owner OR other collaborators), this
-# workflow:
+# On every non-draft, same-repo, human-authored PR this workflow:
 #
 #  1. Applies the `auto-review` label.
 #  2. Requests GitHub Copilot as a reviewer (best-effort).
 #  3. Runs claude-code-action with a JSON-schema-bound verdict:
 #       pass | warn | fail
-#     Claude posts findings as a PR comment and emits the verdict to
-#     `structured_output`.
-#  4. On `verdict == pass` AND same-repo (non-fork) PRs, adds the
-#     `ready-to-merge` label using RELEASE_PAT, which arms auto-merge.yml.
-#     `warn` and `fail` never auto-arm — those keep a human in the loop.
-#     Fork PRs are reviewed for advisory value only; the label is not added.
+#     Claude posts findings (as claude[bot] via the installed Claude App)
+#     and emits the verdict to `structured_output`.
+#  4. On `verdict == pass`, adds the `ready-to-merge` label using
+#     RELEASE_PAT, which arms auto-merge.yml. `warn` and `fail` never
+#     auto-arm — those keep a human in the loop.
 #
-# Bot-authored PRs (dependabot/renovate/etc.) are skipped — those go
-# straight to CI + auto-merge without per-PR review noise.
+# Why `pull_request` (not `pull_request_target`):
+# Anthropic's GitHub App OIDC backend has an event-name allowlist that
+# rejects `pull_request_target` (see anthropics/claude-code-action#713),
+# so that trigger would force a `github_token`-override workaround and
+# comments would be authored by `github-actions[bot]` instead of
+# `claude[bot]`. `pull_request` is the documented supported event for
+# automated PR review with the installed App.
 #
-# `pull_request_target` is used (not `pull_request`) so the workflow has
-# write permissions and access to secrets even for collaborator-authored
-# branches in this repo. Claude's tool allowlist is restricted to read-only
-# operations; we never execute PR code from this workflow.
+# Tradeoff: fork PRs cannot be auto-reviewed (`pull_request` from a fork
+# has no access to secrets). For those rare cases, `@claude review this`
+# in a PR comment triggers the existing `claude.yml` flow as a manual
+# fallback.
 #
-# The `ready-to-merge` label MUST be added via RELEASE_PAT, not
-# GITHUB_TOKEN — GitHub suppresses workflow runs for events triggered by
-# GITHUB_TOKEN, so a label added that way would not fire auto-merge.yml's
-# `labeled` event.
+# The `head.repo == github.repository` guard is belt-and-braces: even on
+# `pull_request`, GITHUB_TOKEN is read-only for fork PRs, so the label-
+# add step would fail. The guard skips the entire job cleanly for forks.
+#
+# Bot-authored PRs (dependabot/renovate/etc.) are skipped via the
+# `user.type == 'User'` filter — those go straight to CI + auto-merge.
+#
+# `ready-to-merge` MUST be added via RELEASE_PAT, not GITHUB_TOKEN.
+# GitHub suppresses workflow runs for `GITHUB_TOKEN`-triggered events,
+# so a label added that way would not fire auto-merge.yml.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, ready_for_review, synchronize]
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
-  actions: read
-  # No `id-token: write` — see the `github_token:` override on the
-  # claude-code-action step below. With that override the action skips
-  # the GitHub-App OIDC exchange entirely (which 401s for us because
-  # the `claude[bot]` App is not authorized for our pull_request_target
-  # events), so id-token permission is unnecessary.
+  id-token: write       # Required for the Claude App OIDC token exchange
 
 concurrency:
   group: pr-auto-review-${{ github.event.pull_request.number }}
@@ -51,7 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.draft == false &&
-      github.event.pull_request.user.type == 'User'
+      github.event.pull_request.user.type == 'User' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Apply auto-review label
         env:
@@ -80,35 +85,27 @@ jobs:
             cat /tmp/copilot.err
           fi
 
-      - name: Checkout PR merge ref
+      - name: Checkout PR
         uses: actions/checkout@v6
         with:
-          # The merge ref is what would be on main after merge — good base
-          # for Claude to read. Safe under pull_request_target because we
-          # restrict Claude's tools to read-only below; PR code is never
-          # executed by this workflow.
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Claude review with structured verdict
         id: review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Short-circuits setupGitHubToken() in the action so it skips the
-          # OIDC → claude[bot] App-token exchange and uses the supplied
-          # token directly. PR comments will be authored by
-          # `github-actions[bot]`, not `claude[bot]` — content unchanged.
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # No `github_token:` — let the action use the installed Claude
+          # App via OIDC so comments are authored by `claude[bot]`.
           claude_args: |
             --json-schema '{"type":"object","required":["verdict","summary","important_findings"],"properties":{"verdict":{"enum":["pass","warn","fail"]},"summary":{"type":"string"},"important_findings":{"type":"array","items":{"type":"string"}}}}'
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(cat:*),Bash(rg:*),Bash(jq:*),Bash(ls:*),Bash(find:*),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(cat:*),Bash(rg:*),Bash(jq:*),Bash(ls:*),Bash(find:*)"
           prompt: |
             You are reviewing pull request #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 
             STEPS:
             1. Read CLAUDE.md to learn the project's conventions (versioning rules, ESM `.js` import requirement, testing/coverage requirements, stdio logging rules, etc.).
-            2. Read the PR diff: `gh pr diff ${{ github.event.pull_request.number }}` (or use git/Read on the working tree, which is checked out at the merge ref).
+            2. Read the PR diff: `gh pr diff ${{ github.event.pull_request.number }}` (or read files in the working tree, which is checked out).
             3. Review the changes for:
                - Correctness and edge cases
                - Adherence to CLAUDE.md conventions
@@ -116,12 +113,13 @@ jobs:
                - Security or data-integrity concerns
 
             SEVERITY MODEL (matches the official code-review plugin):
-              🔴 Important — bug, broken behavior, security/data risk, or violation of a CLAUDE.md convention. Confidence must be ≥80 to count.
+              🔴 Important — bug, broken behavior, security/data risk, or violation of a CLAUDE.md convention. Confidence ≥80 to count.
               🟡 Nit       — style, minor improvement, suggestion. Confidence ≥80.
               🟣 Pre-existing — issue already in the codebase, not introduced by this PR. Never blocking.
 
             OUTPUT:
-            - Post ONE top-level PR comment with findings grouped by severity (use `gh pr comment`). If there are no findings worth surfacing, post a short "No issues found — verdict pass" comment.
+            - For line-specific findings, prefer the inline-comment tool (`mcp__github_inline_comment__create_inline_comment`).
+            - Post ONE top-level summary comment with overall judgment (use `gh pr comment`). If there are no findings worth surfacing, post a short "No issues found — verdict pass" comment.
             - Then emit your structured verdict per the JSON schema:
               • `pass` — no 🔴 Important findings.
               • `warn` — no 🔴 Important findings but at least one 🟡 Nit worth surfacing.
@@ -129,7 +127,7 @@ jobs:
               Set `summary` to a 1-2 sentence overall judgment.
               Set `important_findings` to the list of 🔴 Important finding titles (empty array if none).
 
-            DO NOT modify files, push commits, approve the PR formally, or call `gh pr review` / `gh pr edit`. Posting the comment and emitting the verdict is the entire job. The workflow will gate auto-merge based on your verdict.
+            DO NOT modify files, push commits, approve the PR formally, or call `gh pr review` / `gh pr edit`. Posting comments and emitting the verdict is the entire job. The workflow will gate auto-merge based on your verdict.
 
       - name: Surface verdict in run summary
         if: always() && steps.review.outputs.structured_output != ''
@@ -151,15 +149,14 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Arm auto-merge on pass (same-repo PRs only)
+      - name: Arm auto-merge on pass
         if: |
           steps.review.outputs.structured_output != '' &&
-          fromJSON(steps.review.outputs.structured_output).verdict == 'pass' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          fromJSON(steps.review.outputs.structured_output).verdict == 'pass'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
           gh pr edit "$PR" --repo "$REPO" --add-label ready-to-merge
-          echo "Verdict=pass and PR is same-repo — added ready-to-merge to arm auto-merge."
+          echo "Verdict=pass — added ready-to-merge to arm auto-merge."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Main is always one version ahead of the latest tag. Releases are zero-touch — 
 
 The branch-and-PR shape is required because `main` is protected: direct pushes are blocked, `ci` is a required status check, and admin enforcement is on. The release bot has no escape hatch — every change to main goes through a PR.
 
-<!-- pr-workflow:v2 -->
+<!-- pr-workflow:v3 -->
 ## Pull requests & release notes
 
 **Default workflow: branch + PR. Direct pushes to `main` are blocked by branch protection** (required status check `ci`, required PR flow, admin enforcement on). The PR mechanism is also the only way release notes get generated — `generate_release_notes` (configured in `.github/release.yml`) picks up merged PRs.
@@ -124,10 +124,12 @@ PR handling is **source-aware**:
 | PR author                          | `auto-review` (Claude verdict + Copilot) | Auto-merge                                                                                       |
 |------------------------------------|-------------------------------------------|--------------------------------------------------------------------------------------------------|
 | **You / same-repo collaborators**  | Yes                                       | Yes when Claude verdict = `pass` AND CI is green. `warn` / `fail` → manual `ready-to-merge`.     |
-| **External fork PRs**              | Yes (advisory only)                       | No — you merge manually after reviewing                                                          |
+| **External fork PRs**              | No (workflow skips — fork PRs can't see secrets). Manual: `@claude review this` in a comment triggers `claude.yml`. | No — you merge manually after reviewing |
 | **Dependabot / bots**              | No (skipped to keep noise down)           | Yes, armed immediately; merges when CI is green                                                  |
 
-`pr-auto-review.yml` runs `claude-code-action` with a JSON-schema-bound verdict (`pass` / `warn` / `fail`) on every non-draft PR from a `User` actor. Claude posts findings as a PR comment and emits the verdict to `structured_output`; if `verdict == pass` AND the PR is from a same-repo branch (not a fork), the workflow adds `ready-to-merge` via RELEASE_PAT. `auto-merge.yml` then arms `gh pr merge --auto`. Required status check `ci` still gates the actual merge.
+`pr-auto-review.yml` runs `claude-code-action` on `pull_request` events with a JSON-schema-bound verdict (`pass` / `warn` / `fail`). Claude (posting as `claude[bot]` via the installed Claude GitHub App) leaves inline comments on specific lines plus a top-level summary, and emits the verdict to `structured_output`. On `verdict == pass` the workflow adds `ready-to-merge` via RELEASE_PAT and `auto-merge.yml` arms `gh pr merge --auto`. Required status check `ci` still gates the actual merge.
+
+The workflow uses `pull_request` (not `pull_request_target`) because Anthropic's GitHub App OIDC backend doesn't accept `pull_request_target` events (see [anthropics/claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713)). The tradeoff is that fork PRs are skipped entirely — for those, mention `@claude` in a PR comment to invoke the ad-hoc dispatch in `claude.yml`.
 
 Verdict semantics (Claude follows the official `code-review` plugin's severity model with confidence ≥80 to count):
 - `pass` — no 🔴 Important findings.


### PR DESCRIPTION
## Summary

Supersedes the github_token workaround in #30. The previous fix made the action work but traded against the documented happy path. This PR aligns with the official supported pattern.

### Root cause (confirmed)

Per [anthropics/claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713):

> *"GitHub Actions OIDC tokens include an `event_name` claim. The Anthropic backend appears to validate this against an allowlist that doesn't include `pull_request_target`. **Workaround**: Use `pull_request` trigger instead."*

Every example workflow in the action repo uses \`on: pull_request\` (see [\`examples/pr-review-comprehensive.yml\`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml), [\`pr-review-filtered-authors.yml\`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-filtered-authors.yml)).

The FAQ is also explicit:
> *"Why aren't comments posted as claude[bot]? […] if you provide a github_token in your workflow, the action will use that token's authentication instead. **Solution**: Remove github_token from your workflow file."*

### Changes

- \`on: pull_request_target\` → \`on: pull_request\`
- Restored \`id-token: write\` (required for App OIDC token exchange)
- Removed \`github_token\` override → comments authored by \`claude[bot]\` again
- Added \`head.repo.full_name == github.repository\` guard on the review job — fork PRs are skipped cleanly (\`pull_request\` from a fork has no secrets anyway; GITHUB_TOKEN is read-only, so the label-add would fail without the guard)
- Updated prompt to encourage inline comments via \`mcp__github_inline_comment__create_inline_comment\` (already in allowedTools)
- CLAUDE.md \`pr-workflow:v3\` documents the new shape including the fork-PR fallback (\`@claude review this\` in a comment routes through \`claude.yml\`)

### Tradeoff

Fork PRs are no longer auto-reviewed. ofw-mcp has had zero external contributors so far, and the manual \`@claude\` mention path still works via \`claude.yml\`. Worth it for: official supported pattern, \`claude[bot]\` comment identity, \`use_sticky_comment\` will work if we enable it later, no auth workarounds.

### Is this the best we can do?

For the AI-gated review piece: yes, this matches Anthropic's documented happy path. Possible future polish (not in this PR):
- \`track_progress: true\` for a visible progress comment during long reviews
- \`use_sticky_comment: true\` for a single updating comment across re-runs on \`synchronize\`
- Switch from classic branch protection to a ruleset with release bot in bypass actors (eliminates the "admin enforcement off" carve-out — see [GitHub Changelog 2025-11-03](https://github.blog/changelog/2025-11-03-required-review-by-specific-teams-now-available-in-rulesets/))

## Test plan

- [ ] Land this PR (manual \`ready-to-merge\` — the current main still has the broken-path workflow)
- [ ] Open a trivial follow-up PR; observe:
  - [ ] Review step succeeds (no OIDC 401, no Could-not-fetch-OIDC error)
  - [ ] Comments authored by \`claude[bot]\`
  - [ ] On \`pass\`: \`ready-to-merge\` added, auto-merge arms, PR merges on CI green
- [ ] Run \`actionlint\` (already clean locally)