### PR TITLE
fix: label a live-fetched sent message as sent, not inbox

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -139,6 +139,10 @@ export async function resolveFolderIds(client: OFWClient, store: CacheStore): Pr
     drafts: find('DRAFTS'),
   };
   await store.setMeta('drafts_folder_id', ids.drafts);
+  // Persist the sent folder id too: ofw_get_message's live-fetch path uses it to
+  // label an uncached message sent-vs-inbox from the detail payload's own folder
+  // id, instead of hard-defaulting to inbox.
+  await store.setMeta('sent_folder_id', ids.sent);
   return ids;
 }
 

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -42,6 +42,10 @@ const MessageDetailSchema = z.looseObject({
   from: z.looseObject({ name: z.string().optional() }).optional(),
   files: z.array(z.number()).optional(),
   recipients: z.array(ApiRecipientSchema).optional(),
+  // The detail payload carries its own owning folder ({id, name}). We read the
+  // id to label a live-fetched message sent-vs-inbox instead of blindly
+  // defaulting to inbox — see the folder derivation in ofw_get_message.
+  folder: z.looseObject({ id: z.number() }).optional(),
 });
 
 // Attachment-backfill detail fetch reads only `files`.
@@ -234,7 +238,20 @@ export function registerMessageTools(
       { label: 'ofw-mcp', context: 'GET /pub/v3/messages/{id} (ofw_get_message)' },
     );
 
-    const folder: 'inbox' | 'sent' = cached?.folder ?? 'inbox';
+    // Derive the folder for a live-fetched message. A cached row (reached here
+    // only when its body was NULL) already knows its folder, so keep it.
+    // Otherwise use the detail's own folder id, matched against the sent folder
+    // id persisted by the last resolveFolderIds — a sent message must not be
+    // mislabeled 'inbox' (which would also hide it from ofw_get_unread_sent and
+    // a sent-scoped ofw_list_messages). When that mapping isn't known yet (no
+    // sync has run in this cache), fall back to 'inbox' as before.
+    let folder: 'inbox' | 'sent' = cached?.folder ?? 'inbox';
+    if (!cached) {
+      const sentFolderId = await cache.getMeta('sent_folder_id');
+      if (sentFolderId !== null && detail.folder?.id != null && String(detail.folder.id) === sentFolderId) {
+        folder = 'sent';
+      }
+    }
     const row: MessageRow = {
       id: detail.id,
       folder,

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -63,6 +63,7 @@ describe('resolveFolderIds', () => {
 
     await resolveFolderIds(client, store());
     expect(getMeta('drafts_folder_id')).toBe('333');
+    expect(getMeta('sent_folder_id')).toBe('222');
   });
 
   it('throws if a required system folder is missing', async () => {

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -31,6 +31,7 @@ const attachmentIO = new NodeAttachmentIO();
 const upsertMessage = (row: MessageRow): void => cache.core.upsertMessage(row);
 const upsertDraft = (row: DraftRow): void => cache.core.upsertDraft(row);
 const getMessage = (id: number): MessageRow | null => cache.core.getMessage(id);
+const setMeta = (key: string, value: string): void => cache.core.setMeta(key, value);
 const getDraft = (id: number): DraftRow | null => cache.core.getDraft(id);
 const upsertAttachmentForMessage = (input: UpsertAttachmentInput): void => cache.core.upsertAttachmentForMessage(input);
 const listAttachmentsForMessage = (messageId: number): AttachmentRow[] => cache.core.listAttachmentsForMessage(messageId);
@@ -310,6 +311,51 @@ describe('ofw_get_message (cache-first)', () => {
     const result = await handlers.get('ofw_get_message')!({ messageId: '99' });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.body).toBe('fresh-body');
+  });
+
+  it('labels a live-fetched message "sent" when the detail folder id matches the persisted sent folder id', async () => {
+    // Regression: previously a cache-miss live fetch hard-defaulted to 'inbox',
+    // so a sent message came back mislabeled 'inbox' (and was then cached that
+    // way, hiding it from ofw_get_unread_sent / a sent-scoped list).
+    setMeta('sent_folder_id', '222');
+    const client = new OFWClient();
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      id: 490670431, subject: 'Re: Upcoming travel', body: 'flights booked',
+      date: { dateTime: '2026-02-25T23:19:22Z' }, from: { name: 'Chris Hall' },
+      recipients: [], folder: { id: 222, name: 'Sent' },
+    });
+    setup(client);
+
+    const result = await handlers.get('ofw_get_message')!({ messageId: '490670431' });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.folder).toBe('sent');
+    expect(getMessage(490670431)?.folder).toBe('sent'); // cached with the right folder
+  });
+
+  it('labels a live-fetched message "inbox" when the detail folder id is not the sent folder', async () => {
+    setMeta('sent_folder_id', '222');
+    const client = new OFWClient();
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      id: 700, subject: 'From co-parent', body: 'hi', date: { dateTime: '2026-02-25T00:00:00Z' },
+      from: { name: 'Alison Hall' }, recipients: [], folder: { id: 111, name: 'Inbox' },
+    });
+    setup(client);
+
+    const result = await handlers.get('ofw_get_message')!({ messageId: '700' });
+    expect(JSON.parse(result.content[0].text).folder).toBe('inbox');
+  });
+
+  it('falls back to "inbox" when the detail omits a folder even though the sent id is known', async () => {
+    setMeta('sent_folder_id', '222');
+    const client = new OFWClient();
+    vi.spyOn(client, 'request').mockResolvedValueOnce({
+      id: 701, subject: 'No folder field', body: 'hi', date: { dateTime: '2026-02-25T00:00:00Z' },
+      from: { name: 'Someone' }, recipients: [],
+    });
+    setup(client);
+
+    const result = await handlers.get('ofw_get_message')!({ messageId: '701' });
+    expect(JSON.parse(result.content[0].text).folder).toBe('inbox');
   });
 
   it('routes draft ids to the drafts cache (folder="drafts") even when the messages cache has a stale row for the same id', async () => {


### PR DESCRIPTION
## Problem

On a cache miss, `ofw_get_message` hard-defaulted a live-fetched message's folder to `'inbox'`:

```js
const folder: 'inbox' | 'sent' = cached?.folder ?? 'inbox';
```

The `/pub/v3/messages/{id}` detail payload carries its own owning `folder` object (`{id, name}`), but it was ignored. So a **sent** message fetched by id came back labeled `"folder": "inbox"` — and was then **cached that way**, which also hides it from `ofw_get_unread_sent` and a sent-scoped `ofw_list_messages`.

Observed live: fetching a known sent message returned `"folder": "inbox"` despite the payload's own `folder: { id: <sent>, name: "Sent" }`.

## Fix

- `resolveFolderIds` now persists the **sent** folder id in the `meta` table (`sent_folder_id`), mirroring the existing `drafts_folder_id`.
- The live-fetch path derives sent-vs-inbox by matching the detail's own `folder.id` against `sent_folder_id`. A cached row (reached only when its body was `NULL`) keeps its already-known folder. When the mapping isn't known yet (no sync has run in this cache), it falls back to `'inbox'` as before — no regression for a cold cache.

## Tests

- sent id matches → `sent` (and cached as `sent`)
- id is not the sent folder → `inbox`
- detail omits a folder while sent id is known → `inbox` fallback
- `resolveFolderIds` persists `sent_folder_id`

`npm run test:coverage` green at 100%; build clean.

## Note

Independent of #140 (the sync-resume fix) — disjoint code regions, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)