### PR TITLE
feat: serve connector at connector.ofw.nullnet.app custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Instead of running `ofw-mcp` locally, you can add it to [claude.ai](https://clau
 - **Attachments are inline-only.** The Worker has no local filesystem, so `ofw_download_attachment` always returns bytes as MCP content blocks (`OFW_INLINE_ATTACHMENTS=true`) rather than writing to disk.
 - **Write mode defaults to `all`.** The hosted connector registers every tool by default, configurable per deployment via `OFW_WRITE_MODE` / `OFW_CALENDAR_WRITES` in `wrangler.jsonc` — see [Write protection](#write-protection-ofw_write_mode).
 
-Standing this up requires a Cloudflare account and is a manual, one-time process for whoever hosts it (there is no CI/CD path for it) — see [`docs/DEPLOY-CONNECTOR.md`](docs/DEPLOY-CONNECTOR.md) for the full runbook. The placeholder URL in [`server.json`](server.json)'s `remotes` entry (`https://ofw-mcp.example.workers.dev/mcp`) is a stand-in the operator replaces with their deployed Worker URL after following that runbook. The local stdio / `.mcpb` install above remains the desktop-only alternative if you'd rather run it against just your own account.
+Standing this up requires a Cloudflare account and is a manual, one-time process for whoever hosts it (there is no CI/CD path for it) — see [`docs/DEPLOY-CONNECTOR.md`](docs/DEPLOY-CONNECTOR.md) for the full runbook. `wrangler.jsonc` serves the Worker at a custom domain (`https://connector.ofw.nullnet.app/mcp`) plus the account's `*.workers.dev` URL; whoever hosts it uses their own domain. The local stdio / `.mcpb` install above remains the desktop-only alternative if you'd rather run it against just your own account.
 
 ## Available tools
 

--- a/docs/DEPLOY-CONNECTOR.md
+++ b/docs/DEPLOY-CONNECTOR.md
@@ -102,7 +102,18 @@ it prints the deployed URL:
 https://ofw-connector.<your-subdomain>.workers.dev
 ```
 
-Note that URL — it's what you'll share and what gets added as a connector.
+Because `wrangler.jsonc` also declares a custom-domain route
+(`connector.ofw.nullnet.app`, matching untappd-mcp's
+`connector.untappd.nullnet.app`), the connector is additionally served at:
+
+```
+https://connector.ofw.nullnet.app
+```
+
+Use the custom domain as the stable production URL you share. (The zone must be
+in the deploying Cloudflare account; if it isn't, remove the `routes` entry from
+`wrangler.jsonc` and use the `*.workers.dev` URL instead.) Note whichever URL you
+use — it's what gets added as a connector, with `/mcp` appended.
 
 > **Message-cache Durable Object.** The connector's `ofw_sync_messages` /
 > message-read tools store each user's synced OFW message history in an
@@ -136,8 +147,9 @@ npm run worker:test
 ### 5. Add it as a connector in claude.ai
 
 1. Go to claude.ai → **Settings** → **Connectors** → **Add custom connector**.
-2. Paste the deployed URL with `/mcp` appended:
-   `https://ofw-connector.<your-subdomain>.workers.dev/mcp`
+2. Paste the deployed URL with `/mcp` appended — the custom domain
+   `https://connector.ofw.nullnet.app/mcp` (or, without a custom domain,
+   `https://ofw-connector.<your-subdomain>.workers.dev/mcp`).
 3. Claude will open the connector's login page (served by the Worker at
    `/authorize`) and prompt for an **OFW email or username** and **OFW
    password**. Complete that login — this is the individual user's own

--- a/server.json
+++ b/server.json
@@ -43,11 +43,5 @@
         }
       ]
     }
-  ],
-  "remotes": [
-    {
-      "type": "streamable-http",
-      "url": "https://ofw-mcp.example.workers.dev/mcp"
-    }
   ]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,8 +23,10 @@
     "OFW_WRITE_MODE": "all",
     "OFW_INLINE_ATTACHMENTS": "true"
   },
-  // Operator step: attach a custom domain/route once DNS is ready, e.g.
-  // "routes": [{ "pattern": "connector.ofw.example.app", "custom_domain": true }],
+  // Production custom domain (matches untappd-mcp's connector.untappd.nullnet.app).
+  // The zone must be in the deploying account's Cloudflare; wrangler provisions
+  // the hostname on deploy. Remove this route to deploy to *.workers.dev only.
+  "routes": [{ "pattern": "connector.ofw.nullnet.app", "custom_domain": true }],
   "workers_dev": true,
   "observability": {
     "enabled": true


### PR DESCRIPTION
Follow-up to #130. Matches untappd-mcp's connector URL shape.

- **`wrangler.jsonc`**: activate the custom-domain route `connector.ofw.nullnet.app` (mirroring untappd's `connector.untappd.nullnet.app`) alongside `workers_dev`. Whoever hosts it swaps in their own zone.
- **`server.json`**: drop the placeholder `remotes` entry — untappd advertises no remote; the connector is a manual, personal deploy, not a registry entry. Also removes the `ofw-mcp.example.workers.dev` placeholder that didn't match the `ofw-connector` Worker name.
- **README + `docs/DEPLOY-CONNECTOR.md`**: document the custom domain as the stable production URL (`https://connector.ofw.nullnet.app/mcp`), with the `*.workers.dev` URL as the no-custom-domain fallback.

Verified: `wrangler deploy --dry-run` bundles with all bindings; `npm run worker:test` 10/10; `server.json` parses, description 83 chars.