### PR TITLE
build: exclude release-please metadata from the .mcpb bundle

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -67,3 +67,8 @@ scripts/
 # Don't recursively pack the bundle into itself
 *.mcpb
 *.skill
+
+# Release tooling (release-please) — build/release metadata, not runtime
+release-please-config.json
+.release-please-manifest.json
+CHANGELOG.md


### PR DESCRIPTION
The fleet-canonical `.mcpbignore` predates release-please, so `mcpb pack` still bundles `release-please-config.json`, `.release-please-manifest.json`, and `CHANGELOG.md` (build/release metadata, not runtime). Add the 3 excludes so the `.mcpb` ships only the runtime files. (Verified on evite-mcp: bundle drops to exactly `dist/bundle.js` + `manifest.json` + `package.json`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)