### PR TITLE
refactor: tighten parseLenient generic call site in ofw _shared

### DIFF
--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -91,14 +91,23 @@ const PostMessagesResponseSchema = z.looseObject({
  * `if (result.id !== null)`. When id is null (no id field in the
  * response — never observed in production, but defensive), `raw`
  * carries the POST response so the caller can still surface it.
+ *
+ * The generic is parametrized on the schema's OUTPUT type `T`
+ * (`detailSchema: z.ZodType<T>`, `detail: T`) rather than on the schema
+ * type itself. This mirrors `parseLenient`'s own signature
+ * (`<T>(schema: ZodType<T>, …): T`) exactly, so `T` is inferred straight
+ * from the schema and flows into the return type with no `as` cast — the
+ * compiler verifies that `detail` matches `detailSchema`'s output. (A
+ * `<S extends z.ZodType>` constraint would widen the output to `unknown`
+ * and force a cast at this call site.)
  */
-export async function postMessageAndRefetch<S extends z.ZodType>(
+export async function postMessageAndRefetch<T>(
   client: OFWClient,
   payload: unknown,
-  detailSchema: S,
+  detailSchema: z.ZodType<T>,
   ctx: string,
 ): Promise<
-  | { id: number; detail: z.output<S>; raw: unknown }
+  | { id: number; detail: T; raw: unknown }
   | { id: null; detail: null; raw: unknown }
 > {
   const raw = parseLenient(
@@ -115,6 +124,6 @@ export async function postMessageAndRefetch<S extends z.ZodType>(
     detailSchema,
     await client.request('GET', `/pub/v3/messages/${id}`),
     { label: 'ofw-mcp', context: `GET /pub/v3/messages/{id} (${ctx})`, mode: 'strict' },
-  ) as z.output<S>;
+  );
   return { id, detail, raw };
 }


### PR DESCRIPTION
## What & why

Issue #118 (auto-review nit on #117): after adopting `@chrischall/mcp-utils`' `parseLenient`, the one generic call site inside `postMessageAndRefetch` lost compile-time verification and needed an `as z.output<S>` cast. `parseLenient`'s signature is `<T>(schema: ZodType<T>, …): T`, which is wider than the old bespoke `parseOFW`, so with the function parametrized as `<S extends z.ZodType>` the inferred return type no longer matched `z.output<S>` and the cast papered over the gap.

## Assessment

A genuinely cleaner fix exists — this is **not** a docs/comment-only change.

The root cause is the generic shape. `S extends z.ZodType` widens the schema's output to `unknown` (verified: an explicit `parseLenient<z.output<S>>(…)` still fails to typecheck, because `S` is only known to be `ZodType<unknown>`). Parametrizing on the schema's **output type** `T` instead — `detailSchema: z.ZodType<T>`, `detail: T` — mirrors `parseLenient`'s own signature exactly, so `T` is inferred straight from the schema and flows into the return type with **no cast**. The compiler now verifies that `detail` matches `detailSchema`'s output.

- No safety is moved or weakened elsewhere — the cast is eliminated, not relocated.
- Call sites are unchanged: each caller still gets `detail` typed as its own schema's output (`SentDetailSchema` / `SavedDraftDetailSchema`).
- A short comment on the function documents why the generic is shaped on `T` rather than `S`.

## Verification

- `npm run build` — typechecks clean (no `as`, no errors).
- `npm run test:coverage` — 305 tests pass, 100% statements/branches/functions/lines.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9KoctmEMyZUqtppNntP1R