### PR TITLE
ci: build/test on Node 26 (Current)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24
+          node-version: 26
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24
+          node-version: 26
           cache: npm
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
Bumps CI + publish `node-version: 24 → 26` to build/test on the runtime we develop against. Node 26 is **Current** (released May 2026; Active LTS Oct 2026). The **shipped floor** (`engines` / mcpb `runtimes.node`) is intentionally **unchanged** so consumers on 22/24 LTS still install. `@types/node` stays at 25.x (DefinitelyTyped hasn't published 26). Validated on [mcp-utils#11](https://github.com/chrischall/mcp-utils/pull/11) (CI green on Node 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)