### PR TITLE
feat(deps): adopt @fetchproxy/bootstrap 0.8.0 for SW-eviction-resilient startup capture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "ofw-mcp",
       "version": "2.0.19",
       "dependencies": {
-        "@fetchproxy/bootstrap": "^0.6.0",
+        "@fetchproxy/bootstrap": "^0.8.0",
+        "@fetchproxy/server": "^0.8.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
         "zod": "^4.4.3"
@@ -561,28 +562,28 @@
       }
     },
     "node_modules/@fetchproxy/bootstrap": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-0.6.0.tgz",
-      "integrity": "sha512-ppuH43+mYKEDgwBCqyJGwgmq5ov843apwC2yoaAjkTbwzf6/VJau5VSokCkxq836wZeiB670GHOgcIzKYQ42vQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-0.8.0.tgz",
+      "integrity": "sha512-QA3Wl2aNYnPi5KQcaCcG8Mr51JLlw7D/FPtU0OVve750RPtAsby+0NFNe7YT/ztGxAXuKY66cmfOj0OU+0Q6sA==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^0.6.0",
-        "@fetchproxy/server": "^0.6.0"
+        "@fetchproxy/protocol": "^0.8.0",
+        "@fetchproxy/server": "^0.8.0"
       }
     },
     "node_modules/@fetchproxy/protocol": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-0.6.0.tgz",
-      "integrity": "sha512-IUMGhxyDVGEkhQck7ID7xbFQd2jYegcn5Lhc8EBCL00+44USaStGH1S0hJfPNoG3sXIR0R7DP/yVGtrwsmq62Q==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-0.8.0.tgz",
+      "integrity": "sha512-CJwImuObyqUQnHFgsdHQNJ7wVYeBSjV+LySTkcwS5FZ1icxtKDj5Vv/nvdwkwH/VvPtTqdOAkLW+Ml8KKBlM5Q==",
       "license": "MIT"
     },
     "node_modules/@fetchproxy/server": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-0.6.0.tgz",
-      "integrity": "sha512-NJWtCCl1AsmJSn5B0Ijx34DgaDqGa8lmscxyrjeW12gIbtdrTtw8C03gfFxyrKpSEf16ipMYs8tQm4/inFZByA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-0.8.0.tgz",
+      "integrity": "sha512-a6m4Kxr0JJdzBJd9/M1N/3SZqrA76AqRZmhAFUOix8yX+mpV98hMkwHuE2pHVN5QOzQJ65lak0eM8rIm16IscA==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^0.6.0",
+        "@fetchproxy/protocol": "^0.8.0",
         "ws": "^8.20.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@fetchproxy/bootstrap": "^0.6.0",
+    "@fetchproxy/bootstrap": "^0.8.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",
     "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@fetchproxy/bootstrap": "^0.8.0",
+    "@fetchproxy/server": "^0.8.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",
     "zod": "^4.4.3"

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -135,14 +135,7 @@ export async function resolveAuth(): Promise<ResolvedAuth> {
         source: 'fetchproxy',
       };
     } catch (e) {
-      // 0.8.0+ typed-error discrimination. The fetchproxy server already
-      // retries once on SW eviction (bridgeReviveDelayMs=2000 default), so
-      // a thrown FetchproxyBridgeDownError means the retry also failed —
-      // the extension's service worker is genuinely down and the user
-      // needs to wake it. The `.hint` is the actionable copy
-      // ("click the extension toolbar icon...") that we'd otherwise have
-      // to hand-write here. Surface it verbatim so users in path 2 get
-      // the same self-service guidance as path 3.
+      // FetchproxyBridgeDownError only escapes bootstrap() after the lazy-revive retry fails — surface .hint verbatim (actionable "click toolbar icon" copy).
       if (classifyBridgeError(e) === 'bridge_down') {
         const downErr = e as FetchproxyBridgeDownError;
         throw new Error(

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -47,6 +47,7 @@
 //     selection logic independent of either implementation.
 
 import { bootstrap } from '@fetchproxy/bootstrap';
+import { classifyBridgeError, FetchproxyBridgeDownError } from '@fetchproxy/server';
 import { loginWithPassword } from './auth-password.js';
 import { parseBoolEnv } from './config.js';
 import pkg from '../package.json' with { type: 'json' };
@@ -134,6 +135,20 @@ export async function resolveAuth(): Promise<ResolvedAuth> {
         source: 'fetchproxy',
       };
     } catch (e) {
+      // 0.8.0+ typed-error discrimination. The fetchproxy server already
+      // retries once on SW eviction (bridgeReviveDelayMs=2000 default), so
+      // a thrown FetchproxyBridgeDownError means the retry also failed —
+      // the extension's service worker is genuinely down and the user
+      // needs to wake it. The `.hint` is the actionable copy
+      // ("click the extension toolbar icon...") that we'd otherwise have
+      // to hand-write here. Surface it verbatim so users in path 2 get
+      // the same self-service guidance as path 3.
+      if (classifyBridgeError(e) === 'bridge_down') {
+        const downErr = e as FetchproxyBridgeDownError;
+        throw new Error(
+          `OFW auth: fetchproxy bridge is down (extension service worker unreachable after retry). ${downErr.hint}`,
+        );
+      }
       const msg = e instanceof Error ? e.message : String(e);
       throw new Error(
         `OFW auth: no OFW_USERNAME/OFW_PASSWORD set, and fetchproxy fallback failed: ${msg}`,

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -186,6 +186,24 @@ describe('resolveAuth', () => {
 
       await expect(resolveAuth()).rejects.toThrow(/fetchproxy fallback failed: plain string failure/);
     });
+
+    it('surfaces FetchproxyBridgeDownError.hint verbatim when the SW retry exhausts', async () => {
+      // 0.8.0+: bootstrap propagates FetchproxyBridgeDownError when the
+      // server's lazy-revive retry also fails. We surface the typed
+      // `.hint` so users see the actionable "click the extension toolbar
+      // icon" message in path 2, matching the self-service guidance in
+      // path 3.
+      const { FetchproxyBridgeDownError } = await import('@fetchproxy/server');
+      const downErr = new FetchproxyBridgeDownError({
+        originalError: 'content_script_unreachable',
+        retryAttempted: true,
+        op: 'fetch',
+      });
+      bootstrapMock.mockRejectedValue(downErr);
+
+      await expect(resolveAuth()).rejects.toThrow(/fetchproxy bridge is down/);
+      await expect(resolveAuth()).rejects.toThrow(new RegExp(downErr.hint.slice(0, 20)));
+    });
   });
 
   describe('path 3: nothing configured', () => {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -202,7 +202,7 @@ describe('resolveAuth', () => {
       bootstrapMock.mockRejectedValue(downErr);
 
       await expect(resolveAuth()).rejects.toThrow(/fetchproxy bridge is down/);
-      await expect(resolveAuth()).rejects.toThrow(new RegExp(downErr.hint.slice(0, 20)));
+      await expect(resolveAuth()).rejects.toThrow(downErr.hint.slice(0, 20));
     });
   });
 


### PR DESCRIPTION
## Summary

Adopts `@fetchproxy/bootstrap` 0.8.0 — now published to npm — and wires up the new typed-error hierarchy where it improves user-visible behavior on the fetchproxy auth path.

### What ships transitively (no code changes needed)

`@fetchproxy/server` 0.8.0 turns on two new defaults that flow through `bootstrap()`'s default factory:

- **`fetchTimeoutMs: 30000`** — server-side ceiling on bridge fetches.
- **`bridgeReviveDelayMs: 2000`** — lazy-revive: when the Chrome MV3 service worker is evicted during the one-shot localStorage read, the server waits up to 2s for the extension to reconnect before failing.

User-visible: **startup capture now survives a single MV3 service-worker eviction transparently** (a 2s reconnect window before throwing). Previously a transient eviction during the localStorage read could fail the call.

### What ships as new integration code (this PR)

`src/auth.ts` now catches `FetchproxyBridgeDownError` specifically and surfaces its typed `.hint` ("click the extension toolbar icon...") verbatim, so users on path 2 (fetchproxy fallback) get the same self-service guidance the env-var-missing path 3 already provides. Discriminated via `classifyBridgeError` per the 0.8.0 server docs.

A `FetchproxyBridgeDownError` only escapes `bootstrap()` after the lazy-revive retry also failed — i.e. the SW is genuinely down and only the user can wake it. That's exactly the case where pointing at the toolbar icon is the right answer.

`@fetchproxy/server` is added as an explicit dependency since we now import from it directly (previously transitive-only through bootstrap).

## Test plan

- [x] `npm test` — 221/221 (added 1 new test for the bridge-down branch)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `npm ls @fetchproxy/bootstrap` — `0.8.0`
- [ ] Manual: trigger MCP startup with extension SW evicted; confirm error message contains the typed hint