### PR TITLE
chore(deps): bump @fetchproxy/bootstrap to 0.6.0 + routine deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,20 @@
       "name": "ofw-mcp",
       "version": "2.0.19",
       "dependencies": {
-        "@fetchproxy/bootstrap": "^0.5.1",
+        "@fetchproxy/bootstrap": "^0.6.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "dotenv": "^17.4.0",
-        "zod": "^4.4.2"
+        "dotenv": "^17.4.2",
+        "zod": "^4.4.3"
       },
       "bin": {
         "ofw-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^25.8.0",
-        "@vitest/coverage-v8": "^4.1.6",
+        "@types/node": "^25.9.1",
+        "@vitest/coverage-v8": "^4.1.7",
         "esbuild": "^0.28.0",
-        "typescript": "^6.0.2",
-        "vitest": "^4.1.6"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -561,28 +561,28 @@
       }
     },
     "node_modules/@fetchproxy/bootstrap": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-0.5.1.tgz",
-      "integrity": "sha512-rjfW+899X2qal7s2tXNRYfemmrqoNXguPZhIe9ua07rIxSv/brXwGiO4rA4Ss5bAK14DAOUV5om6yl/mf+iGnQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-0.6.0.tgz",
+      "integrity": "sha512-ppuH43+mYKEDgwBCqyJGwgmq5ov843apwC2yoaAjkTbwzf6/VJau5VSokCkxq836wZeiB670GHOgcIzKYQ42vQ==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^0.5.1",
-        "@fetchproxy/server": "^0.5.1"
+        "@fetchproxy/protocol": "^0.6.0",
+        "@fetchproxy/server": "^0.6.0"
       }
     },
     "node_modules/@fetchproxy/protocol": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-0.5.1.tgz",
-      "integrity": "sha512-oT70TrOLv4aWlQ3ZcUz35DSnMGQCtbVDH28+YuIHrqhAXduG08DNCrZmH5x31yLjovFo5sMeR3oEgtevcX7r9g==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-0.6.0.tgz",
+      "integrity": "sha512-IUMGhxyDVGEkhQck7ID7xbFQd2jYegcn5Lhc8EBCL00+44USaStGH1S0hJfPNoG3sXIR0R7DP/yVGtrwsmq62Q==",
       "license": "MIT"
     },
     "node_modules/@fetchproxy/server": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-0.5.1.tgz",
-      "integrity": "sha512-QeEA8ubMpP65svgFU4AgCtKO7ITHZgdAiSbfdmDGthuQd9tSlezkhaiqO/+Pw/cFOG8ACIuAo5QTjyzFfqXc5w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-0.6.0.tgz",
+      "integrity": "sha512-NJWtCCl1AsmJSn5B0Ijx34DgaDqGa8lmscxyrjeW12gIbtdrTtw8C03gfFxyrKpSEf16ipMYs8tQm4/inFZByA==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^0.5.1",
+        "@fetchproxy/protocol": "^0.6.0",
         "ws": "^8.20.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@fetchproxy/bootstrap": "^0.5.1",
+    "@fetchproxy/bootstrap": "^0.6.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "dotenv": "^17.4.0",
-    "zod": "^4.4.2"
+    "dotenv": "^17.4.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "^25.8.0",
-    "@vitest/coverage-v8": "^4.1.6",
+    "@types/node": "^25.9.1",
+    "@vitest/coverage-v8": "^4.1.7",
     "esbuild": "^0.28.0",
-    "typescript": "^6.0.2",
-    "vitest": "^4.1.6"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
   }
 }


### PR DESCRIPTION
## Summary

Picks up **fetchproxy v0.6.0** plus routine refreshes on common deps.

### fetchproxy 0.5.x → 0.6.0

New in fetchproxy 0.6.0:
- **Peer session renegotiation on extension reconnect.** Previously, when the browser extension reconnected after a service-worker eviction, peer MCPs were stuck on a stale AES-GCM session key while the extension had a fresh one. All peer tool calls hung until the MCP-level timeout. Now peers correctly renegotiate.
- **Multi-MCP pendingPair queue.** Storing pending pairs in a single `chrome.storage` key meant the second-arriving MCP's pair prompt clobbered the first. Now they queue, so the user can approve each in turn from the popup.
- **Pair code surfaced in MCP tool errors.** A new `pair-pending` wire frame plus per-verb fail-fast errors mean the joint pair code appears directly in the chat ("Pairing required... pair code: 845-237") instead of a generic timeout.
- **Multi-tab content-script fallback.** When several tabs match a request URL but the first one has no content script (common after extension reload — Chrome doesn't retroactively inject), the handler now iterates rather than failing on the first stale tab.
- **Lazy bridge connect.** `listen()` no longer binds the port at MCP boot; the WS opens on the first verb call. Quieter startup, no `ERR_CONNECTION_REFUSED` flurry in the extension during parallel MCP startup.

### Routine deps refresh

- `dotenv` ^17.4.0 → ^17.4.2
- `zod` → ^4.4.3
- `@types/node` → ^25.9.1
- `@vitest/coverage-v8` → ^4.1.7
- `typescript` → ^6.0.3
- `vitest` → ^4.1.7

## Test plan

- [x] `npm test` — 220 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)