### PR TITLE
refactor: remove drifted root plugin.json cruft

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -38,7 +38,6 @@ CLAUDE.md
 
 # Registry / plugin / skill manifests (not used at runtime)
 server.json
-plugin.json
 .claude-plugin/
 .mcp.json
 SKILL.md

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,0 @@
-{
-  "name": "ofw",
-  "displayName": "OurFamilyWizard",
-  "version": "1.4.1",
-  "description": "OurFamilyWizard co-parenting tools for Claude",
-  "type": "mcp"
-}


### PR DESCRIPTION
## Summary

Deletes the root `plugin.json` (stuck at v1.4.1), which has silently drifted from the rest of the repo (everything else is 2.4.2) and is no longer consumed by anything. It predates the `.claude-plugin/` directory convention.

## Verification (confirmed unused before deleting)

- **npm package** — `package.json` `files` ships `.claude-plugin`, not the root `plugin.json`.
- **release-please** — only `.claude-plugin/plugin.json` is registered in `release-please-config.json`. That's the root cause of the drift: nothing was bumping the root file, so it froze at 1.4.1.
- **Claude Code plugin loading** — `.claude-plugin/marketplace.json` uses `source: "./"`, and Claude Code resolves the plugin manifest from `.claude-plugin/plugin.json`.
- **mcpb bundle** — `.mcpbignore` already excluded the root file under "not used at runtime".
- **Only references in the repo** were `.mcpbignore` (an exclusion) and a `CLAUDE.md` architecture-diagram line that actually describes the *nested* `.claude-plugin/plugin.json`.
- Last touched 2026-03-24 (`832aaa1`), before the `.claude-plugin/` structure took over.

## Changes

- Delete root `plugin.json`.
- Drop the now-dead `plugin.json` line from `.mcpbignore` (`.claude-plugin/` already covers the nested manifest).

## Testing

- `npm run build` ✅
- `npm test` ✅ (14 files, 309 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)