### PR TITLE
ci: use shared install-mcp-publisher action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -112,14 +112,13 @@ jobs:
 
       # ─── modelcontextprotocol/registry (PulseMCP auto-ingests weekly) ───
       - name: Install mcp-publisher
-        run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+        uses: chrischall/mcp-utils/.github/actions/install-mcp-publisher@main
 
       - name: Authenticate to MCP Registry (OIDC)
-        run: ./mcp-publisher login github-oidc
+        run: mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
+        run: mcp-publisher publish
 
       # ─── ClawHub (OpenClaw skill registry) — conditional on CLAWHUB_TOKEN ───
       # GitHub Actions disallows `secrets.*` in step-level `if:`, so the


### PR DESCRIPTION
Replaces this repo's inline `mcp-publisher` install (`curl …/releases/latest | tar xz` — unpinned, unverified) with the shared composite action from [chrischall/mcp-utils](https://github.com/chrischall/mcp-utils/tree/main/.github/actions/install-mcp-publisher): **pinned version + SHA-256-verified, fail-closed**. The binary is on `PATH`, so `./mcp-publisher` → `mcp-publisher`.

Part of the fleet-wide rollout (mcp-utils#3). Bump the pin once in mcp-utils, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)