### PR TITLE
chore: bump mcp-utils to 0.10.5; drop pass-through wrappers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.4.3",
       "license": "MIT",
       "dependencies": {
-        "@chrischall/mcp-utils": "^0.10.3",
+        "@chrischall/mcp-utils": "^0.10.5",
         "@fetchproxy/bootstrap": "^1.3.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@chrischall/mcp-utils": "^0.10.3",
+    "@chrischall/mcp-utils": "^0.10.5",
     "@fetchproxy/bootstrap": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -46,11 +46,10 @@
 //     specifically so it can be mocked here too. This keeps the
 //     selection logic independent of either implementation.
 
-import { readEnvVar } from '@chrischall/mcp-utils';
+import { parseBoolEnv, readEnvVar } from '@chrischall/mcp-utils';
 import { bootstrap } from '@fetchproxy/bootstrap';
 import { classifyBridgeError, FetchproxyBridgeDownError } from '@chrischall/mcp-utils/fetchproxy';
 import { loginWithPassword } from './auth-password.js';
-import { parseBoolEnv } from './config.js';
 import pkg from '../package.json' with { type: 'json' };
 
 /** Result of resolving auth, regardless of which path was taken. */
@@ -61,17 +60,6 @@ export interface ResolvedAuth {
   expiresAt?: Date;
   /** Which path produced the token. Used for diagnostics + future cache keying. */
   source: 'env' | 'fetchproxy';
-}
-
-/**
- * Read an env var, trim, and treat blank / `${UNEXPANDED}` placeholders as
- * unset. Defends against MCP hosts that pass `.mcp.json` env blocks through
- * without variable expansion. Delegates to @chrischall/mcp-utils' `readEnvVar`,
- * which applies the identical sanitization (blank, `undefined`/`null`,
- * `${...}` placeholder → unset).
- */
-function readEnv(key: string): string | undefined {
-  return readEnvVar(key);
 }
 
 /** True if the user has explicitly disabled the fetchproxy fallback. */
@@ -89,8 +77,11 @@ function fetchproxyDisabled(): boolean {
  */
 export async function resolveAuth(): Promise<ResolvedAuth> {
   // ── Path 1: env-var credentials (unchanged from pre-fetchproxy behavior).
-  const username = readEnv('OFW_USERNAME');
-  const password = readEnv('OFW_PASSWORD');
+  // `readEnvVar` trims and treats blank / `"undefined"` / `"null"` /
+  // `${UNEXPANDED}` placeholders as unset — defends against MCP hosts that
+  // pass `.mcp.json` env blocks through without variable expansion.
+  const username = readEnvVar('OFW_USERNAME');
+  const password = readEnvVar('OFW_PASSWORD');
   if (username && password) {
     const { token, expiresAt } = await loginWithPassword(username, password);
     return { token, expiresAt, source: 'env' };

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,9 +1,8 @@
-import { loadDotenvSafely } from '@chrischall/mcp-utils';
+import { loadDotenvSafely, parseBoolEnv, redactSecrets } from '@chrischall/mcp-utils';
 import { TokenManager } from '@chrischall/mcp-utils/session';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { resolveAuth } from './auth.js';
-import { parseBoolEnv } from './config.js';
 import { BASE_URL, OFW_PROTOCOL_HEADERS, OFW_TOKEN_TTL_MS, OFW_TOKEN_EXPIRY_SKEW_MS } from './protocol.js';
 
 // Load .env for local dev; silently skip if dotenv is unavailable (e.g. mcpb
@@ -36,13 +35,6 @@ function parseContentDispositionFilename(cd: string): string | null {
 // only when debugging, never in normal use.
 function debugLogEnabled(): boolean {
   return parseBoolEnv('OFW_DEBUG_LOG');
-}
-
-function redactHeaders(h: Record<string, string>): Record<string, string> {
-  const out = { ...h };
-  /* v8 ignore next -- request headers always carry Authorization (set in request()); the guard is defensive for arbitrary header maps */
-  if (out.Authorization) out.Authorization = `Bearer ${out.Authorization.slice(7, 17)}…`;
-  return out;
 }
 
 // Per-request timeout. Overridable via OFW_REQUEST_TIMEOUT_MS. The default
@@ -175,7 +167,9 @@ export class OFWClient {
           ? `<FormData entries=${Array.from((body as FormData).keys()).join(',')}>`
           : JSON.stringify(body);
       console.error(`[ofw-debug] → ${method} ${url}${isRetry ? ' (retry)' : ''}`);
-      console.error(`[ofw-debug]   headers: ${JSON.stringify(redactHeaders(headers))}`);
+      // redactSecrets scrubs the Bearer token (and any other secret shapes)
+      // from the serialized header map — shared fleet redaction, never bespoke.
+      console.error(`[ofw-debug]   headers: ${redactSecrets(JSON.stringify(headers))}`);
       console.error(`[ofw-debug]   body: ${bodyPreview}`);
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { parseBoolEnv as parseBoolEnvUtil } from '@chrischall/mcp-utils';
+import { parseBoolEnv, readEnvVar } from '@chrischall/mcp-utils';
 
 // Cache identity drives the per-user SQLite DB filename. Order of preference:
 //   1. OFW_CACHE_IDENTITY — explicit override for users who want to label the
@@ -12,11 +12,7 @@ import { parseBoolEnv as parseBoolEnvUtil } from '@chrischall/mcp-utils';
 //      Single-user installs are fine on this; multi-account users should set
 //      OFW_CACHE_IDENTITY explicitly so their caches don't collide.
 function readCacheIdentity(): string {
-  const explicit = process.env.OFW_CACHE_IDENTITY;
-  if (typeof explicit === 'string' && explicit.trim().length > 0) return explicit.trim();
-  const username = process.env.OFW_USERNAME;
-  if (typeof username === 'string' && username.trim().length > 0) return username.trim();
-  return '_default';
+  return readEnvVar('OFW_CACHE_IDENTITY') ?? readEnvVar('OFW_USERNAME') ?? '_default';
 }
 
 export function getCacheDir(): string {
@@ -40,20 +36,6 @@ export function getAttachmentsDir(): string {
   // just downloaded them. Downloads is the standard "user-accessible files"
   // location across macOS/Linux/Windows.
   return join(homedir(), 'Downloads', 'ofw-mcp');
-}
-
-/**
- * True when a boolean-shaped env var is set to "1", "true", "yes", or "on"
- * (case-insensitive, trimmed). Anything else — unset, empty, or other
- * values — is false. Used for OFW_INLINE_ATTACHMENTS, OFW_DISABLE_FETCHPROXY,
- * OFW_DEBUG_LOG, etc.
- *
- * Delegates to @chrischall/mcp-utils' `parseBoolEnv` (which also recognizes
- * the falsy set 0/false/no/off — behavior-equivalent here since callers only
- * care about the truthy case and everything else defaults to false).
- */
-export function parseBoolEnv(name: string): boolean {
-  return parseBoolEnvUtil(name);
 }
 
 export type WriteMode = 'none' | 'drafts' | 'all';

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -156,8 +156,8 @@ describe('resolveAuth', () => {
   });
 
   describe('env-var sanitization', () => {
-    // readEnv() in auth.ts treats blanks, the literal strings 'undefined' /
-    // 'null', and unsubstituted `${VAR}` placeholders as unset — defends
+    // mcp-utils' readEnvVar() (used in auth.ts) treats blanks, the literal
+    // strings 'undefined' / 'null', and unsubstituted `${VAR}` placeholders as unset — defends
     // against MCP hosts that pass env blocks through without expansion.
     it('treats each sanitized OFW_PASSWORD value as unset and falls through to fetchproxy', async () => {
       const sanitized = ['undefined', 'null', '${OFW_PASSWORD}', '   ', ''];

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -543,8 +543,10 @@ describe('OFWClient', () => {
       const debugLines = lines.filter((l) => l.startsWith('[ofw-debug]'));
       expect(debugLines.some((l) => l.includes('→ POST'))).toBe(true);
       expect(debugLines.some((l) => l.includes('"foo":"bar"'))).toBe(true);
-      // Authorization header is redacted (only the prefix is logged).
-      expect(debugLines.some((l) => l.includes('"Authorization":"Bearer ') && l.includes('…"'))).toBe(true);
+      // Authorization header is redacted via mcp-utils redactSecrets — the
+      // token never appears in the log, only the [REDACTED] placeholder.
+      expect(debugLines.some((l) => l.includes('"Authorization":"Bearer [REDACTED]"'))).toBe(true);
+      expect(debugLines.some((l) => l.includes(MOCK_TOKEN) && l.includes('headers:'))).toBe(false);
       expect(debugLines.some((l) => l.includes('← 200'))).toBe(true);
       expect(debugLines.some((l) => l.includes('response body:'))).toBe(true);
     });


### PR DESCRIPTION
## Summary

- **Pin bump**: `@chrischall/mcp-utils` `^0.10.3` → `^0.10.5`. The lockfile was already resolving 0.10.5 (dependabot in-range bump in #112); this raises the declared floor to match.
- **`src/auth.ts`**: delete the `readEnv()` pass-through — `resolveAuth()` calls mcp-utils `readEnvVar` directly (identical blank / `"undefined"` / `"null"` / `${VAR}`-placeholder sanitization).
- **`src/config.ts`**: delete the exported `parseBoolEnv` wrapper; `auth.ts`, `client.ts`, and `config.ts` now import `parseBoolEnv` from mcp-utils directly. `readCacheIdentity()`'s inline trim/blank env reads now go through `readEnvVar` (same trim + blank-is-unset behavior, plus the fleet-standard placeholder hardening).
- **`src/client.ts`**: replace the hand-rolled `redactHeaders` (logged a 10-char Bearer prefix) with mcp-utils `redactSecrets` over the serialized header map. Strictly stronger: the token is fully `[REDACTED]`, and cookie/API-key/JWT shapes are covered by the shared fleet redaction. Debug-log test updated to assert the token never appears.

Out of scope (deliberately untouched): the OFW client fetch loop (401/429 replay via TokenManager), the SQLite cache, and `validate.ts`.

## Testing

- `npm run build` clean (tsc + esbuild)
- `npm test`: 309 tests passing (14 files)
- `npm run test:coverage`: 100% statements/branches/functions/lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)