### PR TITLE
docs(claude-md): call out 100-char limit on server.json description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,16 @@ npm test           # vitest run
 
 `vitest.config.ts` enforces 100% line/branch/function/statement coverage on `src/**` (excluding `src/index.ts`, the stdio entry point). Failing coverage fails CI. No real API calls — `OFWClient.request` is mocked via `vi.spyOn`.
 
+## Publishing constraints
+
+The MCP Registry's [server.schema.json](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json) caps `server.json`'s `description` at **100 characters**. Values over that fail `mcp-publisher publish` with HTTP 422 (`validation failed: expected length <= 100, location: body.description`). The other description fields (`manifest.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`) have no published length constraint and can stay longer.
+
+Sanity-check before committing a description change:
+
+```bash
+jq -r '.description | length' server.json
+```
+
 ## Versioning
 
 Driven by **release-please** (`googleapis/release-please-action@v4`). Authoritative state lives in `.release-please-manifest.json`; release-please bumps every file registered in `release-please-config.json`'s `extra-files`:


### PR DESCRIPTION
## Summary

The MCP Registry's [server.schema.json](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json) caps \`server.json\`'s \`description\` at **100 characters**. Over-limit values fail \`mcp-publisher publish\` with HTTP 422 (\`validation failed: expected length <= 100, location: body.description\`).

\`zillow-mcp\` v0.2.0 [hit this](https://github.com/chrischall/zillow-mcp/actions/runs/26343025086/job/77548243671) — npm got the package but the MCP Registry rejected it, which then gated ClawHub publish and artifact attachment. Adding a callout to \`CLAUDE.md\` (right before \`## Versioning\`) with a \`jq\` sanity-check so this repo doesn't repeat the same mistake.

No code changes — docs only.

## Test plan

- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)