### PR TITLE
fix: restrict cache dir/db permissions to owner-only (0700/0600)

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, chmodSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { getCacheDbPath } from './config.js';
 
@@ -73,14 +73,32 @@ function migrate(db: DatabaseSync): void {
   ).run('schema_version', '2');
 }
 
+// The cache holds full co-parenting message history — keep it private to the
+// owning user. Modes are asserted on every open (not just creation): mkdirSync
+// `mode` and SQLite's default file mode only apply when the path is first
+// created, so a pre-existing dir/db keeps whatever (world-readable) mode it
+// had. The -wal/-shm siblings appear and disappear with WAL checkpoints, hence
+// the existence check.
+function enforceCachePermissions(dbPath: string): void {
+  chmodSync(dirname(dbPath), 0o700);
+  chmodSync(dbPath, 0o600);
+  for (const sibling of [`${dbPath}-wal`, `${dbPath}-shm`]) {
+    if (existsSync(sibling)) chmodSync(sibling, 0o600);
+  }
+}
+
 export function openCache(): Cache {
   if (instance) return instance;
   const path = getCacheDbPath();
   mkdirSync(dirname(path), { recursive: true });
   const db = new DatabaseSync(path);
+  // First pass: lock down dir + db before WAL siblings exist.
+  enforceCachePermissions(path);
   db.exec('PRAGMA journal_mode = WAL');
   db.exec('PRAGMA foreign_keys = ON');
   migrate(db);
+  // Second pass: the migration writes created -wal/-shm — lock those down too.
+  enforceCachePermissions(path);
   instance = { db };
   return instance;
 }

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, statSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { getCacheDbPath } from '../src/config.js';
 import {
   openCache, closeCache,
   upsertMessage, getMessage, deleteMessage, listMessages, countMessages, type MessageRow,
@@ -71,6 +72,29 @@ describe('openCache', () => {
     openCache();
     closeCache();
     expect(() => openCache()).not.toThrow();
+  });
+
+  it('restricts the cache dir to 0700 and database files (incl. -wal/-shm) to 0600 on open', () => {
+    openCache();
+    const dbPath = getCacheDbPath();
+    expect(statSync(tmp).mode & 0o777).toBe(0o700);
+    expect(statSync(dbPath).mode & 0o777).toBe(0o600);
+    // WAL mode + migration writes mean the -wal/-shm siblings exist while open.
+    expect(existsSync(`${dbPath}-wal`)).toBe(true);
+    expect(statSync(`${dbPath}-wal`).mode & 0o777).toBe(0o600);
+    expect(existsSync(`${dbPath}-shm`)).toBe(true);
+    expect(statSync(`${dbPath}-shm`).mode & 0o777).toBe(0o600);
+  });
+
+  it('re-asserts restrictive permissions on every open, not just at creation', () => {
+    openCache();
+    closeCache();
+    const dbPath = getCacheDbPath();
+    chmodSync(tmp, 0o755);
+    chmodSync(dbPath, 0o644);
+    openCache();
+    expect(statSync(tmp).mode & 0o777).toBe(0o700);
+    expect(statSync(dbPath).mode & 0o777).toBe(0o600);
   });
 });
 


### PR DESCRIPTION
## Summary

[MEDIUM-SECURITY audit finding] The SQLite cache under `~/.cache/ofw-mcp/` holds full co-parenting message history but was created with default world-readable permissions.

- `openCache()` now asserts `chmod 0700` on the cache directory and `chmod 0600` on the database file
- The `-wal`/`-shm` WAL siblings are also locked to `0600` when they exist (existence-checked — they come and go with checkpoints)
- Permissions are re-asserted on **every** open, not just creation — `mkdirSync` mode / SQLite default file mode only apply when the path is first created, so pre-existing caches keep their old world-readable modes otherwise
- Enforcement runs twice per open: once right after the DB handle is created (before WAL siblings exist) and once after migration writes (when `-wal`/`-shm` exist)

## Tests

- New: first open leaves dir at 0700 and db + `-wal`/`-shm` at 0600
- New: loosened modes (0755/0644) on an existing cache are re-tightened on reopen
- `npm run build && npm test`: 269/269 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)