### PR TITLE
ci: switch the deferred-CI gate to status mode (pending ci-gated, green job)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,20 @@
 name: CI
 
 # Thin stub — the gate and steps live in chrischall/workflows.
-# NOTE: converting to a reusable workflow renames the required check from
-# `ci` to `ci / ci`; scripts/update-ruleset.sh flips the ruleset.
+# Status-mode gate: un-armed PRs are blocked by a yellow `ci-gated: pending`
+# commit status (not a red failing job); the repo ruleset must require the
+# `ci-gated` status context (scripts/update-ruleset.sh flips it from `ci / ci`).
+# The permissions block is load-bearing: the reusable workflow posts the
+# `ci-gated` status with this token, and (a) callers pass read-only by default,
+# (b) dependabot-triggered runs are read-only unless permissions are explicit.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: read
+  statuses: write
 
 jobs:
   ci:
@@ -15,3 +23,4 @@ jobs:
       node-version: "26"
       build-command: npm run build
       test-command: npm run test:coverage
+      gate-mode: status


### PR DESCRIPTION
Fleet rollout of the status-mode deferred-CI gate (chrischall/workflows#22, piloted on chrischall/gemini-mcp#51): un-armed PRs are blocked by a yellow `ci-gated: pending` commit status instead of a red failing `ci / ci` job, so red check runs only ever mean real failures. The permissions block is load-bearing (the reusable workflow posts `ci-gated` with this token; dependabot runs are read-only without it).

Immediately after this merges, the ruleset's required check flips from `ci / ci` to `ci-gated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
