### PR TITLE
fix: show a clean message when OFW rejects login credentials

### DIFF
--- a/src/auth-password.ts
+++ b/src/auth-password.ts
@@ -62,8 +62,17 @@ export async function loginWithPassword(
 
   const contentType = response.headers.get('content-type') ?? '';
   if (!contentType.includes('application/json')) {
+    // OFW rejects bad credentials by re-serving its HTML login page (Spring
+    // Security re-renders the form rather than returning 401/JSON). Surface a
+    // clean, actionable message instead of dumping the HTML page — this is what
+    // the hosted connector's login page shows the user on a failed sign-in.
+    if (contentType.includes('text/html')) {
+      throw new Error(
+        'OFW login failed — your OurFamilyWizard email or password was not accepted. Check them and try again.',
+      );
+    }
     const body = await response.text();
-    throw new Error(`OFW login returned unexpected response (${contentType}): ${body.substring(0, 200)}`);
+    throw new Error(`OFW login returned unexpected response (${contentType || 'no content-type'}): ${body.substring(0, 200)}`);
   }
 
   const data = (await response.json()) as LoginResponse;

--- a/tests/auth-password.test.ts
+++ b/tests/auth-password.test.ts
@@ -96,6 +96,23 @@ describe('loginWithPassword', () => {
     await expect(loginWithPassword('u', 'bad')).rejects.toThrow(/OFW login failed: 401/);
   });
 
+  it('throws a clean credentials message (not the HTML dump) when OFW re-serves its login page', async () => {
+    const loginHtml = '<!DOCTYPE html><html lang="en"><head><title>OurFamilyWizard</title></head><body>...</body></html>';
+    mockFetch([
+      { status: 303, headers: { 'set-cookie': 'SESSION=x' } },
+      { status: 200, body: loginHtml, headers: { 'content-type': 'text/html' } },
+    ]);
+    expect.assertions(2);
+    try {
+      await loginWithPassword('u', 'wrong');
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toMatch(/email or password was not accepted/);
+      // The raw HTML page must NOT leak into the error surfaced to the user.
+      expect(msg).not.toContain('<!DOCTYPE');
+    }
+  });
+
   it('throws with truncated body preview when login returns non-JSON', async () => {
     const html = '<html><body>maintenance</body></html>'.repeat(20);
     mockFetch([


### PR DESCRIPTION
Reported from the hosted connector: entering wrong credentials surfaced a raw HTML dump on the login page —

```
OFW login returned unexpected response (text/html): <!DOCTYPE html> <html lang="en"> <head> ...
```

OFW rejects bad credentials by **re-serving its HTML login page** (Spring Security re-renders the form rather than 401/JSON). `loginWithPassword` treated any non-JSON response as "unexpected" and included 200 chars of the HTML in the thrown error, which the connector's `/authorize` page then displayed to the user.

**Fix:** when the login POST returns `text/html`, throw a clean, actionable message (`your OurFamilyWizard email or password was not accepted. Check them and try again.`) with no HTML. Genuinely-unexpected non-JSON responses keep the truncated diagnostic preview for debugging.

Verified: `npm run test:coverage` 335 tests, 100%. New test asserts the clean message and that `<!DOCTYPE` never leaks into the error.