### PR TITLE
fix(client): add per-request timeout to prevent multi-minute hangs

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -45,6 +45,19 @@ function redactHeaders(h: Record<string, string>): Record<string, string> {
   return out;
 }
 
+// Per-request timeout. Overridable via OFW_REQUEST_TIMEOUT_MS. The default
+// (30s) is comfortably above OFW's typical p99 but low enough that a stuck
+// upstream fails fast instead of burning the MCP client-side budget — which
+// is what produced the multi-minute hangs we've seen on ofw_list_messages
+// and ofw_save_draft. Each retry (401/429 replay) gets its own fresh window.
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+function getRequestTimeoutMs(): number {
+  const raw = process.env.OFW_REQUEST_TIMEOUT_MS;
+  if (typeof raw !== 'string' || raw.trim().length === 0) return DEFAULT_REQUEST_TIMEOUT_MS;
+  const n = Number(raw.trim());
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_REQUEST_TIMEOUT_MS;
+}
+
 export class OFWClient {
   private token: string | null = null;
   private tokenExpiry: Date | null = null;
@@ -100,14 +113,42 @@ export class OFWClient {
       console.error(`[ofw-debug]   body: ${bodyPreview}`);
     }
 
-    const response = await fetch(url, {
-      method,
-      headers,
-      ...(body !== undefined ? { body: isFormData ? body : JSON.stringify(body) } : {}),
-    });
+    // AbortController + setTimeout (not AbortSignal.timeout) so vitest fake
+    // timers can drive the timeout in tests, and so we can attach a clear
+    // error message instead of a bare DOMException on the abort path.
+    const timeoutMs = getRequestTimeoutMs();
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), timeoutMs);
+    const startedAt = Date.now();
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method,
+        headers,
+        signal: ac.signal,
+        ...(body !== undefined ? { body: isFormData ? body : JSON.stringify(body) } : {}),
+      });
+    } catch (err) {
+      const elapsed = Date.now() - startedAt;
+      if (ac.signal.aborted) {
+        if (debugLogEnabled()) {
+          console.error(`[ofw-debug] ⏱ TIMEOUT after ${elapsed}ms: ${method} ${url}`);
+        }
+        throw new Error(
+          `OFW API request timed out after ${timeoutMs}ms: ${method} ${path}`,
+        );
+      }
+      if (debugLogEnabled()) {
+        console.error(`[ofw-debug] ✗ ${(err as Error).message} after ${elapsed}ms: ${method} ${url}`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
 
     if (debugLogEnabled()) {
-      console.error(`[ofw-debug] ← ${response.status} ${response.statusText}`);
+      console.error(`[ofw-debug] ← ${response.status} ${response.statusText} (${Date.now() - startedAt}ms)`);
     }
 
     if (response.status === 401 && !isRetry) {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -409,6 +409,89 @@ describe('OFWClient', () => {
         vi.useRealTimers();
       }
     });
+
+    it('propagates non-abort fetch errors (e.g. ECONNREFUSED) unchanged', async () => {
+      let call = 0;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+        call++;
+        if (call === 1) {
+          return {
+            ok: false, status: 303, statusText: '303',
+            headers: { get: (k: string) => k.toLowerCase() === 'set-cookie' ? 'SESSION=x' : null },
+            text: async () => '', json: async () => null,
+          } as unknown as Response;
+        }
+        if (call === 2) {
+          return {
+            ok: true, status: 200, statusText: '200',
+            headers: { get: (k: string) => k.toLowerCase() === 'content-type' ? 'application/json' : null },
+            text: async () => JSON.stringify({ auth: MOCK_TOKEN }),
+            json: async () => ({ auth: MOCK_TOKEN }),
+          } as unknown as Response;
+        }
+        throw new Error('connect ECONNREFUSED');
+      });
+      const client = new OFWClient();
+      await expect(client.request('GET', '/pub/v1/test')).rejects.toThrow('connect ECONNREFUSED');
+    });
+
+    it('logs the timeout and error paths via OFW_DEBUG_LOG when enabled', async () => {
+      const originalDebug = process.env.OFW_DEBUG_LOG;
+      process.env.OFW_DEBUG_LOG = '1';
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      vi.useFakeTimers();
+      try {
+        mockLoginThenHang();
+        const client = new OFWClient();
+        const promise = client.request('GET', '/pub/v1/timeout-check');
+        promise.catch(() => undefined);
+        await vi.advanceTimersByTimeAsync(30_000);
+        await expect(promise).rejects.toThrow(/timed out after 30000ms/);
+
+        const lines = errSpy.mock.calls.map((c) => String(c[0]));
+        expect(lines.some((l) => l.includes('⏱ TIMEOUT after') && l.includes('/pub/v1/timeout-check'))).toBe(true);
+      } finally {
+        vi.useRealTimers();
+        if (originalDebug === undefined) delete process.env.OFW_DEBUG_LOG;
+        else process.env.OFW_DEBUG_LOG = originalDebug;
+      }
+    });
+
+    it('logs non-abort fetch errors via OFW_DEBUG_LOG when enabled', async () => {
+      const originalDebug = process.env.OFW_DEBUG_LOG;
+      process.env.OFW_DEBUG_LOG = '1';
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        let call = 0;
+        vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+          call++;
+          if (call === 1) {
+            return {
+              ok: false, status: 303, statusText: '303',
+              headers: { get: (k: string) => k.toLowerCase() === 'set-cookie' ? 'SESSION=x' : null },
+              text: async () => '', json: async () => null,
+            } as unknown as Response;
+          }
+          if (call === 2) {
+            return {
+              ok: true, status: 200, statusText: '200',
+              headers: { get: (k: string) => k.toLowerCase() === 'content-type' ? 'application/json' : null },
+              text: async () => JSON.stringify({ auth: MOCK_TOKEN }),
+              json: async () => ({ auth: MOCK_TOKEN }),
+            } as unknown as Response;
+          }
+          throw new Error('socket hang up');
+        });
+        const client = new OFWClient();
+        await expect(client.request('GET', '/pub/v1/err-check')).rejects.toThrow('socket hang up');
+
+        const lines = errSpy.mock.calls.map((c) => String(c[0]));
+        expect(lines.some((l) => l.includes('✗ socket hang up') && l.includes('/pub/v1/err-check'))).toBe(true);
+      } finally {
+        if (originalDebug === undefined) delete process.env.OFW_DEBUG_LOG;
+        else process.env.OFW_DEBUG_LOG = originalDebug;
+      }
+    });
   });
 
   describe('OFW_DEBUG_LOG', () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -301,6 +301,116 @@ describe('OFWClient', () => {
     expect(h['ofw-version']).toBe('1.0.0');
   });
 
+  describe('request timeout', () => {
+    // Helper: handle the login fetches normally, then hang on subsequent
+    // calls until the request's AbortSignal fires. This is the shape of a
+    // stuck upstream — fetch never resolves, and prior to the timeout fix
+    // it would burn the entire client-side budget.
+    function mockLoginThenHang(): ReturnType<typeof vi.spyOn> {
+      let call = 0;
+      return vi.spyOn(globalThis, 'fetch').mockImplementation((_url, init) => {
+        call++;
+        if (call === 1) {
+          // LOGIN_INIT
+          return Promise.resolve({
+            ok: false, status: 303, statusText: '303',
+            headers: { get: (k: string) => k.toLowerCase() === 'set-cookie' ? 'SESSION=x' : null },
+            text: async () => '', json: async () => null,
+          } as unknown as Response);
+        }
+        if (call === 2) {
+          // LOGIN_SUCCESS
+          return Promise.resolve({
+            ok: true, status: 200, statusText: '200',
+            headers: { get: (k: string) => k.toLowerCase() === 'content-type' ? 'application/json' : null },
+            text: async () => JSON.stringify({ auth: MOCK_TOKEN }),
+            json: async () => ({ auth: MOCK_TOKEN }),
+          } as unknown as Response);
+        }
+        // Hang until aborted. Fetch contract: rejects with the signal's
+        // reason (or a DOMException) when the signal aborts.
+        return new Promise((_resolve, reject) => {
+          const signal = (init as RequestInit | undefined)?.signal;
+          if (!signal) return; // hang forever — test will time itself out
+          signal.addEventListener('abort', () => {
+            const err: Error & { name?: string } = new Error(
+              (signal.reason as Error | undefined)?.message ?? 'aborted',
+            );
+            err.name = 'AbortError';
+            reject(err);
+          });
+        });
+      });
+    }
+
+    afterEach(() => {
+      delete process.env.OFW_REQUEST_TIMEOUT_MS;
+    });
+
+    it('aborts a hung request after the default 30s timeout with a clear error', async () => {
+      vi.useFakeTimers();
+      try {
+        mockLoginThenHang();
+        const client = new OFWClient();
+        const promise = client.request('GET', '/pub/v3/messages?folders=42&page=1&size=50');
+        promise.catch(() => undefined);
+        await vi.advanceTimersByTimeAsync(30_000);
+        await expect(promise).rejects.toThrow(
+          /OFW API request timed out after 30000ms.*GET \/pub\/v3\/messages/,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('respects OFW_REQUEST_TIMEOUT_MS override', async () => {
+      process.env.OFW_REQUEST_TIMEOUT_MS = '5000';
+      vi.useFakeTimers();
+      try {
+        mockLoginThenHang();
+        const client = new OFWClient();
+        const promise = client.request('GET', '/pub/v3/messages');
+        promise.catch(() => undefined);
+        await vi.advanceTimersByTimeAsync(5_000);
+        await expect(promise).rejects.toThrow(/timed out after 5000ms/);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not fire the timeout when the request completes promptly', async () => {
+      vi.useFakeTimers();
+      try {
+        mockFetch([
+          LOGIN_INIT,
+          LOGIN_SUCCESS,
+          { status: 200, body: { ok: true } },
+        ]);
+        const client = new OFWClient();
+        const result = await client.request<{ ok: boolean }>('GET', '/pub/v1/test');
+        // Advance well past the default timeout to prove the timer is cleared.
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(result).toEqual({ ok: true });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('binaries also respect the timeout', async () => {
+      vi.useFakeTimers();
+      try {
+        mockLoginThenHang();
+        const client = new OFWClient();
+        const promise = client.requestBinary('GET', '/pub/v1/myfiles/1/data');
+        promise.catch(() => undefined);
+        await vi.advanceTimersByTimeAsync(30_000);
+        await expect(promise).rejects.toThrow(/timed out after 30000ms/);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('OFW_DEBUG_LOG', () => {
     let originalDebug: string | undefined;
     let errSpy: ReturnType<typeof vi.spyOn>;


### PR DESCRIPTION
## Summary

- A stuck OFW upstream had no defense in the client — `fetch()` ran with no `AbortSignal`. When a response was slow or never returned, the `await` hung until the MCP client-side budget expired (observed twice today: a ~4-min `ofw_list_messages` hang and a ~4-min `ofw_save_draft` hang).
- Wraps `fetch()` in `AbortController` + `setTimeout` so a stuck call fails fast with `OFW API request timed out after Nms: METHOD /path`. Default 30s, overridable via `OFW_REQUEST_TIMEOUT_MS`. Each 401/429 retry attempt gets a fresh window.
- `OFW_DEBUG_LOG` output now also reports elapsed ms on every response and on the abort/error paths, so the next stall is locatable when debug is on.

Static analysis ruled out the other usual suspects: 401/429 retries are bounded by the `isRetry` guard, and the SQLite cache uses prepared statements with WAL so a read-side lock can't plausibly stall a request. The bare `fetch()` was the only unprotected await.

## Test plan

- [x] `npm test` — 4 new tests pass (default + env override + happy-path + binary path); other suites unaffected.
- [ ] Reviewer: confirm the timeout error message is readable when surfaced through MCP.
- [ ] Optional: set `OFW_DEBUG_LOG=1` locally and look for the new `(Nms)` suffix on the response line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)