### PR TITLE
fix: guard client.ts .env load so the Worker starts

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -7,9 +7,16 @@ import { BASE_URL, OFW_PROTOCOL_HEADERS, OFW_TOKEN_TTL_MS, OFW_TOKEN_EXPIRY_SKEW
 
 // Load .env for local dev; silently skip if dotenv is unavailable (e.g. mcpb
 // bundle). loadDotenvSafely applies override:false + quiet:true and swallows a
-// missing dotenv module, matching the prior inline try/catch exactly.
-const __dirname = dirname(fileURLToPath(import.meta.url));
-await loadDotenvSafely({ path: join(__dirname, '..', '.env') });
+// missing dotenv module. The try/catch additionally guards the Cloudflare
+// Worker runtime, where `import.meta.url` is undefined and
+// `fileURLToPath(undefined)` would otherwise throw at module init (Worker
+// startup validation) — there is no filesystem / .env to load there anyway.
+try {
+  const dir = dirname(fileURLToPath(import.meta.url));
+  await loadDotenvSafely({ path: join(dir, '..', '.env') });
+} catch {
+  /* v8 ignore next -- only reached in a non-Node runtime (Workers): no .env to load */
+}
 
 export interface BinaryResponse {
   body: Buffer;


### PR DESCRIPTION
The first live `wrangler deploy` of the connector failed startup validation:

```
Uncaught TypeError: The "path" argument must be of type string or an instance of URL. Received undefined
    at fileURLToPath (node-internal:internal_url)
    at file:///.../src/client.ts:11
```

`src/client.ts` loads `.env` at module init via `fileURLToPath(import.meta.url)`. In the deployed Workers runtime `import.meta.url` is `undefined`, so `fileURLToPath` throws during upload validation. Miniflare (`npm run worker:test`) didn't catch it because the vitest Workers pool provides `import.meta.url`; only the real deploy exercises the validated bundle.

**Fix:** wrap the `.env` load in a `try/catch`. Node loads `.env` exactly as before; the Worker (no filesystem, no `import.meta.url`) silently skips it. The catch is `/* v8 ignore */`'d (unreachable under the node pool).

Verified: `npm run test:coverage` 100%, `npm run worker:test` 10/10, `npm run build` OK, `wrangler deploy --dry-run` bundles.