### PR TITLE
ci(pr-auto-review): exempt release-please PRs (staging-PR model)

### DIFF
--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -32,6 +32,11 @@ name: PR auto-review
 # Bot-authored PRs (dependabot/renovate/etc.) are skipped via the
 # `user.type == 'User'` filter — those go straight to CI + auto-merge.
 #
+# Release-please PRs are skipped via the `autorelease: pending` label
+# filter so they stay open as long-lived staging artifacts. release-
+# please updates the same PR as more fix:/feat: commits land; you add
+# `ready-to-merge` manually when you decide it's time to ship a batch.
+#
 # `ready-to-merge` MUST be added via RELEASE_PAT, not GITHUB_TOKEN.
 # GitHub suppresses workflow runs for `GITHUB_TOKEN`-triggered events,
 # so a label added that way would not fire auto-merge.yml.
@@ -61,6 +66,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.type == 'User' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') &&
       (github.event.action != 'labeled' || github.event.label.name == 'review-with-opus')
     steps:
       - name: Apply auto-review label


### PR DESCRIPTION
Move from B (continuous deployment: every fix ships immediately) to A (staging PR: release-please's release PR sits open while you accumulate work, merge when ready).

Adds `!contains(labels, 'autorelease: pending')` to pr-auto-review.yml's job filter. release-please applies that label to its release PRs; the filter keeps them out of Claude's auto-review path so they no longer get auto-`ready-to-merge`d.

After this lands:
- `fix:` PR merges → release-please opens release PR with the proposed v2.0.18 → **release PR sits open, CI passed, no `ready-to-merge`**
- More `fix:`/`feat:` PRs merge → release-please updates the SAME PR
- When you decide to ship: add `ready-to-merge` manually → auto-merge.yml arms → publish

Forcing immediate release for an urgent fix: add `ready-to-merge` to the release PR right when release-please opens it.