### PR TITLE
feat: OFW_WRITE_MODE gate (none/drafts/all) for structural write protection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ OFW_CACHE_DIR             Optional. Overrides cache dir (default ~/.cache/ofw-mc
 OFW_ATTACHMENTS_DIR       Optional. Where ofw_download_attachment writes (default ~/Downloads/ofw-mcp)
 OFW_INLINE_ATTACHMENTS    Optional. "1|true|yes|on" → return attachments as MCP content blocks by default
 OFW_DEBUG_LOG             Optional. "1|true|yes|on" → log every OFW request/response to stderr (Authorization redacted). Diagnostic only.
+OFW_WRITE_MODE            Optional. "none" = no write tools registered; "drafts" = draft-level writes only (ofw_save_draft, ofw_delete_draft, ofw_upload_attachment — never send or calendar/expense/journal writes); "all" = everything (default). Unrecognized values fail closed to "none". Structural gate: gated tools are not registered at all, so no host setting or injected instruction can invoke them.
 ```
 
 `auth.ts` ignores blank values, the strings `"undefined"`/`"null"`, and unsubstituted `${VAR}` placeholders — defensive against MCP hosts passing the env block through unexpanded.

--- a/README.md
+++ b/README.md
@@ -126,28 +126,40 @@ OFW_USERNAME=you@example.com OFW_PASSWORD=yourpass node dist/index.js
 
 ## Available tools
 
-Read-only tools run automatically. Write tools ask for your confirmation first.
+Read-only tools run automatically. Write tools ask for your confirmation first. The *Write mode* column shows the minimum `OFW_WRITE_MODE` a tool needs to be available at all — see [Write protection](#write-protection-ofw_write_mode) below.
 
-| Tool | What it does | Permission |
-|------|-------------|------------|
-| `ofw_get_profile` | Your profile and co-parent info | Auto |
-| `ofw_get_notifications` | Dashboard counts (unread messages, upcoming events, outstanding expenses) | Auto |
-| `ofw_list_message_folders` | Folders with unread counts — **get folder IDs here before listing messages** | Auto |
-| `ofw_list_messages` | Messages in a folder | Auto |
-| `ofw_get_message` | Full content of a single message | Auto |
-| `ofw_send_message` | Send a message | Confirm |
-| `ofw_list_drafts` | Draft messages | Auto |
-| `ofw_save_draft` | Create or update a draft | Confirm |
-| `ofw_delete_draft` | Delete a draft | Confirm |
-| `ofw_list_events` | Calendar events in a date range | Auto |
-| `ofw_create_event` | Create a calendar event | Confirm |
-| `ofw_update_event` | Update a calendar event | Confirm |
-| `ofw_delete_event` | Delete a calendar event | Confirm |
-| `ofw_get_expense_totals` | Expense summary totals | Auto |
-| `ofw_list_expenses` | Expense history | Auto |
-| `ofw_create_expense` | Log a new expense | Confirm |
-| `ofw_list_journal_entries` | Journal entries | Auto |
-| `ofw_create_journal_entry` | Create a journal entry | Confirm |
+| Tool | What it does | Permission | Write mode |
+|------|-------------|------------|------------|
+| `ofw_get_profile` | Your profile and co-parent info | Auto | any |
+| `ofw_get_notifications` | Dashboard counts (unread messages, upcoming events, outstanding expenses) | Auto | any |
+| `ofw_list_message_folders` | Folders with unread counts — **get folder IDs here before listing messages** | Auto | any |
+| `ofw_list_messages` | Messages in a folder | Auto | any |
+| `ofw_get_message` | Full content of a single message | Auto | any |
+| `ofw_send_message` | Send a message | Confirm | `all` |
+| `ofw_list_drafts` | Draft messages | Auto | any |
+| `ofw_save_draft` | Create or update a draft | Confirm | `drafts` |
+| `ofw_delete_draft` | Delete a draft | Confirm | `drafts` |
+| `ofw_list_events` | Calendar events in a date range | Auto | any |
+| `ofw_create_event` | Create a calendar event | Confirm | `all` |
+| `ofw_update_event` | Update a calendar event | Confirm | `all` |
+| `ofw_delete_event` | Delete a calendar event | Confirm | `all` |
+| `ofw_get_expense_totals` | Expense summary totals | Auto | any |
+| `ofw_list_expenses` | Expense history | Auto | any |
+| `ofw_create_expense` | Log a new expense | Confirm | `all` |
+| `ofw_list_journal_entries` | Journal entries | Auto | any |
+| `ofw_create_journal_entry` | Create a journal entry | Confirm | `all` |
+
+### Write protection (`OFW_WRITE_MODE`)
+
+The "Confirm" permission above is a *hint* to the MCP host — a host configured to auto-approve tools (or a user who clicked "always allow" once) would leave nothing between model output and a sent message. Because OurFamilyWizard is a court-of-record platform, the server also supports a structural gate: set `OFW_WRITE_MODE` in the server's `env` block and tools above your chosen level are **never registered**, so no host setting or prompt-injected instruction can invoke them.
+
+| `OFW_WRITE_MODE` | What's available |
+|------------------|------------------|
+| `none` | Read/sync/search only. No write tools exist. |
+| `drafts` | Adds draft-level writes: `ofw_save_draft`, `ofw_delete_draft`, `ofw_upload_attachment`. Nothing that lands on the court-visible record — the AI prepares, only a human signed into the OFW web UI can send. |
+| `all` | Everything (the default — fully backward compatible). |
+
+Unrecognized values fail closed to `none`, with a warning on stderr — a typo never silently grants write access.
 
 ## Troubleshooting
 

--- a/manifest.json
+++ b/manifest.json
@@ -38,7 +38,8 @@
         "OFW_USERNAME": "${user_config.ofw_username}",
         "OFW_PASSWORD": "${user_config.ofw_password}",
         "OFW_INLINE_ATTACHMENTS": "${user_config.ofw_inline_attachments}",
-        "OFW_ATTACHMENTS_DIR": "${user_config.ofw_attachments_dir}"
+        "OFW_ATTACHMENTS_DIR": "${user_config.ofw_attachments_dir}",
+        "OFW_WRITE_MODE": "${user_config.ofw_write_mode}"
       }
     }
   },
@@ -68,6 +69,13 @@
       "title": "Attachments download directory",
       "description": "Directory where ofw_download_attachment writes files when not returning inline. Defaults to ~/Downloads/ofw-mcp/. Pick a directory that is readable by your MCP host.",
       "required": false
+    },
+    "ofw_write_mode": {
+      "type": "string",
+      "title": "Write mode",
+      "description": "Structural write gate. \"none\" = no write tools registered (read/sync/search only); \"drafts\" = draft-level writes only (save/delete drafts, upload attachments — never send or calendar/expense/journal writes); \"all\" = everything (default). Unrecognized values fail closed to \"none\".",
+      "required": false,
+      "default": "all"
     }
   },
   "tools": [

--- a/server.json
+++ b/server.json
@@ -28,6 +28,12 @@
           "isRequired": false,
           "format": "string",
           "isSecret": true
+        },
+        {
+          "name": "OFW_WRITE_MODE",
+          "description": "Write-tool gate: \"none\" registers no write tools; \"drafts\" registers draft-level writes only (save/delete drafts, upload attachments); \"all\" registers everything (default). Unrecognized values fail closed to \"none\".",
+          "isRequired": false,
+          "format": "string"
         }
       ]
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,35 @@ export function parseBoolEnv(name: string): boolean {
   return parseBoolEnvUtil(name);
 }
 
+export type WriteMode = 'none' | 'drafts' | 'all';
+
+/**
+ * Gate for write-tool registration, read at registration time (startup).
+ *
+ *   none    No write tools are registered — pure read/sync/search surface.
+ *   drafts  Draft-level writes only (ofw_save_draft, ofw_delete_draft,
+ *           ofw_upload_attachment). Nothing that lands on the court-visible
+ *           record (send, calendar/expense/journal writes) is registered —
+ *           the only way to send remains a human in the OFW web UI.
+ *   all     Every tool registers (the default; fully backward compatible).
+ *
+ * Unregistered tools cannot be invoked by any host permission setting or
+ * injected instruction — the gate is structural, not behavioral. An
+ * unrecognized value fails closed to 'none': this is a safety control, so a
+ * typo must never silently grant write access.
+ */
+export function getWriteMode(): WriteMode {
+  const raw = process.env.OFW_WRITE_MODE;
+  if (typeof raw !== 'string' || raw.trim().length === 0) return 'all';
+  const mode = raw.trim().toLowerCase();
+  if (mode === 'none' || mode === 'drafts' || mode === 'all') return mode;
+  // stdio transport: stderr only — stdout is reserved for JSON-RPC.
+  console.error(
+    `[ofw-mcp] Unrecognized OFW_WRITE_MODE "${raw.trim()}" — failing closed to "none" (no write tools registered). Valid values: none, drafts, all.`,
+  );
+  return 'none';
+}
+
 // Default for ofw_download_attachment's `inline` arg when the caller doesn't
 // pass one. Set OFW_INLINE_ATTACHMENTS=true to have attachments returned as
 // MCP content blocks by default (skipping disk) — useful on sandboxed MCP

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -2,8 +2,12 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { OFWClient } from '../client.js';
 import { jsonResponse, textResponse } from './_shared.js';
+import { getWriteMode } from '../config.js';
 
 export function registerCalendarTools(server: McpServer, client: OFWClient): void {
+  // Calendar writes land on the court-visible record — OFW_WRITE_MODE 'all' only.
+  const allowWrites = getWriteMode() === 'all';
+
   server.registerTool('ofw_list_events', {
     description: 'List OurFamilyWizard calendar events in a date range',
     annotations: { readOnlyHint: true },
@@ -21,7 +25,7 @@ export function registerCalendarTools(server: McpServer, client: OFWClient): voi
     return jsonResponse(data);
   });
 
-  server.registerTool('ofw_create_event', {
+  if (allowWrites) server.registerTool('ofw_create_event', {
     description: 'Create a calendar event in OurFamilyWizard',
     annotations: { destructiveHint: false },
     inputSchema: {
@@ -42,7 +46,7 @@ export function registerCalendarTools(server: McpServer, client: OFWClient): voi
     return jsonResponse(data);
   });
 
-  server.registerTool('ofw_update_event', {
+  if (allowWrites) server.registerTool('ofw_update_event', {
     description: 'Update an existing OurFamilyWizard calendar event',
     annotations: { destructiveHint: true },
     inputSchema: {
@@ -61,7 +65,7 @@ export function registerCalendarTools(server: McpServer, client: OFWClient): voi
     return jsonResponse(data);
   });
 
-  server.registerTool('ofw_delete_event', {
+  if (allowWrites) server.registerTool('ofw_delete_event', {
     description: 'Delete an OurFamilyWizard calendar event',
     annotations: { destructiveHint: true },
     inputSchema: {

--- a/src/tools/expenses.ts
+++ b/src/tools/expenses.ts
@@ -2,8 +2,12 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { OFWClient } from '../client.js';
 import { jsonResponse } from './_shared.js';
+import { getWriteMode } from '../config.js';
 
 export function registerExpenseTools(server: McpServer, client: OFWClient): void {
+  // Expense writes land on the court-visible record — OFW_WRITE_MODE 'all' only.
+  const allowWrites = getWriteMode() === 'all';
+
   server.registerTool('ofw_get_expense_totals', {
     description: 'Get OurFamilyWizard expense summary totals (owed/paid)',
     annotations: { readOnlyHint: true },
@@ -26,7 +30,7 @@ export function registerExpenseTools(server: McpServer, client: OFWClient): void
     return jsonResponse(data);
   });
 
-  server.registerTool('ofw_create_expense', {
+  if (allowWrites) server.registerTool('ofw_create_expense', {
     description: 'Log a new expense in OurFamilyWizard',
     annotations: { destructiveHint: false },
     inputSchema: {

--- a/src/tools/journal.ts
+++ b/src/tools/journal.ts
@@ -2,8 +2,12 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { OFWClient } from '../client.js';
 import { jsonResponse } from './_shared.js';
+import { getWriteMode } from '../config.js';
 
 export function registerJournalTools(server: McpServer, client: OFWClient): void {
+  // Journal writes land on the court-visible record — OFW_WRITE_MODE 'all' only.
+  const allowWrites = getWriteMode() === 'all';
+
   server.registerTool('ofw_list_journal_entries', {
     description: 'List OurFamilyWizard journal entries',
     annotations: { readOnlyHint: true },
@@ -19,7 +23,7 @@ export function registerJournalTools(server: McpServer, client: OFWClient): void
     return jsonResponse(data);
   });
 
-  server.registerTool('ofw_create_journal_entry', {
+  if (allowWrites) server.registerTool('ofw_create_journal_entry', {
     description: 'Create a new journal entry in OurFamilyWizard',
     annotations: { destructiveHint: false },
     inputSchema: {

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -9,7 +9,7 @@ import {
   getDraft,
   type MessageRow, type DraftRow,
 } from '../cache.js';
-import { getAttachmentsDir, getDefaultInlineAttachments } from '../config.js';
+import { getAttachmentsDir, getDefaultInlineAttachments, getWriteMode } from '../config.js';
 import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, extname, join } from 'node:path';
 import { fileBlob } from '@chrischall/mcp-utils';
@@ -56,6 +56,14 @@ function listDataHintsAtFiles(listData: unknown): boolean {
 }
 
 export function registerMessageTools(server: McpServer, client: OFWClient): void {
+  // OFW_WRITE_MODE gate (see config.ts). Send lands on the court-visible
+  // record, so it is 'all'-only; draft-level writes (save/delete drafts,
+  // upload attachments) also register under 'drafts'. Read/sync/download
+  // tools always register.
+  const writeMode = getWriteMode();
+  const allowSend = writeMode === 'all';
+  const allowDrafts = writeMode !== 'none';
+
   server.registerTool('ofw_list_message_folders', {
     description: 'List OurFamilyWizard message folders (inbox, sent, etc.) and their unread counts. Returns folder IDs needed to call ofw_list_messages. Does NOT return message content.',
     annotations: { readOnlyHint: true },
@@ -194,7 +202,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     return jsonResponse({ ...row, attachments });
   });
 
-  server.registerTool('ofw_send_message', {
+  if (allowSend) server.registerTool('ofw_send_message', {
     description: 'Send a message via OurFamilyWizard. To send an existing draft, pass messageId — subject/body/recipientIds become optional overrides (missing fields default to the draft\'s cached values) and the draft is deleted after sending. To send a fresh message, supply subject/body/recipientIds directly. draftId is the legacy spelling of messageId and works the same way. If replyToId is provided, the cache may rewrite it to the latest reply in the same thread (a note is included in the response when this happens). Attach files by passing their fileIds (from ofw_upload_attachment) in myFileIDs. After sending, the tool re-fetches the message from OFW to populate the local cache and link attachments to the new message id.',
     annotations: { destructiveHint: true },
     inputSchema: {
@@ -342,7 +350,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     return jsonResponse(payload);
   });
 
-  server.registerTool('ofw_save_draft', {
+  if (allowDrafts) server.registerTool('ofw_save_draft', {
     description: 'Save a message as a draft in OurFamilyWizard. Recipients are optional. Pass messageId to replace an existing draft — note that under the hood this creates a NEW draft and deletes the old one (OFW\'s update-in-place endpoint silently no-ops while echoing the posted body, so we don\'t use it); the response.id will be the NEW id, not the messageId you passed, and the change is documented in a transparency NOTE in the response. If replyToId is provided, the cache may rewrite it to the latest reply in the thread (note included in response). Attach files by passing their fileIds (from ofw_upload_attachment) in myFileIDs. After saving, the tool re-fetches the draft from OFW to populate the local cache from authoritative server state.',
     annotations: { readOnlyHint: false },
     inputSchema: {
@@ -423,7 +431,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     return textResponse(notes ? `${notes}\n\n${text}` : text);
   });
 
-  server.registerTool('ofw_delete_draft', {
+  if (allowDrafts) server.registerTool('ofw_delete_draft', {
     description: 'Delete a draft message from OurFamilyWizard. Also removes the draft from the local cache.',
     annotations: { destructiveHint: true },
     inputSchema: {
@@ -465,7 +473,7 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     return jsonResponse(unread);
   });
 
-  server.registerTool('ofw_upload_attachment', {
+  if (allowDrafts) server.registerTool('ofw_upload_attachment', {
     description: 'Upload a local file to OurFamilyWizard\'s "My Files" so it can be attached to a message. Returns the fileId — pass that to ofw_send_message or ofw_save_draft in myFileIDs to attach it. The file is uploaded as PRIVATE (visible only to you) by default; pass shareClass:"SHARED" to share with co-parents directly via the My Files area.',
     annotations: { destructiveHint: false },
     inputSchema: {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { getAttachmentsDir, getCacheDbPath, getDefaultInlineAttachments, getCacheDir } from '../src/config.js';
+import { getAttachmentsDir, getCacheDbPath, getDefaultInlineAttachments, getCacheDir, getWriteMode } from '../src/config.js';
 
 describe('getCacheDbPath', () => {
   let tmp: string;
@@ -138,5 +138,40 @@ describe('getCacheDir', () => {
       if (orig === undefined) delete process.env.OFW_CACHE_DIR;
       else process.env.OFW_CACHE_DIR = orig;
     }
+  });
+});
+
+describe('getWriteMode', () => {
+  let original: string | undefined;
+  beforeEach(() => {
+    original = process.env.OFW_WRITE_MODE;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.OFW_WRITE_MODE;
+    else process.env.OFW_WRITE_MODE = original;
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to "all" when unset or blank', () => {
+    delete process.env.OFW_WRITE_MODE;
+    expect(getWriteMode()).toBe('all');
+    process.env.OFW_WRITE_MODE = '   ';
+    expect(getWriteMode()).toBe('all');
+  });
+
+  it('accepts none/drafts/all, case-insensitive and trimmed', () => {
+    process.env.OFW_WRITE_MODE = 'none';
+    expect(getWriteMode()).toBe('none');
+    process.env.OFW_WRITE_MODE = ' Drafts ';
+    expect(getWriteMode()).toBe('drafts');
+    process.env.OFW_WRITE_MODE = 'ALL';
+    expect(getWriteMode()).toBe('all');
+  });
+
+  it('fails closed to "none" on an unrecognized value, warning on stderr', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.OFW_WRITE_MODE = 'readonly';
+    expect(getWriteMode()).toBe('none');
+    expect(err).toHaveBeenCalledWith(expect.stringContaining('Unrecognized OFW_WRITE_MODE "readonly"'));
   });
 });

--- a/tests/tools/calendar.test.ts
+++ b/tests/tools/calendar.test.ts
@@ -104,3 +104,33 @@ describe('ofw_delete_event', () => {
   });
 });
 
+
+describe('OFW_WRITE_MODE gating', () => {
+  let original: string | undefined;
+  beforeEach(() => {
+    original = process.env.OFW_WRITE_MODE;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.OFW_WRITE_MODE;
+    else process.env.OFW_WRITE_MODE = original;
+  });
+
+  it('calendar writes are absent below mode "all"', () => {
+    for (const mode of ['none', 'drafts']) {
+      process.env.OFW_WRITE_MODE = mode;
+      setup(makeClient({}));
+      expect(handlers.has('ofw_create_event')).toBe(false);
+      expect(handlers.has('ofw_update_event')).toBe(false);
+      expect(handlers.has('ofw_delete_event')).toBe(false);
+      expect(handlers.has('ofw_list_events')).toBe(true); // reads unaffected
+    }
+  });
+
+  it('calendar writes register in mode "all"', () => {
+    process.env.OFW_WRITE_MODE = 'all';
+    setup(makeClient({}));
+    expect(handlers.has('ofw_create_event')).toBe(true);
+    expect(handlers.has('ofw_update_event')).toBe(true);
+    expect(handlers.has('ofw_delete_event')).toBe(true);
+  });
+});

--- a/tests/tools/expenses.test.ts
+++ b/tests/tools/expenses.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { OFWClient } from '../../src/client.js';
 import { registerExpenseTools } from '../../src/tools/expenses.js';
@@ -75,3 +75,30 @@ describe('ofw_create_expense', () => {
   });
 });
 
+
+describe('OFW_WRITE_MODE gating', () => {
+  let original: string | undefined;
+  beforeEach(() => {
+    original = process.env.OFW_WRITE_MODE;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.OFW_WRITE_MODE;
+    else process.env.OFW_WRITE_MODE = original;
+  });
+
+  it('ofw_create_expense is absent below mode "all"', () => {
+    for (const mode of ['none', 'drafts']) {
+      process.env.OFW_WRITE_MODE = mode;
+      setup(makeClient({}));
+      expect(handlers.has('ofw_create_expense')).toBe(false);
+      expect(handlers.has('ofw_list_expenses')).toBe(true); // reads unaffected
+      expect(handlers.has('ofw_get_expense_totals')).toBe(true);
+    }
+  });
+
+  it('ofw_create_expense registers in mode "all"', () => {
+    process.env.OFW_WRITE_MODE = 'all';
+    setup(makeClient({}));
+    expect(handlers.has('ofw_create_expense')).toBe(true);
+  });
+});

--- a/tests/tools/journal.test.ts
+++ b/tests/tools/journal.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { OFWClient } from '../../src/client.js';
 import { registerJournalTools } from '../../src/tools/journal.js';
@@ -60,3 +60,29 @@ describe('ofw_create_journal_entry', () => {
   });
 });
 
+
+describe('OFW_WRITE_MODE gating', () => {
+  let original: string | undefined;
+  beforeEach(() => {
+    original = process.env.OFW_WRITE_MODE;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.OFW_WRITE_MODE;
+    else process.env.OFW_WRITE_MODE = original;
+  });
+
+  it('ofw_create_journal_entry is absent below mode "all"', () => {
+    for (const mode of ['none', 'drafts']) {
+      process.env.OFW_WRITE_MODE = mode;
+      setup(makeClient({}));
+      expect(handlers.has('ofw_create_journal_entry')).toBe(false);
+      expect(handlers.has('ofw_list_journal_entries')).toBe(true); // reads unaffected
+    }
+  });
+
+  it('ofw_create_journal_entry registers in mode "all"', () => {
+    process.env.OFW_WRITE_MODE = 'all';
+    setup(makeClient({}));
+    expect(handlers.has('ofw_create_journal_entry')).toBe(true);
+  });
+});

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -1686,3 +1686,52 @@ describe('messages.ts — attachment-backfill branches', () => {
     }
   });
 });
+
+describe('OFW_WRITE_MODE gating', () => {
+  let original: string | undefined;
+  beforeEach(() => {
+    original = process.env.OFW_WRITE_MODE;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.OFW_WRITE_MODE;
+    else process.env.OFW_WRITE_MODE = original;
+  });
+
+  it('mode "none" registers no message write tools', () => {
+    process.env.OFW_WRITE_MODE = 'none';
+    setup(makeClient({}));
+    expect(handlers.has('ofw_send_message')).toBe(false);
+    expect(handlers.has('ofw_save_draft')).toBe(false);
+    expect(handlers.has('ofw_delete_draft')).toBe(false);
+    expect(handlers.has('ofw_upload_attachment')).toBe(false);
+    // read/sync/download surface stays intact
+    expect(handlers.has('ofw_list_message_folders')).toBe(true);
+    expect(handlers.has('ofw_list_messages')).toBe(true);
+    expect(handlers.has('ofw_get_message')).toBe(true);
+    expect(handlers.has('ofw_list_drafts')).toBe(true);
+    expect(handlers.has('ofw_get_unread_sent')).toBe(true);
+    expect(handlers.has('ofw_download_attachment')).toBe(true);
+    expect(handlers.has('ofw_sync_messages')).toBe(true);
+  });
+
+  it('mode "drafts" registers draft-level writes but never send', () => {
+    process.env.OFW_WRITE_MODE = 'drafts';
+    setup(makeClient({}));
+    expect(handlers.has('ofw_send_message')).toBe(false);
+    expect(handlers.has('ofw_save_draft')).toBe(true);
+    expect(handlers.has('ofw_delete_draft')).toBe(true);
+    expect(handlers.has('ofw_upload_attachment')).toBe(true);
+  });
+
+  it('mode "all" (and unset) registers everything', () => {
+    process.env.OFW_WRITE_MODE = 'all';
+    setup(makeClient({}));
+    expect(handlers.has('ofw_send_message')).toBe(true);
+    delete process.env.OFW_WRITE_MODE;
+    setup(makeClient({}));
+    expect(handlers.has('ofw_send_message')).toBe(true);
+    expect(handlers.has('ofw_save_draft')).toBe(true);
+    expect(handlers.has('ofw_delete_draft')).toBe(true);
+    expect(handlers.has('ofw_upload_attachment')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `OFW_WRITE_MODE` env var proposed in #82 — a structural gate, read at startup, controlling which write tools get **registered** at all:

| Mode | Effect |
|------|--------|
| `none` | No write tools registered — pure read/sync/search surface |
| `drafts` | Draft-level writes only (`ofw_save_draft`, `ofw_delete_draft`, `ofw_upload_attachment`); nothing that lands on the court-visible record (send, calendar/expense/journal writes) |
| `all` | Current behavior — the default, fully backward compatible |

Unrecognized values **fail closed to `none`** with a stderr warning, so a typo never silently grants write access. The gate is skip-registration (structural), not register-but-error (behavioral): unregistered tools can't be invoked by any host permission setting or prompt-injected instruction.

Changes:
- `src/config.ts`: `WriteMode` type + `getWriteMode()` (trimmed, case-insensitive, fail-closed)
- `src/tools/{messages,calendar,expenses,journal}.ts`: registration gated per tier
- Docs: CLAUDE.md env table, README tool table (new *Write mode* column) + a *Write protection* section, `server.json` env-var schema entry

## Verification

TDD: gating tests were written first and confirmed failing (6 failures across 5 files), then the implementation turned them green.

```
npm run test:coverage   # vitest run --coverage
 Test Files  13 passed (13)
      Tests  281 passed (281)
Statements   : 100% ( 632/632 )
Branches     : 100% ( 527/527 )
Functions    : 100% ( 102/102 )
Lines        : 100% ( 580/580 )

npm run build           # tsc + esbuild bundle — clean
```

New tests cover: default `all` (unset/blank), case-insensitive/trimmed parsing, fail-closed typo path (with stderr assertion), and per-mode registration presence/absence for every gated tool in all four tool modules (reads asserted unaffected in every mode).

## Open question (deliberately out of scope)

@thanbey also raised whether `ofw_get_message` on unread inbox messages belongs behind the gate in `none` mode — fetching an unread message fires a court-visible read receipt, so it's arguably a "write" to the record. This PR leaves `ofw_get_message` ungated to keep the read surface intact; happy to take that as a follow-up if we want a `OFW_WRITE_MODE`-aware (or separate) control for read receipts.

## Credit

Thanks to @thanbey for the proposal, the threat-model framing (host hints ≠ enforcement; synced co-parent messages are an untrusted prompt-injection vector), and a reference implementation with tests (thanbey/ofw-mcp@f0a62a09c6fa00ff6732726b66f6874812d0e680). This PR was written against current main but adapts their design directly: the `getWriteMode()` shape in `config.ts`, the per-module `allowWrites`/`allowSend`/`allowDrafts` gating pattern, and the fail-closed stderr message.

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)