### PR TITLE
refactor: adopt shared TokenManager for the OFW bearer lifecycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ofw-mcp",
       "version": "2.3.1",
       "dependencies": {
-        "@chrischall/mcp-utils": "^0.6.0",
+        "@chrischall/mcp-utils": "^0.9.0",
         "@fetchproxy/bootstrap": "^1.3.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/@chrischall/mcp-utils": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.6.0.tgz",
-      "integrity": "sha512-My+O1SJ1fkBRFJwZYwECJY268O7V7345xn2JoWKGb/dEEvkhsBIZaJIoeunH/3LxDepnIcjLZpMlVg5+6CjxpQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.9.0.tgz",
+      "integrity": "sha512-xBliGuEqqmXagDY4i8eJkA8w1o7fAIp8szZGQfBUYA86+VKgeAJWA0gk13WNXXIfl4ndE/3ua6rpKd/BY9rekw==",
       "license": "MIT",
       "peerDependencies": {
         "@fetchproxy/server": "*",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@chrischall/mcp-utils": "^0.6.0",
+    "@chrischall/mcp-utils": "^0.9.0",
     "@fetchproxy/bootstrap": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -83,9 +83,9 @@ function fetchproxyDisabled(): boolean {
  * Resolve OFW auth using the three-path priority described at the top of
  * this file. Throws with an actionable error message when no path succeeds.
  *
- * Callers (i.e. `OFWClient.login()`) treat the return value as opaque
- * credentials — they should not branch on `source`. The field exists for
- * logging / future cache-keying only.
+ * Callers (i.e. the `OFWClient` TokenManager refresh callback) treat the
+ * return value as opaque credentials — they should not branch on `source`.
+ * The field exists for logging / future cache-keying only.
  */
 export async function resolveAuth(): Promise<ResolvedAuth> {
   // ── Path 1: env-var credentials (unchanged from pre-fetchproxy behavior).

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import { loadDotenvSafely } from '@chrischall/mcp-utils';
+import { TokenManager } from '@chrischall/mcp-utils/session';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { resolveAuth } from './auth.js';
@@ -57,13 +58,47 @@ function getRequestTimeoutMs(): number {
   return Number.isFinite(n) && n > 0 ? n : DEFAULT_REQUEST_TIMEOUT_MS;
 }
 
+// Sentinel "refresh token" handed to the shared TokenManager. OFW has no
+// OAuth-style refresh token — every renewal re-runs the full `resolveAuth()`
+// (password POST or fetchproxy snapshot). The TokenManager only refuses to
+// refresh when its refresh token is `undefined`, so a non-empty placeholder
+// keeps the single-flight refresh path live; the refresh callback ignores it.
+const OFW_REFRESH_SENTINEL = 'ofw';
+
 export class OFWClient {
-  private token: string | null = null;
-  private tokenExpiry: Date | null = null;
+  // Bearer-token lifecycle is delegated to the shared, race-safe TokenManager
+  // (proactive refresh inside the skew window, single-flight refresh so a burst
+  // of concurrent callers coalesces onto ONE `resolveAuth()`, and a 401-replay
+  // guarded against double-refresh). It is created lazily, seeded with an
+  // already-expired placeholder token so the first request drives the refresh
+  // callback — i.e. the original "log in on first request" behavior.
+  private tokenManager: TokenManager | undefined;
+
+  private getTokenManager(): TokenManager {
+    if (!this.tokenManager) {
+      this.tokenManager = new TokenManager({
+        initial: { accessToken: '', refreshToken: OFW_REFRESH_SENTINEL, expiresAt: 0 },
+        skewMs: OFW_TOKEN_EXPIRY_SKEW_MS,
+        // Map OFW's mint/refresh onto the refresh callback. `resolveAuth()`
+        // returns a token and a best-effort expiry; when the fetchproxy path
+        // can't supply one we fall back to the same 6h estimate the password
+        // path uses (the 401-replay covers a wrong guess). We re-arm the
+        // sentinel so the manager can refresh again later.
+        refresh: async () => {
+          const { token, expiresAt } = await resolveAuth();
+          return {
+            accessToken: token,
+            refreshToken: OFW_REFRESH_SENTINEL,
+            expiresAt: (expiresAt ?? new Date(Date.now() + OFW_TOKEN_TTL_MS)).getTime(),
+          };
+        },
+      });
+    }
+    return this.tokenManager;
+  }
 
   async request<T>(method: string, path: string, body?: unknown): Promise<T> {
-    await this.ensureAuthenticated();
-    const response = await this.fetchWithRetry(method, path, body, 'application/json', false);
+    const response = await this.fetchAuthed(method, path, body, 'application/json');
     const text = await response.text();
     if (debugLogEnabled()) {
       console.error(`[ofw-debug] response body: ${text || '<empty>'}`);
@@ -73,8 +108,7 @@ export class OFWClient {
 
   /** Like `request`, but returns the raw bytes plus Content-Type/-Disposition metadata. */
   async requestBinary(method: string, path: string): Promise<BinaryResponse> {
-    await this.ensureAuthenticated();
-    const response = await this.fetchWithRetry(method, path, undefined, 'application/octet-stream', false);
+    const response = await this.fetchAuthed(method, path, undefined, 'application/octet-stream');
     return {
       body: Buffer.from(await response.arrayBuffer()),
       contentType: response.headers.get('content-type'),
@@ -82,21 +116,54 @@ export class OFWClient {
     };
   }
 
-  // Single fetch+retry scaffold for both JSON and binary callers. Handles
-  // 401 (re-auth and replay once), 429 (wait 2s and replay once), and
-  // turns any other non-2xx into a thrown Error.
-  private async fetchWithRetry(
+  // Authenticated fetch for both JSON and binary callers. Auth (proactive
+  // refresh inside the skew window + one 401-replay, guarded against a
+  // double-refresh under concurrency) is delegated to the shared TokenManager's
+  // `withAuth`. The 429 wait-and-replay and the non-2xx → throw remain here.
+  private async fetchAuthed(
     method: string,
     path: string,
     body: unknown,
     accept: string,
-    isRetry: boolean,
+  ): Promise<Response> {
+    // `withAuth` invokes `call` once, and again after a refresh on a 401. The
+    // second invocation is the replay — mark it `(retry)` in the debug log,
+    // preserving the prior bespoke-loop diagnostic.
+    let attempt = 0;
+    let response = await this.getTokenManager().withAuth((token) =>
+      this.fetchOnce(method, path, body, accept, token, attempt++ > 0),
+    );
+    if (response.status === 429) {
+      await new Promise<void>((r) => setTimeout(r, 2000));
+      response = await this.getTokenManager().withAuth((token) =>
+        this.fetchOnce(method, path, body, accept, token, true),
+      );
+      if (response.status === 429) throw new Error('Rate limited by OFW API');
+    }
+    if (!response.ok) {
+      throw new Error(`OFW API error: ${response.status} ${response.statusText} for ${method} ${path}`);
+    }
+    return response;
+  }
+
+  // A single OFW API fetch with the bearer token supplied by `withAuth`.
+  // Carries the per-request timeout (AbortController + setTimeout so vitest
+  // fake timers can drive it and we attach a clear error message) and the
+  // OFW_DEBUG_LOG instrumentation. Returns the raw Response — 401/429/non-2xx
+  // handling lives in the callers (`withAuth` and `fetchAuthed`).
+  private async fetchOnce(
+    method: string,
+    path: string,
+    body: unknown,
+    accept: string,
+    token: string,
+    isRetry = false,
   ): Promise<Response> {
     const isFormData = body instanceof FormData;
     const headers: Record<string, string> = {
       ...OFW_PROTOCOL_HEADERS,
       Accept: accept,
-      Authorization: `Bearer ${this.token!}`,
+      Authorization: `Bearer ${token}`,
     };
     if (body !== undefined && !isFormData) headers['Content-Type'] = 'application/json';
 
@@ -150,47 +217,7 @@ export class OFWClient {
       console.error(`[ofw-debug] ← ${response.status} ${response.statusText} (${Date.now() - startedAt}ms)`);
     }
 
-    if (response.status === 401 && !isRetry) {
-      this.token = null;
-      this.tokenExpiry = null;
-      await this.ensureAuthenticated();
-      return this.fetchWithRetry(method, path, body, accept, true);
-    }
-    if (response.status === 429) {
-      if (!isRetry) {
-        await new Promise<void>((r) => setTimeout(r, 2000));
-        return this.fetchWithRetry(method, path, body, accept, true);
-      }
-      throw new Error('Rate limited by OFW API');
-    }
-    if (!response.ok) {
-      throw new Error(`OFW API error: ${response.status} ${response.statusText} for ${method} ${path}`);
-    }
     return response;
-  }
-
-  private async ensureAuthenticated(): Promise<void> {
-    if (!this.isTokenExpiredSoon()) return;
-    await this.login();
-  }
-
-  // Auth resolution is delegated to `./auth.ts`. This client doesn't care
-  // whether the token came from a password POST or from a one-shot
-  // fetchproxy session-snapshot — it just consumes the result.
-  //
-  // If `expiresAt` is missing (the fetchproxy path on a tab whose
-  // browser didn't persist tokenExpiry), we fall back to the same 6h
-  // estimate the password path uses. The 401-replay path covers us if
-  // the estimate is wrong.
-  private async login(): Promise<void> {
-    const { token, expiresAt } = await resolveAuth();
-    this.token = token;
-    this.tokenExpiry = expiresAt ?? new Date(Date.now() + OFW_TOKEN_TTL_MS);
-  }
-
-  private isTokenExpiredSoon(): boolean {
-    if (!this.token || !this.tokenExpiry) return true;
-    return this.tokenExpiry.getTime() - Date.now() < OFW_TOKEN_EXPIRY_SKEW_MS;
   }
 }
 


### PR DESCRIPTION
Wave 7 of the 2026-06-09 fleet audit: migrate OFW's hand-rolled token lifecycle onto the shared, race-safe `TokenManager` from `@chrischall/mcp-utils/session`.

## What changed

`OFWClient`'s bespoke bearer machinery is replaced by a lazily-constructed `TokenManager`:

**Deleted** (`src/client.ts`):
- `token` / `tokenExpiry` instance fields
- `ensureAuthenticated()` — proactive refresh gate
- `login()` — `resolveAuth()` + 6h TTL fallback
- `isTokenExpiredSoon()` — skew check
- the in-loop `401 → null token → re-auth → replay` branch of `fetchWithRetry`

**Mapping:**
- OFW's mint/refresh (`resolveAuth()`, with the 6h `OFW_TOKEN_TTL_MS` fallback when the fetchproxy path yields no expiry) now lives in the `TokenManager` **refresh callback**.
- The 5-min skew (`OFW_TOKEN_EXPIRY_SKEW_MS`) is passed as `skewMs`.
- OFW has no OAuth refresh token, so a non-empty sentinel keeps the single-flight refresh path live; the callback ignores it and always re-runs the full login.
- The manager is seeded with an expired placeholder (`expiresAt: 0`, empty token) so the first request drives the refresh callback — preserving "log in on first request". The empty token never hits the wire (proactive refresh fires first).
- Authed requests route through `tokenManager.withAuth(...)`; the renamed `fetchOnce` is the single-attempt fetch.

## Gains
- **Single-flight refresh** — a burst of concurrent callers coalesces onto ONE `resolveAuth()`.
- **Double-refresh guard** — a late 401 under the old token (after a concurrent rotation) replays without a second refresh.

## Preserved (OFW-specific, kept in the client)
Per-request timeout (AbortController + setTimeout), `OFW_DEBUG_LOG` instrumentation incl. the `(retry)` marker on the 401-replay, binary responses, and the 429 wait-2s-and-replay path.

## Tests
Pure refactor — **all 269 tests pass with no test changes**; 100% line/branch/function/statement coverage retained. Bumps `@chrischall/mcp-utils` `^0.6.0` → `^0.9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)