### PR TITLE
chore(deps): bump @fetchproxy to ^0.5.1; Node 22 → 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ofw-mcp",
       "version": "2.0.18",
       "dependencies": {
-        "@fetchproxy/bootstrap": "^0.4.2",
+        "@fetchproxy/bootstrap": "^0.5.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.0",
         "zod": "^4.4.2"
@@ -561,28 +561,28 @@
       }
     },
     "node_modules/@fetchproxy/bootstrap": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-0.4.2.tgz",
-      "integrity": "sha512-rM1lT0d9ZUZIQA7jkccdppMEAIJIoLDeGzq6Fjxn7DYa3+e+v69SNpmj9yKDUIvwusYgoSETBhFLpDhoW1xNVQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-0.5.1.tgz",
+      "integrity": "sha512-rjfW+899X2qal7s2tXNRYfemmrqoNXguPZhIe9ua07rIxSv/brXwGiO4rA4Ss5bAK14DAOUV5om6yl/mf+iGnQ==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^0.4.0",
-        "@fetchproxy/server": "^0.4.0"
+        "@fetchproxy/protocol": "^0.5.1",
+        "@fetchproxy/server": "^0.5.1"
       }
     },
     "node_modules/@fetchproxy/protocol": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-0.4.2.tgz",
-      "integrity": "sha512-cPNhc+dxTK9FuS/SjvJDxjrkiYbT5v+/pnU3b9XHoyW4hGMGdibFrpiBpHInlOl8NVm+tFYws8O0jEa2hGgAqg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-0.5.1.tgz",
+      "integrity": "sha512-oT70TrOLv4aWlQ3ZcUz35DSnMGQCtbVDH28+YuIHrqhAXduG08DNCrZmH5x31yLjovFo5sMeR3oEgtevcX7r9g==",
       "license": "MIT"
     },
     "node_modules/@fetchproxy/server": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-0.4.2.tgz",
-      "integrity": "sha512-OsJ0IMJi3HdqgzhIP511e+6w3nPkWp1yNW+vfbR6jIJOkh0dahgYhuGFEXQCpZKxYXSAHKNPoye2KXV43/1UaQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-0.5.1.tgz",
+      "integrity": "sha512-QeEA8ubMpP65svgFU4AgCtKO7ITHZgdAiSbfdmDGthuQd9tSlezkhaiqO/+Pw/cFOG8ACIuAo5QTjyzFfqXc5w==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^0.4.2",
+        "@fetchproxy/protocol": "^0.5.1",
         "ws": "^8.20.0"
       }
     },
@@ -3170,9 +3170,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@fetchproxy/bootstrap": "^0.4.2",
+    "@fetchproxy/bootstrap": "^0.5.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.0",
     "zod": "^4.4.2"


### PR DESCRIPTION
## What

- Bumps `@fetchproxy/{server,bootstrap}` from `^0.4.2` to `^0.5.1`
- Bumps `node-version: 22` → `24` in `.github/workflows/ci.yml`

## Why

**fetchproxy v0.5.1** (chrischall/fetchproxy#44) adds session-key renegotiation on extension reconnect — closes a window where the bridge silently lost state after the SW was evicted and re-bound. Combined with v0.5.0's typed `FetchErrorKind` (chrischall/fetchproxy#24), the downstream transport surface is materially better.

**Node 24** is what the publish workflows in this cohort already use (npm 11.5.1+ is required for Trusted Publisher OIDC). This brings ci.yml into alignment so dev/test runs match what publish runs against.

## Compat

The `FetchErrorKind` field was optional in 0.5.0 and is non-optional in 0.5.1. Downstream code that doesn't read `result.kind` is unaffected (the field is additive). Code that reads it gets tighter type inference, still works.

## Test plan

- [x] `npm install` resolves to 0.5.1
- [x] `npm test` green
- [x] `tsc --noEmit` clean
- [x] `npm run build` produces bundle
