### PR TITLE
fix: bump @chrischall/mcp-utils to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.4.3",
       "license": "MIT",
       "dependencies": {
-        "@chrischall/mcp-utils": "^0.11.0",
+        "@chrischall/mcp-utils": "^0.12.0",
         "@fetchproxy/bootstrap": "^1.3.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@chrischall/mcp-utils": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.11.0.tgz",
-      "integrity": "sha512-kMZxHRU/dluZPOs/9emt9JRQErgE6Pdq62+Y+6vpVQzHdCJjuJnP9nodaejGMynUMOxK2jhI1ETLyY88v3/YEg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.12.0.tgz",
+      "integrity": "sha512-WaqbTaT1F2ssZTANvwtmpcCwR/CZy/y1lkeChyl02BAZ8VkDJbvnFboMTNOzvSqGGyRitoPQejlstnzMrcgUWA==",
       "license": "MIT",
       "peerDependencies": {
         "@fetchproxy/server": "*",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@chrischall/mcp-utils": "^0.11.0",
+    "@chrischall/mcp-utils": "^0.12.0",
     "@fetchproxy/bootstrap": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
## What
- Pin-only bump of `@chrischall/mcp-utils` `^0.11.0` → `^0.12.0` (first-party fleet package; regenerated `package-lock.json`).
- No code adoption: this repo imports no scrape fns and has no `registerBridgeHealthcheckTool`, so neither 0.12.0 addition (scrape subpath, `classifyThrown` detail hook) applies.

## Verification
- Lock resolves `@chrischall/mcp-utils@0.12.0` (`npm ls`).
- `npm run build`: green (tsc + esbuild bundle).
- `npm run test:coverage`: green — 13 files, 305 tests passing; coverage 100% statements/branches/functions/lines (enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)