### PR TITLE
feat: adopt @fetchproxy/server 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "ofw-mcp",
       "version": "2.2.0",
       "dependencies": {
-        "@fetchproxy/bootstrap": "^0.8.0",
-        "@fetchproxy/server": "^0.8.0",
+        "@fetchproxy/bootstrap": "^0.11.0",
+        "@fetchproxy/server": "^0.11.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
         "zod": "^4.4.3"
@@ -562,29 +562,29 @@
       }
     },
     "node_modules/@fetchproxy/bootstrap": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-0.8.0.tgz",
-      "integrity": "sha512-QA3Wl2aNYnPi5KQcaCcG8Mr51JLlw7D/FPtU0OVve750RPtAsby+0NFNe7YT/ztGxAXuKY66cmfOj0OU+0Q6sA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-0.11.0.tgz",
+      "integrity": "sha512-D4+1OqiLv+sQXQ3fATCjsxXgUSOpi83IZj+IZRF9P2M+VrN8dSBVCin2gTts7IwflGVJLsxpMvL7Blnp8G3v+g==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^0.8.0",
-        "@fetchproxy/server": "^0.8.0"
+        "@fetchproxy/protocol": "^0.11.0",
+        "@fetchproxy/server": "^0.11.0"
       }
     },
     "node_modules/@fetchproxy/protocol": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-0.8.0.tgz",
-      "integrity": "sha512-CJwImuObyqUQnHFgsdHQNJ7wVYeBSjV+LySTkcwS5FZ1icxtKDj5Vv/nvdwkwH/VvPtTqdOAkLW+Ml8KKBlM5Q==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-0.11.0.tgz",
+      "integrity": "sha512-xGlD6ZHX+1mBblB70Kp9ic8Q7gwtCllYwIK6UyeZzclcVodWwzsqaRtVMh7mcoWMnhJgAyVxSgAX5eZfPLF8xw==",
       "license": "MIT"
     },
     "node_modules/@fetchproxy/server": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-0.8.0.tgz",
-      "integrity": "sha512-a6m4Kxr0JJdzBJd9/M1N/3SZqrA76AqRZmhAFUOix8yX+mpV98hMkwHuE2pHVN5QOzQJ65lak0eM8rIm16IscA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-0.11.0.tgz",
+      "integrity": "sha512-FPfkyxUI0dr1V+n53lzctb+t6SYd6Igp3tfgh2CEZg7wLw9OpU5UaovOyp1nGZgUR1Kdz/UqX0NnwKa2yUVHzw==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^0.8.0",
-        "ws": "^8.20.0"
+        "@fetchproxy/protocol": "^0.11.0",
+        "ws": "^8.21.0"
       }
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@fetchproxy/bootstrap": "^0.8.0",
-    "@fetchproxy/server": "^0.8.0",
+    "@fetchproxy/bootstrap": "^0.11.0",
+    "@fetchproxy/server": "^0.11.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",
     "zod": "^4.4.3"


### PR DESCRIPTION
## Summary

Floor bump of `@fetchproxy/server` **0.8.0 → 0.11.0** (a multi-minor jump). This is a fetchproxy-only bump — no `@chrischall/realty-core`, no SSR-parsing helper swaps.

## What changed across the gap (0.8 → 0.11)

- **0.9.0** — bulk helpers (`mapWithConcurrency`, …); additive.
- **0.10.0** — resilience kit (`requestJson`, `runProbe`, `withDeadline`, `classifyBotWall`, `TokenBucket`, `backoffDelayMs`) + keep-alive default-ON; additive.
- **0.11.0** — SSR-parsing helpers (`extractGlobalAssign`, …); additive.

ofw imports only `classifyBridgeError` and `FetchproxyBridgeDownError` from `@fetchproxy/server` (in `src/auth.ts`). Both are present and type-stable in 0.11.0 (`classifyBridgeError → 'bridge_down'`, `FetchproxyBridgeDownError.hint`). No resilience-kit, bulk-helper, or SSR-helper APIs are used, so the surface ofw depends on is unchanged.

## Transport adaptation

No transport/keep-alive config to adapt: ofw has **no** `transport-fetchproxy.ts` wiring and never passed `keepAliveIntervalMs` — fetchproxy is a one-shot session-snapshot read in `auth.ts`, never in the request hot path. So there was no redundant keep-alive opt-in to drop.

The one adaptation required was bumping **`@fetchproxy/bootstrap` in lockstep to `^0.11.0`**. `bootstrap` declares `@fetchproxy/server` as a same-version-range dependency, so leaving it at `^0.8.0` while moving server to `^0.11.0` resolves to **two copies** of `@fetchproxy/server` (0.11.0 top-level + a nested 0.8.0 under bootstrap). That would break cross-package error handling — `bootstrap()` throws `FetchproxyBridgeDownError` from its nested 0.8.0 copy, while `auth.ts`'s `classifyBridgeError` import comes from the top-level 0.11.0 copy (cross-realm `instanceof` mismatch). The lockstep bump dedupes to a single `@fetchproxy/server@0.11.0` / `@fetchproxy/protocol@0.11.0`.

## Verification (all green)

- `npm test` — **236/236 pass**
- `npx tsc --noEmit` — clean (exit 0)
- `npm run build` — clean (tsc + esbuild bundle)
- Boot smoke (`node dist/bundle.js`, real stdio entrypoint) — banner to stderr, `initialize` + `tools/list` handshake returns all 25 tools, clean exit. No startup throw.

## Files changed

- `package.json` — `@fetchproxy/server` + `@fetchproxy/bootstrap` → `^0.11.0`
- `package-lock.json` — `@fetchproxy/{server,bootstrap,protocol}` 0.8.0 → 0.11.0, `ws` → 8.21.0; no unrelated churn