### PR TITLE
ci: pin install-mcp-publisher action to v0.2.1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -112,7 +112,7 @@ jobs:
 
       # ─── modelcontextprotocol/registry (PulseMCP auto-ingests weekly) ───
       - name: Install mcp-publisher
-        uses: chrischall/mcp-utils/.github/actions/install-mcp-publisher@main
+        uses: chrischall/mcp-utils/.github/actions/install-mcp-publisher@v0.2.1
 
       - name: Authenticate to MCP Registry (OIDC)
         run: mcp-publisher login github-oidc


### PR DESCRIPTION
Follow-up to the merged conversion PR. The shared action landed on `main` referencing the floating **`@main`** ref (the auto-review 🔴). This pins it to the immutable **`@v0.2.1`** tag — matching the workflow's existing `@v6.0.2`/`@v5` convention. Dependabot (`github-actions` ecosystem) keeps it current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)