### PR TITLE
fix: restore release publishing — npm has been stuck at 2.5.0 since 2.6.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,5 +52,11 @@ jobs:
         with:
           version: ${{ needs.release-please.outputs.version }}
           tag-name: ${{ needs.release-please.outputs.tag_name }}
+          # This repo ships TWO skills — skills/ofw (the MCP skill) and
+          # skills/ofw-fpx (the fpx-CLI sibling) — so the action's
+          # single-skills/*/SKILL.md auto-discovery can't pick one and hard-
+          # fails the release. skills/ofw is the one that pairs with this npm
+          # package; ofw-fpx documents reaching OFW without the server.
+          skill-path: skills/ofw/SKILL.md
           clawhub-token: ${{ secrets.CLAWHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,10 @@ Sanity-check before committing a description change:
 jq -r '.description | length' server.json
 ```
 
+**The `skill-path` input is mandatory here.** `chrischall/workflows`' `mcp-publish` action auto-discovers the skill to package as the `.skill` artifact (and to push to ClawHub): an explicit `skill-path`, else a root `SKILL.md`, else a *single* `skills/*/SKILL.md`. This repo has TWO (`skills/ofw` + `skills/ofw-fpx`), so auto-discovery hard-fails the publish job with `Multiple skills/*/SKILL.md found — set the skill-path input`. `.github/workflows/release-please.yml` therefore pins `skill-path: skills/ofw/SKILL.md`. If you add or rename a skill directory, that pin is what keeps releases publishing — don't drop it.
+
+This bit once: v2.6.0/2.6.1/2.6.2 were all tagged and had GitHub Releases created, but their publish jobs failed, so **npm sat at 2.5.0 while three releases looked done**. The release-please job and the publish job are separate — a green tag does not mean a green publish. After any release, confirm with `npm view ofw-mcp version`.
+
 ## Versioning
 
 Driven by **release-please** (`googleapis/release-please-action@v4`). Authoritative state lives in `.release-please-manifest.json`; release-please bumps every file registered in `release-please-config.json`'s `extra-files`:


### PR DESCRIPTION
## What broke

The publish job has failed on **every** release since 2.6.0:

```
Multiple skills/*/SKILL.md found — set the skill-path input.
```

[chrischall/workflows#41](https://github.com/chrischall/workflows/pull/41) ("resolve SKILL.md in plugin-shaped `skills/` layouts", merged 2026-07-13 21:32) taught `mcp-publish` to auto-discover the skill it packages as the `.skill` artifact: an explicit `skill-path` → else a root `SKILL.md` → else a **single** `skills/*/SKILL.md`. This repo has had **two** since [#126](https://github.com/chrischall/ofw-mcp/pull/126) added `skills/ofw-fpx` next to `skills/ofw`, so discovery is ambiguous. The action refuses to guess — correctly — and hard-fails.

Every repo pins the action at `@main`, so this broke with **no change here**, the moment #41 merged. The timeline lines up exactly:

| When | What |
|---|---|
| 07-13 16:49 | redfin/compass/zillow/homes/creditkarma release wave — all green (2 skills each) |
| 07-13 21:32 | workflows#41 merges |
| 07-14 17:35 | ofw-mcp v2.6.0 — **fails** |
| 07-15 13:19 | ofw-mcp v2.6.1 — **fails** |
| 07-17 12:33 | ofw-mcp v2.6.2 — **fails** |

Ironically #41 was fixing a real silent bug in this repo: the action used to hardcode a root `SKILL.md`, so v2.5.0 shipped **no `.skill` artifact at all** (`gh release view v2.5.0` lists only the `.mcpb`). It swapped a silent skip for a loud failure.

## The damage is wider than one red run

`release-please` and `publish` are separate jobs. The first succeeded every time, so **v2.6.0, v2.6.1 and v2.6.2 were each tagged, with a GitHub Release created, and looked shipped** — while npm still serves **2.5.0**:

```
$ npm view ofw-mcp version
2.5.0
$ gh release list
v2.6.2  Latest ...
```

Nothing from those three releases — including the sync-starvation fix in [#144](https://github.com/chrischall/ofw-mcp/pull/144) — has reached an installing user. The GitHub Releases for them have no assets attached either.

## The fix

Pin `skill-path: skills/ofw/SKILL.md` — the skill that pairs with this npm package (`ofw-fpx` documents reaching OFW *without* the server). Verified the path resolves both at `HEAD` and at the `v2.6.2` tag (the publish job checks out the tag, not main).

Also documented in `CLAUDE.md`, including the trap that made this invisible: **a green tag does not mean a green publish** — check `npm view ofw-mcp version` after a release.

## Why `fix:` and not `ci:`

Deliberate. `ci:` doesn't trigger a release, and a release is exactly what's needed to carry the already-tagged 2.6.x code to npm. The package contents are unchanged — **2.6.3 is 2.6.2 that actually publishes**. npm will jump 2.5.0 → 2.6.3; the 2.6.0–2.6.2 tags stay as-is (harmless, they're just tags).

Re-running the failed run can't fix this: a re-run reuses the workflow file from its own triggering commit, which lacks the pin.

## ⚠️ This is a fleet-wide landmine — 5 more repos are armed

`redfin-mcp`, `compass-mcp`, `zillow-mcp`, `homes-mcp`, `creditkarma-mcp` **all have two skills and no `skill-path`**. They're green only because none has released since #41. Each will fail on its next release exactly like this — and, like here, will look released while npm silently stalls. `setlist-mcp` has already failed once (07-14).

This PR only unblocks ofw-mcp. The fleet-level call is yours: pin `skill-path` in each repo, or change the shared action (e.g. prefer the skill matching the package name, or package all of them). I haven't touched `chrischall/workflows` — that's 7 repos' behavior and your design call. Happy to do either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)