### PR TITLE
fix: sanitize co-parent-controlled attachment filename on download (path traversal)

### DIFF
--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -640,13 +640,18 @@ export function registerMessageTools(server: McpServer, client: OFWClient): void
     }
 
     let dest: string;
+    // The filename comes from OFW file metadata — i.e. it is controlled by the
+    // co-parent who uploaded the attachment. basename() it before interpolating
+    // into a path so a crafted `../…` name can't escape the target directory
+    // (the upload path at :549 already applies basename to its input).
+    const safeName = basename(cached.fileName);
     if (args.saveTo) {
       // Treat saveTo as a directory if it ends with a separator; otherwise as a full path.
       const isDirArg = args.saveTo.endsWith('/') || args.saveTo.endsWith('\\');
       const abs = expandPath(args.saveTo);
-      dest = isDirArg ? join(abs, `${fileId}-${cached.fileName}`) : abs;
+      dest = isDirArg ? join(abs, `${fileId}-${safeName}`) : abs;
     } else {
-      dest = join(getAttachmentsDir(), `${fileId}-${cached.fileName}`);
+      dest = join(getAttachmentsDir(), `${fileId}-${safeName}`);
     }
 
     if (!args.force && cached.downloadedPath === dest) {

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { z } from 'zod';
 import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { OFWClient } from '../../src/client.js';
 import { registerMessageTools } from '../../src/tools/messages.js';
@@ -1214,6 +1214,35 @@ describe('ofw_download_attachment', () => {
       // File actually exists on disk
       const written = readFileSync(parsed.path);
       expect(written.equals(xlsxBytes)).toBe(true);
+    } finally {
+      rmSync(downloadDir, { recursive: true, force: true });
+    }
+  });
+
+  it('sanitizes a co-parent-controlled ../ filename so the write stays in the target dir', async () => {
+    const client = new OFWClient();
+    const bytes = Buffer.from('evil-bytes', 'utf8');
+    // The co-parent who uploaded the file controls the metadata fileName.
+    const malicious = '../../../../tmp/ofw-traversal-evil.png';
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      fileId: 66, label: malicious, fileName: malicious,
+      fileType: 'image/png', fileSize: bytes.length,
+    });
+    vi.spyOn(client, 'requestBinary').mockResolvedValueOnce({
+      body: bytes, contentType: 'image/png', suggestedFileName: malicious,
+    });
+    setup(client);
+
+    const downloadDir = mkdtempSync(join(tmpdir(), 'ofw-dl-'));
+    try {
+      const result = await handlers.get('ofw_download_attachment')!({ fileId: 66, saveTo: downloadDir + '/' });
+      const parsed = JSON.parse(result.content[0].text);
+      // The written path must stay directly under the requested dir…
+      expect(resolve(dirname(parsed.path))).toBe(resolve(downloadDir));
+      // …with the traversal segments stripped (basename only).
+      expect(parsed.path).toMatch(/66-ofw-traversal-evil\.png$/);
+      expect(parsed.path).not.toContain('..');
+      expect(readFileSync(parsed.path).equals(bytes)).toBe(true);
     } finally {
       rmSync(downloadDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
**M3** in `~/git/mcp-audit/SECURITY-2026-07-06.md`.

`ofw_download_attachment` built its destination as `join(dir, \`${fileId}-${cached.fileName}\`)` where `cached.fileName` comes from OFW file metadata — i.e. it is controlled by the **co-parent who uploaded the attachment**. A crafted name like `../../../../tmp/evil.png` escaped the attachments directory and wrote attacker-influenced bytes to an attacker-influenced path. This repo is legal-sensitive, which raises the weighting.

Fix: `basename(cached.fileName)` before interpolating, on both the `saveTo`-dir and default-dir branches — mirroring the upload path (`:549`), which already sanitizes its input.

TDD: a new test mocks a malicious metadata `fileName` and asserts the written path stays directly under the requested dir with the traversal segments stripped. 99 tests pass, 100% coverage maintained, `tsc`+esbuild clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)