### PR TITLE
fix: bot PRs bypass the CI gate unconditionally (upstream curtaincall#86 review)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,15 @@ jobs:
     #     runs; the label event fires the run, and pushes to an armed PR
     #     re-run via synchronize (label still present).
     #   - release-please PRs: deferred to the `release-ready` ship signal.
-    #   - BOT-authored PRs (dependabot): immediate CI on open/synchronize —
+    #   - BOT-authored PRs (dependabot): CI on EVERY event, unconditionally —
+    #     a label event must not gate them (upstream curtaincall#86 review) —
     #     bots never receive auto-review, so they'd otherwise merge with CI
     #     skipped (native auto-merge treats a skipped required check as
     #     satisfied).
     #   - non-pull_request runs (workflow_call / push) fall through unharmed.
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.user.type != 'User' && github.event.action != 'labeled') ||
+      github.event.pull_request.user.type != 'User' ||
       (
         (github.event.action != 'labeled' || github.event.label.name == 'release-ready' || github.event.label.name == 'ready-to-merge') &&
         (


### PR DESCRIPTION
The PR-workflow-gates rollout shipped a buggy bot clause in the CI job-level `if:`: `(github.event.pull_request.user.type != 'User' && github.event.action != 'labeled')` makes any label event skip CI on bot-authored PRs, and since bots never receive auto-review, a bot PR could end up merging with the required CI check skipped (native auto-merge treats a skipped required check as satisfied). This applies the fix from the upstream curtaincall review (chrischall/curtaincall#86): the bot clause becomes an unconditional bypass — `github.event.pull_request.user.type != 'User' ||` — so bot PRs run CI on every event, with the comment updated to match.