### PR TITLE
fix(skill): correct requests.md retry-recipe temp file and id/entityId precedence

### DIFF
--- a/skills/ofw-fpx/references/requests.md
+++ b/skills/ofw-fpx/references/requests.md
@@ -82,7 +82,7 @@ BODY=$(jq -n \
 RESP=$(curl -s -X POST 'https://ofw.ourfamilywizard.com/pub/v3/messages' \
   "${AUTH_HEADERS[@]}" -H 'Content-Type: application/json' --data "$BODY")
 
-NEW_ID=$(jq -r '.entityId // .id // empty' <<<"$RESP")
+NEW_ID=$(jq -r '.id // .entityId // empty' <<<"$RESP")
 [ -n "$NEW_ID" ] || { echo "SEND UNCONFIRMED: no id in response: $RESP" >&2; exit 1; }
 
 # Re-GET immediately — the only honest way to confirm the write landed.
@@ -233,7 +233,10 @@ curl -s -X POST 'https://ofw.ourfamilywizard.com/pub/v1/journals' \
 ## Auth-error / retry recipe (wrap any of the above)
 
 ```sh
-call() { curl -s -o /tmp/ofw-resp.json -w '%{http_code}' "$@" "${AUTH_HEADERS[@]}"; }
+RESP_FILE=$(mktemp /tmp/ofw-resp.XXXXXX.json)
+trap 'rm -f "$RESP_FILE"' EXIT
+
+call() { curl -s -o "$RESP_FILE" -w '%{http_code}' "$@" "${AUTH_HEADERS[@]}"; }
 
 STATUS=$(call 'https://ofw.ourfamilywizard.com/pub/v2/profiles')
 if [ "$STATUS" = "429" ]; then
@@ -244,6 +247,6 @@ if [ "$STATUS" = "401" ]; then
   echo "token expired — reload/sign in on the ourfamilywizard.com tab, then re-run the fpx local-storage capture" >&2
   exit 1
 fi
-[ "$STATUS" -lt 300 ] || { echo "OFW API error: $STATUS $(cat /tmp/ofw-resp.json)" >&2; exit 1; }
-jq . /tmp/ofw-resp.json
+[ "$STATUS" -lt 300 ] || { echo "OFW API error: $STATUS $(cat "$RESP_FILE")" >&2; exit 1; }
+jq . "$RESP_FILE"
 ```


### PR DESCRIPTION
## Summary
- Auto-review nit follow-up for #127 (from PR #126's `warn` verdict).
- `references/requests.md`'s auth-error/retry recipe wrote sensitive OFW responses to a fixed, predictable `/tmp/ofw-resp.json` — switched to `mktemp` + `trap 'rm -f ...' EXIT` so the path is unpredictable and always cleaned up.
- `references/requests.md` line 85's jq fallback `.entityId // .id` was reversed vs. the source's actual precedence: `postMessageAndRefetch` in `src/tools/_shared.ts` (lines 136-139) checks `raw?.id` before `raw?.entityId`. Fixed to `.id // .entityId`.

Closes #127

## Test plan
- [x] Verified `postMessageAndRefetch` in `src/tools/_shared.ts` checks `id` before `entityId` (lines 136-139), confirming the corrected jq order matches source.
- [x] Ran the corrected mktemp+trap snippet standalone — response file is created, used, and removed on exit (no leaked predictable path).
- [x] Ran `jq -r '.id // .entityId // empty'` against both `{"id":42,"entityId":99}` and `{"entityId":99}` — returns 42 and 99 respectively, confirming id-first precedence.
- Doc-only change; no code/tests affected.