### PR TITLE
ci: defer CI to ready-to-merge arming; release-ready gate for release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,34 @@ name: CI
 
 on:
   pull_request:
+    # `labeled` so arming `ready-to-merge` (or `release-ready` on a release
+    # PR) triggers the deferred run.
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   ci:
     runs-on: ubuntu-latest
+    # CI is the LAST gate, not a parallel cost:
+    #   - normal (human) PRs: CI runs only once auto-review passes and arms
+    #     `ready-to-merge` — review findings get fixed without burning CI
+    #     runs; the label event fires the run, and pushes to an armed PR
+    #     re-run via synchronize (label still present).
+    #   - release-please PRs: deferred to the `release-ready` ship signal.
+    #   - BOT-authored PRs (dependabot): immediate CI on open/synchronize —
+    #     bots never receive auto-review, so they'd otherwise merge with CI
+    #     skipped (native auto-merge treats a skipped required check as
+    #     satisfied).
+    #   - non-pull_request runs (workflow_call / push) fall through unharmed.
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.user.type != 'User' && github.event.action != 'labeled') ||
+      (
+        (github.event.action != 'labeled' || github.event.label.name == 'release-ready' || github.event.label.name == 'ready-to-merge') &&
+        (
+          (startsWith(github.event.pull_request.head.ref, 'release-please--') && contains(github.event.pull_request.labels.*.name, 'release-ready')) ||
+          (!startsWith(github.event.pull_request.head.ref, 'release-please--') && contains(github.event.pull_request.labels.*.name, 'ready-to-merge'))
+        )
+      )
     steps:
       - uses: actions/checkout@v6.0.2
 

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -70,10 +70,10 @@ jobs:
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.type == 'User' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      !startsWith(github.event.pull_request.head.ref, 'release-please--') &&
-      !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') &&
+      (!startsWith(github.event.pull_request.head.ref, 'release-please--') || contains(github.event.pull_request.labels.*.name, 'release-ready')) &&
+      (!contains(github.event.pull_request.labels.*.name, 'autorelease: pending') || contains(github.event.pull_request.labels.*.name, 'release-ready')) &&
       !contains(github.event.pull_request.labels.*.name, 'ready-to-merge') &&
-      (github.event.action != 'labeled' || github.event.label.name == 'review-with-opus')
+      (github.event.action != 'labeled' || github.event.label.name == 'review-with-opus' || github.event.label.name == 'release-ready')
     steps:
       - name: Apply auto-review label
         env:


### PR DESCRIPTION
## Summary
Fleet rollout of the curtaincall PR-workflow economy — same logic as chrischall/curtaincall#84 (release-ready gate) + chrischall/curtaincall#86 (CI after arming). CI becomes the LAST gate, not a parallel cost:

- **Human PRs**: CI runs only once auto-review passes and arms `ready-to-merge` — review-fix iterations cost zero CI runs. The label event fires the run; pushes to an armed PR re-run via synchronize.
- **Bot PRs (dependabot)**: immediate CI on open/synchronize, exactly as before — bots never get auto-review, and native auto-merge treats a skipped required check as satisfied; gating them would merge unbuilt code.
- **release-please PRs**: CI + review defer to the new **`release-ready` label** (the ship signal). New release flow: merge features → when ready to ship, label the release PR `release-ready` → CI + review run → pass arms `ready-to-merge` → auto-merge → tag/publish.
- `workflow_call` / push triggers fall through unharmed.

New normal-PR lifecycle: open → review (CI silent) → fix findings (CI silent) → pass → `ready-to-merge` → **CI runs** → green → auto-merge.

⚠️ Self-referential quirk: THIS PR runs under the OLD rules (CI fired on open); the first PR after merge proves the new flow.

## Test Plan
- [x] Both yaml valid (ruby -ryaml)
- [x] `release-ready` label created (green)
- [ ] Next human PR: CI absent until armed, runs on the label, merges on green
- [ ] Next release PR: stays quiet until `release-ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
