### PR TITLE
ci: disable track_progress on labeled-event reviews so they don't crash

### DIFF
--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -163,7 +163,11 @@ jobs:
           # example). In automation mode this is off by default; we enable
           # it so reviews are visibly "in flight" rather than appearing all
           # at once at the end.
-          track_progress: true
+          # EXCEPT on `labeled` events (the `release-ready` /
+          # `review-with-opus` triggers): the action only supports
+          # track_progress for opened/synchronize/ready_for_review/reopened
+          # and hard-errors on anything else, killing the review.
+          track_progress: ${{ github.event.action != 'labeled' }}
           claude_args: |
             --model ${{ steps.model.outputs.model }}
             --json-schema '{"type":"object","required":["verdict","summary","important_findings"],"properties":{"verdict":{"enum":["pass","warn","fail"]},"summary":{"type":"string"},"important_findings":{"type":"array","items":{"type":"string"}}}}'


### PR DESCRIPTION
Fleet rollout of chrischall/gogcli-mcp#103: `claude-code-action` hard-errors on `labeled` pull_request events when `track_progress: true` — which is exactly how the `release-ready` gate and the `review-with-opus` force-rerun trigger reviews. Both label paths crashed before reviewing anything, blocking releases.

Fix: `track_progress: ${{ github.event.action != 'labeled' }}` — live progress comment stays for normal events; label-triggered runs lose only the cosmetic in-flight comment.

Note: this PR's own auto-review will fail the action's "workflow file must be identical to the default branch" validation — expected and ignorable for any PR that edits the review workflow itself (same as gogcli-mcp#103). CI still gates the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)