### PR TITLE
ci: convert to chrischall/workflows reusable pipeline

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,33 +1,7 @@
 name: Auto-merge PRs
 
-# Source-aware auto-merge:
-#
-#  - dependabot[bot] PRs: arm `--auto --squash` as soon as the PR is non-
-#    draft. Merges when CI is green; no review gating.
-#  - Same-repo (non-fork) PRs with the `ready-to-merge` label: arm
-#    `--auto --squash`. That label is added either:
-#      * by the owner manually (to override Claude's warn/fail), OR
-#      * automatically by pr-auto-review.yml when Claude's verdict =
-#        `pass` on a same-repo PR, OR
-#      * automatically by release-please.yml on the release PR.
-#    Either way, the label is the signal.
-#  - Fork PRs: never auto-armed. Reviewed for advisory value only;
-#    the owner merges those by hand.
-#
-# The merge still waits for branch protection's required status check
-# (`ci`), so this is "merge as soon as CI is green," not "merge without
-# CI."
-#
-# pull_request_target is used (not pull_request) so dependabot PRs can
-# arm — dependabot's pull_request token is restricted. Safe because we
-# never check out or execute PR code; we only call the GitHub API via
-# the gh CLI.
-#
-# RELEASE_PAT (not GITHUB_TOKEN) is used to arm `gh pr merge --auto`.
-# GitHub suppresses workflow runs for events triggered by GITHUB_TOKEN
-# to prevent loops; with the PAT, the merge it eventually performs
-# fires `push` events on main, which is what release-please.yml
-# listens on (to open / tag / publish the next release).
+# Thin stub — the pipeline lives in chrischall/workflows.
+# pull_request_target so dependabot PRs can arm; PR code is never executed.
 
 on:
   pull_request_target:
@@ -42,50 +16,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  arm-dependabot:
-    runs-on: ubuntu-latest
-    # Fire on the lifecycle events but NOT on `labeled` — that's the
-    # owner-PR path. Without this guard, adding any label to a
-    # dependabot PR would re-arm (harmless but noisy).
-    if: |
-      github.event.action != 'labeled' &&
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.user.login == 'dependabot[bot]'
-    steps:
-      - name: Arm auto-merge for dependabot
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          if gh pr merge --auto --squash "$PR_URL"; then exit 0; fi
-          state="$(gh pr view "$PR_URL" --json state --jq .state 2>/dev/null || echo UNKNOWN)"
-          if [ "$state" = "MERGED" ]; then
-            echo "PR already merged (instant-merge race) — treating as success."
-            exit 0
-          fi
-          echo "::error::auto-merge arm failed (PR state=$state)"
-          exit 1
-
-  arm-on-ready-label:
-    runs-on: ubuntu-latest
-    # Same-repo PRs only (excludes forks). The label may be added by the
-    # owner manually or by pr-auto-review.yml on Claude's `verdict=pass`.
-    if: |
-      github.event.action == 'labeled' &&
-      github.event.label.name == 'ready-to-merge' &&
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    steps:
-      - name: Arm auto-merge on ready-to-merge label
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          if gh pr merge --auto --squash "$PR_URL"; then exit 0; fi
-          state="$(gh pr view "$PR_URL" --json state --jq .state 2>/dev/null || echo UNKNOWN)"
-          if [ "$state" = "MERGED" ]; then
-            echo "PR already merged (instant-merge race) — treating as success."
-            exit 0
-          fi
-          echo "::error::auto-merge arm failed (PR state=$state)"
-          exit 1
+  arm:
+    uses: chrischall/workflows/.github/workflows/reusable-auto-merge.yml@main
+    secrets:
+      release_pat: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,45 +1,17 @@
 name: CI
 
+# Thin stub — the gate and steps live in chrischall/workflows.
+# NOTE: converting to a reusable workflow renames the required check from
+# `ci` to `ci / ci`; scripts/update-ruleset.sh flips the ruleset.
+
 on:
   pull_request:
-    # `labeled` so arming `ready-to-merge` (or `release-ready` on a release
-    # PR) triggers the deferred run.
     types: [opened, synchronize, reopened, labeled]
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
-    # CI is the LAST gate, not a parallel cost:
-    #   - normal (human) PRs: CI runs only once auto-review passes and arms
-    #     `ready-to-merge` — review findings get fixed without burning CI
-    #     runs; the label event fires the run, and pushes to an armed PR
-    #     re-run via synchronize (label still present).
-    #   - release-please PRs: deferred to the `release-ready` ship signal.
-    #   - BOT-authored PRs (dependabot): CI on EVERY event, unconditionally —
-    #     a label event must not gate them (upstream curtaincall#86 review) —
-    #     bots never receive auto-review, so they'd otherwise merge with CI
-    #     skipped (native auto-merge treats a skipped required check as
-    #     satisfied).
-    #   - non-pull_request runs (workflow_call / push) fall through unharmed.
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.user.type != 'User' ||
-      (
-        (github.event.action != 'labeled' || github.event.label.name == 'release-ready' || github.event.label.name == 'ready-to-merge') &&
-        (
-          (startsWith(github.event.pull_request.head.ref, 'release-please--') && contains(github.event.pull_request.labels.*.name, 'release-ready')) ||
-          (!startsWith(github.event.pull_request.head.ref, 'release-please--') && contains(github.event.pull_request.labels.*.name, 'ready-to-merge'))
-        )
-      )
-    steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-node@v6.4.0
-        with:
-          node-version: 26
-          cache: npm
-
-      - run: npm ci
-      - run: npm run build
-      # Coverage-enforced: vitest.config.ts declares 100% thresholds, so this fails on a regression.
-      - run: npm run test:coverage
+    uses: chrischall/workflows/.github/workflows/reusable-mcp-ci.yml@main
+    with:
+      node-version: "26"
+      build-command: npm run build
+      test-command: npm run test:coverage

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -1,258 +1,35 @@
 name: PR auto-review
 
-# On every non-draft, same-repo, human-authored PR this workflow:
-#
-#  1. Applies the `auto-review` label.
-#  2. Requests GitHub Copilot as a reviewer (best-effort).
-#  3. Runs claude-code-action with a JSON-schema-bound verdict:
-#       pass | warn | fail
-#     Claude posts findings (as claude[bot] via the installed Claude App)
-#     and emits the verdict to `structured_output`.
-#  4. On `verdict == pass`, adds the `ready-to-merge` label using
-#     RELEASE_PAT, which arms auto-merge.yml. `warn` and `fail` never
-#     auto-arm — those keep a human in the loop.
-#
-# Why `pull_request` (not `pull_request_target`):
-# Anthropic's GitHub App OIDC backend has an event-name allowlist that
-# rejects `pull_request_target` (see anthropics/claude-code-action#713),
-# so that trigger would force a `github_token`-override workaround and
-# comments would be authored by `github-actions[bot]` instead of
-# `claude[bot]`. `pull_request` is the documented supported event for
-# automated PR review with the installed App.
-#
-# Tradeoff: fork PRs cannot be auto-reviewed (`pull_request` from a fork
-# has no access to secrets). For those rare cases, `@claude review this`
-# in a PR comment triggers the existing `claude.yml` flow as a manual
-# fallback.
-#
-# The `head.repo == github.repository` guard is belt-and-braces: even on
-# `pull_request`, GITHUB_TOKEN is read-only for fork PRs, so the label-
-# add step would fail. The guard skips the entire job cleanly for forks.
-#
-# Bot-authored PRs (dependabot/renovate/etc.) are skipped via the
-# `user.type == 'User'` filter — those go straight to CI + auto-merge.
-#
-# PRs that already carry `ready-to-merge` are skipped — they've passed
-# review once and are armed for auto-merge, so re-reviewing on a follow-up
-# `synchronize` (or unrelated label change) just burns quota.
-#
-# Release-please PRs are skipped via the `autorelease: pending` label
-# filter so they stay open as long-lived staging artifacts. release-
-# please updates the same PR as more fix:/feat: commits land; you add
-# `ready-to-merge` manually when you decide it's time to ship a batch.
-#
-# `ready-to-merge` MUST be added via RELEASE_PAT, not GITHUB_TOKEN.
-# GitHub suppresses workflow runs for `GITHUB_TOKEN`-triggered events,
-# so a label added that way would not fire auto-merge.yml.
+# Thin stub — the pipeline lives in chrischall/workflows.
 
 on:
   pull_request:
-    # `labeled` is included so adding `review-with-opus` forces a
-    # re-review with Opus. The job filter scopes that re-fire to *just*
-    # that label so unrelated label changes (auto-review, ready-to-merge,
-    # etc.) don't trigger redundant reviews.
     types: [opened, reopened, ready_for_review, synchronize, labeled]
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
-  id-token: write       # Required for the Claude App OIDC token exchange
+  id-token: write
 
+# `labeled` events get their own group keyed by label name: opening a PR
+# with --label fires `opened`+`labeled` back-to-back, and a shared group
+# would let the labeled event displace the queued review, leaving the PR
+# with no verdict and no label.
 concurrency:
-  group: pr-auto-review-${{ github.event.pull_request.number }}
+  group: |
+    pr-auto-review-${{ github.event.pull_request.number }}${{
+      github.event.action == 'labeled'
+        && format('-labeled-{0}', github.event.label.name)
+        || ''
+    }}
   cancel-in-progress: false
 
 jobs:
   review:
-    runs-on: ubuntu-latest
-    if: |
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.user.type == 'User' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (!startsWith(github.event.pull_request.head.ref, 'release-please--') || contains(github.event.pull_request.labels.*.name, 'release-ready')) &&
-      (!contains(github.event.pull_request.labels.*.name, 'autorelease: pending') || contains(github.event.pull_request.labels.*.name, 'release-ready')) &&
-      !contains(github.event.pull_request.labels.*.name, 'ready-to-merge') &&
-      (github.event.action != 'labeled' || github.event.label.name == 'review-with-opus' || github.event.label.name == 'release-ready')
-    steps:
-      - name: Apply auto-review label
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: gh pr edit "$PR" --repo "$REPO" --add-label auto-review
-
-      - name: Request Copilot reviewer
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Copilot code-review surfaces as the `Copilot` user (sometimes
-          # `copilot-pull-request-reviewer[bot]`). The REST endpoint accepts
-          # the bare login. If the repo/org doesn't have Copilot review
-          # enabled, this returns 422 — swallow that so the rest of the
-          # workflow still succeeds.
-          if gh api --method POST \
-              "/repos/${REPO}/pulls/${PR}/requested_reviewers" \
-              -f 'reviewers[]=Copilot' 2>/tmp/copilot.err; then
-            echo "Requested Copilot as reviewer."
-          else
-            echo "Could not request Copilot reviewer (likely not enabled):"
-            cat /tmp/copilot.err
-          fi
-
-      - name: Checkout PR
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Pick model by PR size (or label override)
-        id: model
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-          HAS_OPUS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'review-with-opus') }}
-        run: |
-          # The Claude CLI's default is `claude-opus-4-7[1m]` — the 1M
-          # context Opus tier, the priciest model. For most PRs that's
-          # overkill. Three-tier ladder by additions+deletions, with a
-          # `review-with-opus` label as a manual escalation knob:
-          #
-          #   `review-with-opus` label present  →  Opus 4.7    (forced)
-          #   ≤50 lines                         →  Haiku 4.5   (~$0.01/PR)
-          #   51-500 lines                      →  Sonnet 4.6  (~$0.05/PR)
-          #   >500 lines                        →  Opus 4.7    (~$0.26/PR)
-          #
-          # Never the [1m] variant — our codebase + diff is well under
-          # 200k tokens. If Sonnet starts missing subtle issues on small
-          # PRs, lower the 500 threshold; if Haiku flags too many false
-          # positives or misses real ones, raise the 50 threshold (or drop
-          # the Haiku tier entirely).
-          CHANGED=$(gh api "/repos/${REPO}/pulls/${PR}" --jq '.additions + .deletions')
-          if [ "$HAS_OPUS_LABEL" = "true" ]; then
-            MODEL="claude-opus-4-7"
-            REASON="\`review-with-opus\` label (forced)"
-          elif [ "$CHANGED" -le 50 ]; then
-            MODEL="claude-haiku-4-5"
-            REASON="${CHANGED} lines (≤50, trivial)"
-          elif [ "$CHANGED" -le 500 ]; then
-            MODEL="claude-sonnet-4-6"
-            REASON="${CHANGED} lines (51-500)"
-          else
-            MODEL="claude-opus-4-7"
-            REASON="${CHANGED} lines (>500, complex)"
-          fi
-          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
-          echo "Selected ${MODEL} — ${REASON}"
-          echo "**Model:** \`${MODEL}\` — ${REASON}" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Claude review with structured verdict
-        id: review
-        uses: anthropics/claude-code-action@v1
-        with:
-          # Auth via the user's Claude Max plan (OAuth token from
-          # `claude setup-token`). PR reviews count against the Max
-          # subscription's quota instead of pay-per-token API billing.
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # No `github_token:` — let the action use the installed Claude
-          # App via OIDC so comments are authored by `claude[bot]`.
-          # `track_progress: true` posts a live progress comment as Claude
-          # works (recommended by the action's pr-review-comprehensive.yml
-          # example). In automation mode this is off by default; we enable
-          # it so reviews are visibly "in flight" rather than appearing all
-          # at once at the end.
-          # EXCEPT on `labeled` events (the `release-ready` /
-          # `review-with-opus` triggers): the action only supports
-          # track_progress for opened/synchronize/ready_for_review/reopened
-          # and hard-errors on anything else, killing the review.
-          track_progress: ${{ github.event.action != 'labeled' }}
-          claude_args: |
-            --model ${{ steps.model.outputs.model }}
-            --json-schema '{"type":"object","required":["verdict","summary","important_findings"],"properties":{"verdict":{"enum":["pass","warn","fail"]},"summary":{"type":"string"},"important_findings":{"type":"array","items":{"type":"string"}}}}'
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(cat:*),Bash(rg:*),Bash(jq:*),Bash(ls:*),Bash(find:*)"
-          prompt: |
-            You are reviewing pull request #${{ github.event.pull_request.number }} in ${{ github.repository }}.
-
-            STEPS:
-            1. Read CLAUDE.md to learn the project's conventions (versioning rules, ESM `.js` import requirement, testing/coverage requirements, stdio logging rules, etc.).
-            2. Read the PR diff: `gh pr diff ${{ github.event.pull_request.number }}` (or read files in the working tree, which is checked out).
-            3. Review the changes for:
-               - Correctness and edge cases
-               - Adherence to CLAUDE.md conventions
-               - Test coverage of new code paths (note: vitest enforces 100% coverage in CI)
-               - Security or data-integrity concerns
-
-            CONVENTIONS ARE GROUNDED, NOT INVENTED:
-            A "convention" exists only if it is (a) written in CLAUDE.md, (b) enforced by a repo config (eslint/prettier/tsconfig), or (c) consistently followed by the surrounding code. Before citing a CLAUDE.md rule you MUST be able to quote its exact text — if it is not in CLAUDE.md, it is NOT a CLAUDE.md rule. Never infer an unwritten style rule.
-
-            SEVERITY MODEL (matches the official code-review plugin):
-              🔴 Important — bug, broken behavior, security/data risk, or violation of a convention you can QUOTE from CLAUDE.md. Confidence ≥80 to count.
-              🟡 Nit       — a concrete, actionable minor issue grounded in CLAUDE.md, a linter/formatter config, or a clear inconsistency with adjacent code. Confidence ≥80.
-              🟣 Pre-existing — issue already in the codebase, not introduced by this PR. Never blocking.
-
-            OUT OF SCOPE — never a finding, never affects the verdict:
-              - Formatting taste a formatter would own: comment length, single- vs multi-line comments, blank lines, line breaks, import order not enforced by a config.
-              - Rephrasing comments/identifiers that are already clear.
-              - Anything you cannot ground in CLAUDE.md, a repo config, or adjacent-code style.
-            If your only findings are out-of-scope, the verdict is `pass`.
-
-            OUTPUT:
-            - For line-specific findings, prefer the inline-comment tool (`mcp__github_inline_comment__create_inline_comment`).
-            - Post ONE top-level summary comment with overall judgment (use `gh pr comment`). If there are no findings worth surfacing, post a short "No issues found — verdict pass" comment.
-            - Then emit your structured verdict per the JSON schema:
-              • `pass` — no 🔴 Important findings.
-              • `warn` — no 🔴 Important findings but at least one 🟡 Nit worth surfacing.
-              • `fail` — at least one 🔴 Important finding.
-              Set `summary` to a 1-2 sentence overall judgment.
-              Set `important_findings` to the list of 🔴 Important finding titles (empty array if none).
-
-            DO NOT modify files, push commits, approve the PR formally, or call `gh pr review` / `gh pr edit`. Posting comments and emitting the verdict is the entire job. The workflow will gate auto-merge based on your verdict.
-
-      - name: Surface verdict in run summary
-        if: always() && steps.review.outputs.structured_output != ''
-        env:
-          OUT: ${{ steps.review.outputs.structured_output }}
-        run: |
-          {
-            echo "## Claude review verdict"
-            echo ""
-            echo "**Verdict:** \`$(echo "$OUT" | jq -r .verdict)\`"
-            echo ""
-            echo "**Summary:** $(echo "$OUT" | jq -r .summary)"
-            echo ""
-            COUNT=$(echo "$OUT" | jq -r '.important_findings | length')
-            echo "**Important findings:** ${COUNT}"
-            if [ "$COUNT" -gt 0 ]; then
-              echo ""
-              echo "$OUT" | jq -r '.important_findings[] | "- " + .'
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Arm auto-merge on pass
-        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-          OUT: ${{ steps.review.outputs.structured_output }}
-        run: |
-          verdict=""
-          [ -n "$OUT" ] && verdict=$(echo "$OUT" | jq -r '.verdict // empty')
-          # Fallback: claude-code-action intermittently returns an empty
-          # structured_output even on a clean pass (the verdict comment still
-          # posts). Re-derive the verdict from the latest claude[bot] verdict
-          # marker. ONLY an explicit `pass` arms; warn/fail/anything-else keeps
-          # a human in the loop.
-          if [ -z "$verdict" ]; then
-            body=$(gh pr view "$PR" --repo "$REPO" --json comments --jq '[.comments[]|select(.author.login=="claude")]|last|.body' 2>/dev/null || echo "")
-            vline=$(printf '%s' "$body" | grep -ioE 'verdict[^a-z]{0,6}(pass|warn|fail)' | tail -1)
-            case "$vline" in *[Pp]ass*) verdict="pass";; esac
-          fi
-          if [ "$verdict" = "pass" ]; then
-            gh pr edit "$PR" --repo "$REPO" --add-label ready-to-merge
-            echo "Verdict=pass — added ready-to-merge to arm auto-merge."
-          else
-            echo "Verdict=${verdict:-unknown} — not arming (human-in-the-loop preserved)."
-          fi
+    uses: chrischall/workflows/.github/workflows/reusable-pr-auto-review.yml@main
+    with:
+      conventions_hint: ""
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      release_pat: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,28 +1,12 @@
 name: release-please
 
-# Canonical release-please workflow.
+# Thin stub: release-please runs here; the publish steps are the
+# chrischall/workflows mcp-publish composite action. The publish job stays
+# in THIS file (not a reusable workflow) because npm trusted publishing and
+# mcp-publisher bind to this repo's workflow identity via OIDC.
 #
-# On every push to main, run googleapis/release-please-action. It scans
-# Conventional-Commit messages since the last release tag and:
-#
-#   - If new fix:/feat:/etc. commits are present, opens or updates a
-#     "release PR" that bumps every file registered in extra-files (see
-#     release-please-config.json) and updates CHANGELOG.md.
-#   - When that release PR merges, the action creates a `v<VERSION>` tag
-#     and a GitHub Release populated from the CHANGELOG section.
-#
-# The release PR is left open as a human review gate. You merge it
-# (manually via the GitHub UI, or by adding the `ready-to-merge` label so
-# auto-merge.yml arms it) when you're ready to ship.
-#
-# When the release PR merges, this workflow runs again, release_created
-# becomes true, and the `publish` job runs.
-#
-# RELEASE_PAT (not GITHUB_TOKEN) is used so:
-#   - The release PR's `opened` event triggers downstream workflows (CI,
-#     pr-auto-review.yml).
-#   - The `v<VERSION>` tag push, if anything downstream listens for it,
-#     would fire (we don't currently — publish runs in this same workflow).
+# The release PR is the human review gate: add `release-ready` to ship it.
+# The PAT (not GITHUB_TOKEN) so the release PR's events trigger CI/review.
 
 on:
   push:
@@ -58,101 +42,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
+      id-token: write    # npm provenance + mcp-publisher OIDC
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: chrischall/workflows/.github/actions/mcp-publish@main
         with:
-          node-version: 26
-          cache: npm
-          registry-url: https://registry.npmjs.org
-
-      # Strip always-auth from .npmrc (set by setup-node, deprecated in npm 11)
-      - run: sed -i '/always-auth/d' "$NPM_CONFIG_USERCONFIG"
-
-      - run: npm ci
-      - run: npm run build
-
-      - name: Set VERSION env
-        run: echo "VERSION=${{ needs.release-please.outputs.version }}" >> "$GITHUB_ENV"
-
-      - name: Package skill
-        run: |
-          python3 - <<'EOF'
-          import zipfile, pathlib, os
-
-          version = os.environ["VERSION"]
-          skill_name = "ofw-mcp"
-          out = pathlib.Path(f"{skill_name}-{version}.skill")
-
-          with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zf:
-              zf.write(pathlib.Path("skills/ofw/SKILL.md"), f"{skill_name}/SKILL.md")
-
-          print(f"Packaged {out} ({out.stat().st_size} bytes)")
-          EOF
-
-      - name: Build .mcpb bundle
-        run: |
-          npx @anthropic-ai/mcpb pack
-          mv ofw-mcp.mcpb "ofw-mcp-${VERSION}.mcpb"
-
-      # Idempotent: skip if this version is already on the registry.
-      - name: Publish to npm
-        run: |
-          PKG=$(node -p "require('./package.json').name")
-          PUBLISHED=$(npm view "${PKG}@${VERSION}" version 2>/dev/null || true)
-          if [ "$PUBLISHED" = "$VERSION" ]; then
-            echo "npm already has ${PKG}@${VERSION} — skipping publish."
-            exit 0
-          fi
-          npm publish --access public --provenance
-
-      # ─── modelcontextprotocol/registry (PulseMCP auto-ingests weekly) ───
-      - name: Install mcp-publisher
-        uses: chrischall/mcp-utils/.github/actions/install-mcp-publisher@v0.6.0
-
-      - name: Authenticate to MCP Registry (OIDC)
-        run: mcp-publisher login github-oidc
-
-      - name: Publish to MCP Registry
-        run: mcp-publisher publish
-
-      # ─── ClawHub (OpenClaw skill registry) — conditional on CLAWHUB_TOKEN ───
-      # GitHub Actions disallows `secrets.*` in step-level `if:`, so the
-      # token check happens inside the run block.
-      - name: Publish skill to ClawHub
-        continue-on-error: true
-        env:
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-        run: |
-          if [ -z "$CLAWHUB_TOKEN" ]; then
-            echo "CLAWHUB_TOKEN not set — skipping ClawHub publish."
-            exit 0
-          fi
-          if [ ! -f skills/ofw/SKILL.md ]; then
-            echo "skills/ofw/SKILL.md not present — skipping ClawHub publish."
-            exit 0
-          fi
-          npx --yes clawhub login --token "$CLAWHUB_TOKEN" --no-browser
-          # ClawHub's `publish` rejects folders that look like a plugin
-          # (.claude-plugin/plugin.json present), and `package publish`
-          # requires an openclaw.plugin.json we don't have. Workaround: copy
-          # SKILL.md to a clean temp dir and publish that as a standalone skill.
-          SKILL_DIR=$(mktemp -d)
-          cp skills/ofw/SKILL.md "$SKILL_DIR/"
-          npx --yes clawhub publish "$SKILL_DIR" --version "${VERSION}" --slug ofw-mcp
-
-      # release-please already created the GitHub Release with CHANGELOG
-      # content; just attach the build artifacts. --clobber so re-running
-      # the workflow on the same tag overwrites prior uploads.
-      - name: Attach artifacts to release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
-            "ofw-mcp-${VERSION}.skill" \
-            "ofw-mcp-${VERSION}.mcpb" \
-            --clobber
+          version: ${{ needs.release-please.outputs.version }}
+          tag-name: ${{ needs.release-please.outputs.tag_name }}
+          clawhub-token: ${{ secrets.CLAWHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaces vendored pipeline workflows with thin stubs calling chrischall/workflows@main.

- pr-auto-review: reusable (forced verdict + fail-loud + pass-only arming)
- auto-merge: reusable (dependabot + ready-to-merge label arms)
- ci: reusable node CI (deferred gate) — required check becomes `ci / ci`
- release-please: thin stub + mcp-publish composite action (OIDC identity preserved)

After this PR is open, run `scripts/update-ruleset.sh chrischall/ofw-mcp` in chrischall/workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
