### PR TITLE
fix(ci): prevent labeled event from cancelling auto-review

### DIFF
--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -57,7 +57,7 @@ permissions:
 
 concurrency:
   group: pr-auto-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   review:


### PR DESCRIPTION
## Summary
- Changes `cancel-in-progress` from `true` to `false` in pr-auto-review.yml
- Fixes a race condition where creating a PR with `--label` causes the `labeled` event to cancel the `opened` event's review run, then skip itself

## Root cause
`gh pr create --label <name>` fires two `pull_request` events: `opened` and `labeled`. With `cancel-in-progress: true`, the `labeled` run cancels the in-progress `opened` run. The `labeled` run then skips because the label isn't `review-with-opus`. Net result: no review ever runs.

## Test plan
- [ ] This PR itself should get auto-reviewed (it was created with `--label ci`)
- [ ] The review should complete without being cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)