### PR TITLE
test: drive coverage to 100% and enforce it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,5 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npm test
+      # Coverage-enforced: vitest.config.ts declares 100% thresholds, so this fails on a regression.
+      - run: npm run test:coverage

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --external:dotenv --banner:js='import { createRequire as __createRequire } from \"module\"; const require = __createRequire(import.meta.url);' --outfile=dist/bundle.js",
     "dev": "node --env-file=.env dist/index.js",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -264,6 +264,7 @@ export function countMessages(opts: MessageFilter): number {
   const { where, params } = buildMessageFilter(opts);
   const r = db.prepare(`SELECT COUNT(*) as n FROM messages ${where}`)
     .get(...params as never[]) as { n: number } | undefined;
+  /* v8 ignore next -- SELECT COUNT(*) always returns exactly one row; the ?./?? are defensive */
   return r?.n ?? 0;
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,6 +39,7 @@ function debugLogEnabled(): boolean {
 
 function redactHeaders(h: Record<string, string>): Record<string, string> {
   const out = { ...h };
+  /* v8 ignore next -- request headers always carry Authorization (set in request()); the guard is defensive for arbitrary header maps */
   if (out.Authorization) out.Authorization = `Bearer ${out.Authorization.slice(7, 17)}…`;
   return out;
 }

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -537,6 +537,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
       // sentinel — gets re-linked if a message later references this file.
       await fetchAttachmentMeta(client, fileId, 0);
       cached = getAttachment(fileId);
+      /* v8 ignore next -- fetchAttachmentMeta persists the row it just fetched; a still-null read here is an unreachable storage failure */
       if (!cached) throw new Error(`failed to fetch metadata for fileId ${fileId}`);
     }
 

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -8,6 +8,7 @@ import {
   upsertDraft, getDraft, listDrafts, deleteDraft, listDraftIds, type DraftRow,
   getSyncState, setSyncState, getMeta, setMeta,
   findLatestReplyTip,
+  upsertAttachmentForMessage, getAttachment,
 } from '../src/cache.js';
 
 let tmp: string;
@@ -326,5 +327,39 @@ describe('findLatestReplyTip', () => {
       sentAt: '2026-05-04T14:00:00Z',
     }));
     expect(findLatestReplyTip(142)).toBe(200);
+  });
+});
+
+describe('cache null/fallback branches', () => {
+  it('upsertMessage stores nulls for omitted optional fields (recipients/body/listData)', () => {
+    openCache();
+    upsertMessage(sampleRow({ recipients: undefined, body: undefined, fetchedBodyAt: undefined, replyToId: undefined, chainRootId: undefined, listData: undefined }));
+    const got = getMessage(100);
+    expect(got?.recipients).toEqual([]);
+    expect(got?.body).toBeNull();
+    expect(got?.listData).toBeNull();
+  });
+
+  it('upsertDraft stores nulls for omitted optional fields (recipients/listData)', () => {
+    openCache();
+    upsertDraft(sampleDraft({ recipients: undefined, listData: undefined }));
+    const got = getDraft(200);
+    expect(got?.recipients).toEqual([]);
+    expect(got?.listData).toBeNull();
+  });
+
+  it('upsertAttachmentForMessage: re-linking the same messageId does not duplicate it', () => {
+    openCache();
+    const base = { fileId: 9, fileName: 'a.pdf', label: 'A', mimeType: 'application/pdf', sizeBytes: 10, metadata: { x: 1 } };
+    upsertAttachmentForMessage({ ...base, messageId: 5 });
+    upsertAttachmentForMessage({ ...base, messageId: 5 }); // prior already includes 5
+    expect(getAttachment(9)!.messageIds).toEqual([5]);
+  });
+
+  it('upsertAttachmentForMessage stores nulls for omitted size/metadata', () => {
+    openCache();
+    upsertAttachmentForMessage({ fileId: 11, fileName: 'b.txt', label: 'B', mimeType: 'text/plain', sizeBytes: null, metadata: undefined, messageId: 0 });
+    const got = getAttachment(11);
+    expect(got?.sizeBytes).toBeNull();
   });
 });

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -785,3 +785,35 @@ describe('OFWClient.requestBinary', () => {
     });
   });
 });
+
+describe('OFWClient — config/auth fallback branches', () => {
+  beforeEach(() => {
+    process.env.OFW_USERNAME = 'test@example.com';
+    process.env.OFW_PASSWORD = 'testpass';
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('reads OFW_REQUEST_TIMEOUT_MS (valid → used, invalid → default)', async () => {
+    const orig = process.env.OFW_REQUEST_TIMEOUT_MS;
+    try {
+      mockFetch([LOGIN_INIT, LOGIN_SUCCESS, { status: 200, body: {} }, { status: 200, body: {} }]);
+      const client = new OFWClient();
+      process.env.OFW_REQUEST_TIMEOUT_MS = '5000';
+      await client.request('GET', '/pub/v1/a'); // valid number → `? n`
+      process.env.OFW_REQUEST_TIMEOUT_MS = 'not-a-number';
+      await client.request('GET', '/pub/v1/b'); // invalid → `: DEFAULT`
+    } finally {
+      if (orig === undefined) delete process.env.OFW_REQUEST_TIMEOUT_MS;
+      else process.env.OFW_REQUEST_TIMEOUT_MS = orig;
+    }
+  });
+
+  it('falls back to a TTL-based token expiry when resolveAuth returns no expiresAt', async () => {
+    const auth = await import('../src/auth.js');
+    const spy = vi.spyOn(auth, 'resolveAuth').mockResolvedValue({ token: 'tok', expiresAt: undefined });
+    mockFetch([{ status: 200, body: { data: 'ok' } }]); // resolveAuth mocked → no login fetches
+    const client = new OFWClient();
+    await client.request('GET', '/pub/v1/x');
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { getAttachmentsDir, getCacheDbPath, getDefaultInlineAttachments } from '../src/config.js';
+import { getAttachmentsDir, getCacheDbPath, getDefaultInlineAttachments, getCacheDir } from '../src/config.js';
 
 describe('getCacheDbPath', () => {
   let tmp: string;
@@ -123,5 +123,20 @@ describe('getDefaultInlineAttachments', () => {
   it.each(['false', '0', 'no', 'off', '', 'maybe'])('treats %j as false', (val) => {
     process.env.OFW_INLINE_ATTACHMENTS = val;
     expect(getDefaultInlineAttachments()).toBe(false);
+  });
+});
+
+describe('getCacheDir', () => {
+  it('honors OFW_CACHE_DIR when set, else falls back to ~/.cache/ofw-mcp', () => {
+    const orig = process.env.OFW_CACHE_DIR;
+    try {
+      process.env.OFW_CACHE_DIR = '/tmp/custom-cache';
+      expect(getCacheDir()).toBe('/tmp/custom-cache');
+      delete process.env.OFW_CACHE_DIR;
+      expect(getCacheDir()).toBe(join(homedir(), '.cache', 'ofw-mcp'));
+    } finally {
+      if (orig === undefined) delete process.env.OFW_CACHE_DIR;
+      else process.env.OFW_CACHE_DIR = orig;
+    }
   });
 });

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -525,6 +525,35 @@ describe('syncAll', () => {
     expect(result.note).toMatch(/unread inbox/);
   });
 
+  it('silently skips a folder outside the known set (defensive no-op)', async () => {
+    const client = new OFWClient();
+    const spy = vi.spyOn(client, 'request').mockResolvedValueOnce(foldersResponse());
+    // The tool layer constrains folders via a zod enum; at this layer an
+    // unknown folder matches none of the branches and is skipped.
+    const result = await syncAll(client, { folders: ['bogus' as never] });
+    expect(result.synced).toEqual({});
+    expect(spy).toHaveBeenCalledTimes(1); // only resolveFolderIds
+  });
+
+  it('threads deep:true through to the inbox and sent folder walks', async () => {
+    const client = new OFWClient();
+    vi.spyOn(client, 'request')
+      .mockResolvedValueOnce(foldersResponse())
+      // inbox: one read item, body, then empty (deep walks to the empty page)
+      .mockResolvedValueOnce(listResponse([{ id: 10, unread: false }]))
+      .mockResolvedValueOnce({ body: 'inbox-10' })
+      .mockResolvedValueOnce(listResponse([]))
+      // sent: one item, body, then empty
+      .mockResolvedValueOnce(listResponse([{ id: 20 }]))
+      .mockResolvedValueOnce({ body: 'sent-20' })
+      .mockResolvedValueOnce(listResponse([]))
+      .mockResolvedValueOnce(draftListResponse([])); // drafts empty
+
+    const result = await syncAll(client, { deep: true }); // sync.ts:290 opts.deep present
+
+    expect(result.synced).toEqual({ inbox: 1, sent: 1, drafts: 0 });
+  });
+
   it('respects an explicit folders subset', async () => {
     const client = new OFWClient();
     const spy = vi.spyOn(client, 'request')
@@ -538,5 +567,58 @@ describe('syncAll', () => {
     const sentCalls = spy.mock.calls.filter((c) => (c[1] as string).includes('folders=222'));
     expect(inboxCalls).toHaveLength(0);
     expect(sentCalls).toHaveLength(0);
+  });
+});
+
+describe('sync — missing-optional-field fallbacks', () => {
+  it('syncMessageFolder fills defaults for bare items, empty body, and a bare attachment meta', async () => {
+    const client = new OFWClient();
+    vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ data: [
+        { id: 10, showNeverViewed: false, recipients: [] },                                    // read, no subject/from/date
+        { id: 11, showNeverViewed: true, date: { dateTime: '2026-05-04T12:00:00Z' }, recipients: [] }, // unread, no from
+      ] })
+      .mockResolvedValueOnce({ files: [777] })  // detail for 10: no body, has a file attachment
+      .mockResolvedValueOnce({})                // /myfiles/777: bare meta → all ?? fallbacks
+      .mockResolvedValueOnce({ data: [] });     // page 2 empty → break
+
+    const result = await syncMessageFolder(client, 'inbox', '111', { fetchUnreadBodies: false });
+    expect(result.synced).toBe(2);
+    expect(getMessage(10)?.subject).toBe('(no subject)');
+    expect(getMessage(10)?.fromUser).toBe('');
+    expect(getMessage(10)?.body).toBe('');
+    expect(result.unread).toEqual([{ id: 11, subject: undefined, from: '', sentAt: '2026-05-04T12:00:00Z' }]);
+    const atts = listAttachmentsForMessage(10);
+    expect(atts[0]?.fileName).toBe('file-777');
+  });
+
+  it('resolveFolderIds throws when the response has no systemFolders array', async () => {
+    const client = new OFWClient();
+    vi.spyOn(client, 'request').mockResolvedValue({} as never); // no systemFolders → `?? []`
+    await expect(resolveFolderIds(client)).rejects.toThrow();
+  });
+
+  it('syncDrafts fills defaults for a bare draft (no date/subject/body)', async () => {
+    const client = new OFWClient();
+    vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ data: [{ id: 50, recipients: [] }] }) // no date/subject
+      .mockResolvedValueOnce({}); // detail: no subject/body
+    const result = await syncDrafts(client, '333');
+    expect(result.synced).toBe(1);
+    expect(getDraft(50)?.subject).toBe('(no subject)');
+    expect(getDraft(50)?.body).toBe('');
+  });
+});
+
+describe('sync — empty/missing data arrays', () => {
+  it('syncMessageFolder treats a missing data array as an empty page', async () => {
+    const client = new OFWClient();
+    vi.spyOn(client, 'request').mockResolvedValueOnce({} as never); // no `data` → `?? []` → break
+    expect((await syncMessageFolder(client, 'inbox', '111', { fetchUnreadBodies: false })).synced).toBe(0);
+  });
+  it('syncDrafts treats a missing data array as no drafts', async () => {
+    const client = new OFWClient();
+    vi.spyOn(client, 'request').mockResolvedValueOnce({} as never);
+    expect((await syncDrafts(client, '333')).synced).toBe(0);
   });
 });

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -1532,3 +1532,157 @@ describe('ofw_get_message attachments', () => {
   });
 });
 
+
+describe('messages.ts — coverage backfill', () => {
+  it('upload_attachment: unknown extension + bare meta → octet-stream + filename fallbacks', async () => {
+    const file = join(tmpDir, 'note.unknownext');
+    writeFileSync(file, 'X');
+    const c = new OFWClient();
+    vi.spyOn(c, 'request').mockResolvedValue({ fileId: 8 }); // bare meta → 504–517
+    setup(c);
+    const out = JSON.parse((await handlers.get('ofw_upload_attachment')!({ path: file })).content[0].text);
+    expect(out.fileId).toBe(8);
+    expect(out.fileName).toBe('note.unknownext');
+    expect(out.mimeType).toBe('application/octet-stream'); // mimeFromName fallback (43)
+  });
+
+  it('upload_attachment: rejects a non-file path', async () => {
+    const c = new OFWClient();
+    vi.spyOn(c, 'request').mockResolvedValue({});
+    setup(c);
+    await expect(handlers.get('ofw_upload_attachment')!({ path: tmpDir })).rejects.toThrow(/Not a file/); // 480
+  });
+
+  it('download_attachment: fetches metadata when uncached and writes into a saveTo directory', async () => {
+    const c = new OFWClient();
+    vi.spyOn(c, 'request').mockResolvedValue({ fileId: 50, fileName: 'f.bin', fileType: 'application/octet-stream', fileSize: 3 });
+    vi.spyOn(c, 'requestBinary').mockResolvedValue({ body: Buffer.from('abc'), contentType: 'application/octet-stream', suggestedFileName: 'f.bin' } as never);
+    setup(c);
+    const out = JSON.parse((await handlers.get('ofw_download_attachment')!({ fileId: 50, saveTo: join(tmpDir, 'dl') + '/' })).content[0].text);
+    expect(out.path).toContain('50-f.bin'); // 540 (uncached) + dir branch (574–577)
+  });
+
+  it('download_attachment: writes to an explicit saveTo file path (binary fallbacks)', async () => {
+    upsertAttachmentForMessage({ fileId: 51, fileName: 'g.bin', label: 'g', mimeType: 'application/octet-stream', sizeBytes: 3, metadata: {}, messageId: 0 });
+    const c = new OFWClient();
+    vi.spyOn(c, 'requestBinary').mockResolvedValue({ body: Buffer.from('xyz') } as never); // no contentType/suggestedFileName → fallbacks
+    setup(c);
+    const dest = join(tmpDir, 'explicit.bin');
+    const out = JSON.parse((await handlers.get('ofw_download_attachment')!({ fileId: 51, saveTo: dest })).content[0].text);
+    expect(out.path).toBe(dest); // file-path branch (578)
+  });
+
+  it('list_messages: folderId "sent" + a paged note when results exceed the page', async () => {
+    for (let i = 1; i <= 5; i++) upsertMessage({ id: i, folder: 'sent', subject: `s${i}`, fromUser: 'A', sentAt: `2026-05-0${i}T00:00:00Z`, recipients: [], body: 'b', fetchedBodyAt: 't', replyToId: null, chainRootId: null, listData: {} });
+    const c = new OFWClient(); vi.spyOn(c, 'request').mockResolvedValue({}); setup(c);
+    const out = JSON.parse((await handlers.get('ofw_list_messages')!({ folderId: 'sent', size: 2, page: 1 })).content[0].text);
+    expect(out.total).toBe(5);
+    expect(out.note).toMatch(/Showing 1–2 of 5/); // 85 (sent) + 102 (paged note)
+  });
+
+  it('get_message: detail fetch with missing optional fields fills defaults', async () => {
+    const c = new OFWClient();
+    vi.spyOn(c, 'request').mockResolvedValue({ id: 77, subject: 'S', files: [] }); // detail: no subject/from/date/body
+    setup(c);
+    const out = JSON.parse((await handlers.get('ofw_get_message')!({ messageId: 77 })).content[0].text);
+    expect(out.fromUser).toBe('');  // 180
+    expect(out.body).toBe('');      // 183
+  });
+
+  it('send_message: reports the missing required fields for a fresh send', async () => {
+    const c = new OFWClient(); vi.spyOn(c, 'request').mockResolvedValue({}); setup(c);
+    await expect(handlers.get('ofw_send_message')!({})).rejects.toThrow(/subject|body|recipientIds/); // 244–246
+  });
+});
+
+describe('messages.ts — attachment-backfill branches', () => {
+  const M = (over: Record<string, unknown>) => ({ id: 0, folder: 'inbox', subject: 's', fromUser: 'A', sentAt: 't', recipients: [], body: 'b', fetchedBodyAt: 't', replyToId: null, chainRootId: null, listData: {}, ...over });
+
+  it('get_message: cached message with non-object listData skips backfill', async () => {
+    upsertMessage(M({ id: 60, listData: 'not-an-object' }) as never);
+    const c = new OFWClient(); vi.spyOn(c, 'request').mockResolvedValue({}); setup(c);
+    expect(JSON.parse((await handlers.get('ofw_get_message')!({ messageId: 60 })).content[0].text).id).toBe(60); // 51
+  });
+
+  it('get_message: cached listData.files array triggers attachment backfill', async () => {
+    upsertMessage(M({ id: 61, listData: { files: [9] } }) as never);
+    const c = new OFWClient();
+    vi.spyOn(c, 'request').mockResolvedValueOnce({ files: [9] }).mockResolvedValueOnce({ fileId: 9, fileName: 'x.pdf' });
+    setup(c);
+    expect(JSON.parse((await handlers.get('ofw_get_message')!({ messageId: 61 })).content[0].text).attachments).toHaveLength(1); // 54
+  });
+
+  it('get_message: non-cached detail with files harvests attachment metadata', async () => {
+    const c = new OFWClient();
+    vi.spyOn(c, 'request').mockResolvedValueOnce({ id: 62, subject: 'S', files: [12] }).mockResolvedValueOnce({ fileId: 12, fileName: 'y.pdf' });
+    setup(c);
+    expect(JSON.parse((await handlers.get('ofw_get_message')!({ messageId: 62 })).content[0].text).attachments).toHaveLength(1); // 190-191
+  });
+
+  it('get_message: listData hints files but re-fetch returns none → no backfill', async () => {
+    upsertMessage(M({ id: 63, listData: { files: [9] } }) as never);
+    const c = new OFWClient();
+    vi.spyOn(c, 'request').mockResolvedValueOnce({ files: [] }); // detail has no fileIds → 157[1]
+    setup(c);
+    expect(JSON.parse((await handlers.get('ofw_get_message')!({ messageId: 63 })).content[0].text).attachments).toHaveLength(0);
+  });
+
+  it('send_message: subject+body present lists only the missing recipientIds', async () => {
+    const c = new OFWClient(); vi.spyOn(c, 'request'); setup(c);
+    await expect(handlers.get('ofw_send_message')!({ subject: 'S', body: 'B' })) // 244[1],245[1]
+      .rejects.toThrow(/requires recipientIds\b/);
+  });
+
+  it('send_message: only recipientIds present lists subject, body', async () => {
+    const c = new OFWClient(); vi.spyOn(c, 'request'); setup(c);
+    await expect(handlers.get('ofw_send_message')!({ recipientIds: [1] })) // 246[1]
+      .rejects.toThrow(/requires subject, body\b/);
+  });
+
+  it('send_message: re-fetched detail missing fields falls back to inputs', async () => {
+    const c = new OFWClient();
+    vi.spyOn(c, 'request')
+      .mockResolvedValueOnce({ entityId: 500 }) // POST
+      .mockResolvedValueOnce({ id: 500 }); // GET bare detail → 290-294 fallbacks
+    setup(c);
+    const out = JSON.parse((await handlers.get('ofw_send_message')!({ subject: 'S', body: 'B', recipientIds: [1] })).content[0].text);
+    expect(out.id).toBe(500);
+    expect(out.subject).toBe('S'); // detail.subject ?? subject
+    expect(out.fromUser).toBe(''); // detail.from?.name ?? ''
+    expect(out.body).toBe('B'); // detail.body ?? body
+  });
+
+  it('send_message: POST with no id returns the generic success message', async () => {
+    const c = new OFWClient();
+    vi.spyOn(c, 'request').mockResolvedValueOnce(null); // raw falsy, id null → 324[1]
+    setup(c);
+    const text = (await handlers.get('ofw_send_message')!({ subject: 'S', body: 'B', recipientIds: [1] })).content[0].text;
+    expect(text).toBe('Message sent successfully.');
+  });
+
+  it('save_draft: POST with no id returns the generic saved message', async () => {
+    const c = new OFWClient();
+    vi.spyOn(c, 'request').mockResolvedValueOnce(null); // raw falsy, id null → 421[1]
+    setup(c);
+    const text = (await handlers.get('ofw_save_draft')!({ subject: 'S', body: 'B' })).content[0].text;
+    expect(text).toBe('Draft saved.');
+  });
+
+  it('download_attachment: no saveTo writes into the default attachments dir', async () => {
+    const c = new OFWClient();
+    vi.spyOn(c, 'request').mockResolvedValueOnce({ fileId: 70, fileName: 'd.bin', fileType: 'application/octet-stream', fileSize: 3 });
+    vi.spyOn(c, 'requestBinary').mockResolvedValueOnce({ body: Buffer.from('def'), contentType: 'application/octet-stream', suggestedFileName: 'd.bin' } as never);
+    setup(c);
+    const dir = mkdtempSync(join(tmpdir(), 'ofw-attach-'));
+    const prev = process.env.OFW_ATTACHMENTS_DIR;
+    process.env.OFW_ATTACHMENTS_DIR = dir;
+    try {
+      const out = JSON.parse((await handlers.get('ofw_download_attachment')!({ fileId: 70 })).content[0].text); // 578
+      expect(out.path).toBe(join(dir, '70-d.bin'));
+      expect(readFileSync(out.path).toString()).toBe('def');
+    } finally {
+      if (prev === undefined) delete process.env.OFW_ATTACHMENTS_DIR; else process.env.OFW_ATTACHMENTS_DIR = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,9 @@
 import { defineConfig } from 'vitest/config';
 
-// Thresholds are aspirational targets, not strict gates — CI runs
-// `npm test` (no --coverage), so these only fire on a local
-// `vitest run --coverage`. Set them slightly below current reality so
-// a real regression trips them, but a one-line uncovered branch
-// doesn't. Tighten as we add coverage; never raise above the actual
-// number to avoid creating a perpetual red light.
+// Coverage-enforced: `npm run test:coverage` (wired into CI) fails the
+// build on any regression below 100%. Genuinely-unreachable defensive
+// branches are excluded inline with `/* v8 ignore next */`. The bare
+// `npm test` stays coverage-free for fast local iteration.
 export default defineConfig({
   test: {
     coverage: {
@@ -13,10 +11,10 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['src/index.ts'], // stdio entry point — not unit-testable
       thresholds: {
-        lines: 95,
+        lines: 100,
         functions: 100,
-        branches: 80,
-        statements: 95,
+        branches: 100,
+        statements: 100,
       },
     },
   },


### PR DESCRIPTION
## What

Follow-up to #72 (mcp-utils 0.4.0 `fileBlob` adoption): close the remaining coverage gaps and make 100% a hard gate.

- **`vitest.config.ts`** — raise thresholds to 100% lines/branches/functions/statements (was aspirational 95/80/100/95).
- **`package.json`** — add `test:coverage` = `vitest run --coverage`.
- **`.github/workflows/ci.yml`** — CI runs `npm run test:coverage` instead of `npm test`, so a coverage regression now fails the build (matching the skylight-mcp pattern).
- **Tests** — backfill null/fallback branches in `cache`, the auth/timeout fallbacks in `client`, the cache-dir fallback in `config`, the `deep`/empty-data/unknown-folder paths in `sync`, and the `send_message`/`save_draft` missing-field, bare-detail-refetch, no-id, and no-`saveTo` download branches in `tools/messages`.
- **`/* v8 ignore */`** — three genuinely-unreachable defensive guards (cache `COUNT(*)` row, client `Authorization` redaction, messages attachment-meta refetch), each annotated with a rationale.

## Coverage

```
Statements   : 100% ( 609/609 )
Branches     : 100% ( 505/505 )
Functions    : 100% ( 98/98 )
Lines        : 100% ( 568/568 )
```

`npm run build` and `npm run test:coverage` both green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)