### PR TITLE
fix(ci): arm auto-merge from verdict comment when structured_output is empty

### DIFF
--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -218,13 +218,28 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Arm auto-merge on pass
-        if: |
-          steps.review.outputs.structured_output != '' &&
-          fromJSON(steps.review.outputs.structured_output).verdict == 'pass'
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          OUT: ${{ steps.review.outputs.structured_output }}
         run: |
-          gh pr edit "$PR" --repo "$REPO" --add-label ready-to-merge
-          echo "Verdict=pass — added ready-to-merge to arm auto-merge."
+          verdict=""
+          [ -n "$OUT" ] && verdict=$(echo "$OUT" | jq -r '.verdict // empty')
+          # Fallback: claude-code-action intermittently returns an empty
+          # structured_output even on a clean pass (the verdict comment still
+          # posts). Re-derive the verdict from the latest claude[bot] verdict
+          # marker. ONLY an explicit `pass` arms; warn/fail/anything-else keeps
+          # a human in the loop.
+          if [ -z "$verdict" ]; then
+            body=$(gh pr view "$PR" --repo "$REPO" --json comments --jq '[.comments[]|select(.author.login=="claude")]|last|.body' 2>/dev/null || echo "")
+            vline=$(printf '%s' "$body" | grep -ioE 'verdict[^a-z]{0,6}(pass|warn|fail)' | tail -1)
+            case "$vline" in *[Pp]ass*) verdict="pass";; esac
+          fi
+          if [ "$verdict" = "pass" ]; then
+            gh pr edit "$PR" --repo "$REPO" --add-label ready-to-merge
+            echo "Verdict=pass — added ready-to-merge to arm auto-merge."
+          else
+            echo "Verdict=${verdict:-unknown} — not arming (human-in-the-loop preserved)."
+          fi


### PR DESCRIPTION
Fixes an intermittent bug where a clean `pass` failed to arm auto-merge because `claude-code-action` returned an empty `structured_output` (the verdict comment still posts, but the label was never added, leaving clean-pass PRs un-armed).

The "Arm auto-merge on pass" step now:
- Reads the verdict from `structured_output` when present.
- Falls back to re-deriving the verdict from the latest `claude` bot verdict comment when `structured_output` is empty.
- Arms (adds `ready-to-merge`) **only** on an explicit `pass` — warn/fail/empty/error keep a human in the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)