### PR TITLE
ci: skip auto-review on PRs already labeled ready-to-merge

### DIFF
--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -32,6 +32,10 @@ name: PR auto-review
 # Bot-authored PRs (dependabot/renovate/etc.) are skipped via the
 # `user.type == 'User'` filter — those go straight to CI + auto-merge.
 #
+# PRs that already carry `ready-to-merge` are skipped — they've passed
+# review once and are armed for auto-merge, so re-reviewing on a follow-up
+# `synchronize` (or unrelated label change) just burns quota.
+#
 # Release-please PRs are skipped via the `autorelease: pending` label
 # filter so they stay open as long-lived staging artifacts. release-
 # please updates the same PR as more fix:/feat: commits land; you add
@@ -68,6 +72,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       !startsWith(github.event.pull_request.head.ref, 'release-please--') &&
       !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') &&
+      !contains(github.event.pull_request.labels.*.name, 'ready-to-merge') &&
       (github.event.action != 'labeled' || github.event.label.name == 'review-with-opus')
     steps:
       - name: Apply auto-review label


### PR DESCRIPTION
## Summary
- Add a `!contains(labels, 'ready-to-merge')` guard to the `pr-auto-review.yml` job filter so PRs already armed for auto-merge are skipped.
- Update the header comment to document the new skip condition.

## Why
A PR that already has `ready-to-merge` has passed review and is armed for `auto-merge.yml`. Re-reviewing on a follow-up `synchronize` (or any unrelated label change) just burns Max-plan quota without changing the outcome.

## Test plan
- [ ] Workflow YAML parses (GitHub Actions validates on push).
- [ ] On the next PR that gets `ready-to-merge`, follow-up pushes to the same branch should no longer trigger a new review run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)