### PR TITLE
Route fetchproxy bridge primitives through @chrischall/mcp-utils/fetchproxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,8 @@
       "name": "ofw-mcp",
       "version": "2.3.0",
       "dependencies": {
-        "@chrischall/mcp-utils": "^0.1.0",
+        "@chrischall/mcp-utils": "^0.1.1",
         "@fetchproxy/bootstrap": "^0.11.0",
-        "@fetchproxy/server": "^0.11.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
         "zod": "^4.4.3"
@@ -87,9 +86,9 @@
       }
     },
     "node_modules/@chrischall/mcp-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.1.0.tgz",
-      "integrity": "sha512-uiEoxg75px10lJF0QCcYMSNpGzl0apHdmCwaVZtf6jnTnxTAA1dunTQ6QZrh/IDLCyXq2Ngyeg9559M0hSlFig==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.1.1.tgz",
+      "integrity": "sha512-SBN1pnqt/8Fa0oiawj9pHmRD5H/SKEf1gpPaS1p031awvVtsxffAFHNcWhqNy98Qv2sqThtZnMJal8JdLMPshA==",
       "license": "MIT",
       "peerDependencies": {
         "@fetchproxy/server": "*",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@chrischall/mcp-utils": "^0.1.0",
+    "@chrischall/mcp-utils": "^0.1.1",
     "@fetchproxy/bootstrap": "^0.11.0",
-    "@fetchproxy/server": "^0.11.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",
     "zod": "^4.4.3"

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -48,7 +48,7 @@
 
 import { readEnvVar } from '@chrischall/mcp-utils';
 import { bootstrap } from '@fetchproxy/bootstrap';
-import { classifyBridgeError, FetchproxyBridgeDownError } from '@fetchproxy/server';
+import { classifyBridgeError, FetchproxyBridgeDownError } from '@chrischall/mcp-utils/fetchproxy';
 import { loginWithPassword } from './auth-password.js';
 import { parseBoolEnv } from './config.js';
 import pkg from '../package.json' with { type: 'json' };

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -193,7 +193,7 @@ describe('resolveAuth', () => {
       // `.hint` so users see the actionable "click the extension toolbar
       // icon" message in path 2, matching the self-service guidance in
       // path 3.
-      const { FetchproxyBridgeDownError } = await import('@fetchproxy/server');
+      const { FetchproxyBridgeDownError } = await import('@chrischall/mcp-utils/fetchproxy');
       const downErr = new FetchproxyBridgeDownError({
         originalError: 'content_script_unreachable',
         retryAttempted: true,


### PR DESCRIPTION
Routes the fetchproxy bridge symbols used by the bootstrap-only auth path through the `@chrischall/mcp-utils/fetchproxy` subpath, now that mcp-utils 0.1.1 re-exports them verbatim from `@fetchproxy/server`.

## Changes
- `@chrischall/mcp-utils` → `^0.1.1`.
- `src/auth.ts` + `tests/auth.test.ts`: `classifyBridgeError`, `FetchproxyBridgeDownError` now import from `@chrischall/mcp-utils/fetchproxy` (single import site each — no split).
- `@fetchproxy/bootstrap` import unchanged (not re-exported).
- Dropped the now-unused direct `@fetchproxy/server` dependency; it remains resolvable transitively via `@fetchproxy/bootstrap` and `mcp-utils/fetchproxy`.

## Verification
The re-export preserves class/function identity (verified `sub.X === srv.X`), so the raw-string `classifyBridgeError(e) === 'bridge_down'` check and the test's thrown `FetchproxyBridgeDownError` behave identically. Test mock boundary (`@fetchproxy/bootstrap`) still intercepts — no test changes beyond the import source.

`npm run build` ✅ · `npm test` ✅ 236 tests / 13 files (100% coverage gate satisfied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)