### PR TITLE
refactor: adopt mcp-utils 0.4.0 fileBlob for attachment upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ofw-mcp",
       "version": "2.3.0",
       "dependencies": {
-        "@chrischall/mcp-utils": "^0.1.1",
+        "@chrischall/mcp-utils": "^0.4.0",
         "@fetchproxy/bootstrap": "^0.11.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/@chrischall/mcp-utils": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.1.1.tgz",
-      "integrity": "sha512-SBN1pnqt/8Fa0oiawj9pHmRD5H/SKEf1gpPaS1p031awvVtsxffAFHNcWhqNy98Qv2sqThtZnMJal8JdLMPshA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.4.0.tgz",
+      "integrity": "sha512-TOHsUFEX8H/jqG4IwYXStksK8QX3qLvghY+XCaEOtekwNn13SAiuzn1ClLXazHF3DUxaq6FgVyYrpfoHpyu98w==",
       "license": "MIT",
       "peerDependencies": {
         "@fetchproxy/server": "*",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@chrischall/mcp-utils": "^0.1.1",
+    "@chrischall/mcp-utils": "^0.4.0",
     "@fetchproxy/bootstrap": "^0.11.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -10,8 +10,9 @@ import {
   type MessageRow, type DraftRow,
 } from '../cache.js';
 import { getAttachmentsDir, getDefaultInlineAttachments } from '../config.js';
-import { mkdirSync, openAsBlob, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, extname, join } from 'node:path';
+import { fileBlob } from '@chrischall/mcp-utils';
 import { expandPath, jsonResponse, mapRecipients, postMessageAndRefetch, textResponse, type ApiRecipient } from './_shared.js';
 
 // Lightweight mime sniff from extension. OFW re-derives mime from the filename
@@ -482,8 +483,8 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
 
     // Build the multipart payload matching the OFW web UI's request shape.
     const form = new FormData();
-    // Stream the file off disk (a file-backed Blob) instead of buffering it.
-    form.append('file', await openAsBlob(abs, { type: mime }), fileName);
+    // fileBlob streams the file off disk (a file-backed Blob) instead of buffering it.
+    form.append('file', await fileBlob(abs, { type: mime }), fileName);
     form.append('source', 'message');
     form.append('description', args.description ?? fileName);
     form.append('label', args.label ?? fileName);


### PR DESCRIPTION
Adopts the new `@chrischall/mcp-utils` **0.4.0** `fileBlob` helper for `ofw_upload_attachment`.

## Changes
- Bump `@chrischall/mcp-utils` `^0.1.1` → `^0.4.0`. The imported symbols (`loadDotenvSafely`, `runMcp`, `readEnvVar`, `parseBoolEnv`, `expandPath`, `rawTextResult`, `textResult`, and the `/fetchproxy` bridge helpers) are unchanged across the range — ofw has its own `client.ts`, so none of the `createApiClient`/`tokenManager` churn applies.
- `messages.ts`: swap the local `openAsBlob(abs, { type })` for the shared **`fileBlob(abs, { type })`** — identical file-backed streaming Blob, now from the fleet helper.

## Result
**236 tests pass**, build clean. No behavior change to the multipart upload.

> Coverage backfill (the repo's declared 100% target — currently ~98%/88% branches because `npm test` doesn't run `--coverage`) is a separate, larger effort; tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)