### PR TITLE
test(version-sync): skip marker-mentions without a literal

### DIFF
--- a/tests/version-sync.test.ts
+++ b/tests/version-sync.test.ts
@@ -42,7 +42,11 @@ describe('version sync', () => {
         const match = line.match(
           /['"]([0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.]+)?)['"]/
         );
-        const ver = match?.[1] ?? '<no version literal found>';
+        // Lines that mention the marker but carry no version literal
+        // (e.g. a docstring explaining the convention) are not real
+        // declarations — skip them.
+        if (!match) return;
+        const ver = match[1];
         if (ver !== pkg.version) {
           mismatches.push(
             `${relative(ROOT, f)}:${i + 1} → ${ver} (expected ${pkg.version})`


### PR DESCRIPTION
Follow-up to the version-sync invariant: ignore lines that mention the x-release-please-version marker but have no quoted version literal (e.g. docstrings explaining the convention). Surfaced when resy-mcp tripped the check.