### PR TITLE
docs: add missing tools to the README table (sync, unread-sent, attachments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,14 @@ Read-only tools run automatically. Write tools ask for your confirmation first. 
 | `ofw_list_message_folders` | Folders with unread counts — **get folder IDs here before listing messages** | Auto | any |
 | `ofw_list_messages` | Messages in a folder | Auto | any |
 | `ofw_get_message` | Full content of a single message | Auto | any |
+| `ofw_sync_messages` | Sync messages into the local cache (unread bodies left unfetched to avoid read receipts) | Auto | any |
+| `ofw_get_unread_sent` | Sent messages a recipient hasn't read yet (from local cache) | Auto | any |
+| `ofw_download_attachment` | Download a message attachment to disk (or inline as MCP content) | Auto | any |
 | `ofw_send_message` | Send a message | Confirm | `all` |
 | `ofw_list_drafts` | Draft messages | Auto | any |
 | `ofw_save_draft` | Create or update a draft | Confirm | `drafts` |
 | `ofw_delete_draft` | Delete a draft | Confirm | `drafts` |
+| `ofw_upload_attachment` | Upload a local file to My Files; returns a fileId to attach via `ofw_send_message`/`ofw_save_draft` | Auto | `drafts` |
 | `ofw_list_events` | Calendar events in a date range | Auto | any |
 | `ofw_create_event` | Create a calendar event | Confirm | `all` |
 | `ofw_update_event` | Update a calendar event | Confirm | `all` |


### PR DESCRIPTION
## Summary
The README "Available tools" table was missing 4 of the 22 tools the server registers:

| Tool | Permission | Write mode |
|---|---|---|
| `ofw_sync_messages` | Auto | any |
| `ofw_get_unread_sent` | Auto | any |
| `ofw_download_attachment` | Auto | any |
| `ofw_upload_attachment` | Auto | `drafts` |

`ofw_upload_attachment` is listed as **Auto** (not Confirm): it has no confirm gate in `src/tools/messages.ts` — it's a non-destructive upload to the user's private My Files (`destructiveHint: false`) that only returns a fileId. Its Write-mode is `drafts` per the #90 gating (`if (allowDrafts)`).

## Verification
- `comm -3` of `server.registerTool()` names across `src/tools/*.ts` vs the README table rows → exact 1:1 match (22/22).
- `skills/ofw/SKILL.md` already documents all four tools (lines 92–102), so README was the only gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)