### PR TITLE
fix(ci): treat instant-merge race as success in auto-merge arm

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -56,7 +56,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          if gh pr merge --auto --squash "$PR_URL"; then exit 0; fi
+          state="$(gh pr view "$PR_URL" --json state --jq .state 2>/dev/null || echo UNKNOWN)"
+          if [ "$state" = "MERGED" ]; then
+            echo "PR already merged (instant-merge race) — treating as success."
+            exit 0
+          fi
+          echo "::error::auto-merge arm failed (PR state=$state)"
+          exit 1
 
   arm-on-ready-label:
     runs-on: ubuntu-latest
@@ -72,4 +80,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          if gh pr merge --auto --squash "$PR_URL"; then exit 0; fi
+          state="$(gh pr view "$PR_URL" --json state --jq .state 2>/dev/null || echo UNKNOWN)"
+          if [ "$state" = "MERGED" ]; then
+            echo "PR already merged (instant-merge race) — treating as success."
+            exit 0
+          fi
+          echo "::error::auto-merge arm failed (PR state=$state)"
+          exit 1


### PR DESCRIPTION
## Problem

When a PR is already fully mergeable, `gh pr merge --auto --squash` merges it instantly. That merge plus `delete_branch_on_merge` races the arm job, which then exits non-zero (e.g. 143) and reports the run as a **failure even though the merge succeeded**. This trains maintainers to ignore real auto-merge failures.

## Fix

Guard both arm steps (`arm-dependabot` and `arm-on-ready-label`): if the arm command fails, re-check the PR state and treat an already-`MERGED` PR as success. Genuine arm failures (state != `MERGED`) still surface as `exit 1` with an `::error::` annotation.

The `env:` blocks and step structure are unchanged. YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
