### PR TITLE
docs: restore the branch-protection ruleset specifics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ To skip a release temporarily, close release-please's PR — it'll re-open with 
 
 Recovery from a flaky publish step: re-run the failed `release-please.yml` workflow run from the GitHub Actions UI. The publish job's npm step is idempotent (skips if already published); MCP Registry publish is idempotent in practice; `gh release upload --clobber` overwrites any prior uploads.
 
-The branch-and-PR shape is still required because `main` is protected by the *main protection (PR + ci)* ruleset.
+The branch-and-PR shape is still required because `main` is protected by **two** rulesets: *Block force-push and deletion on main* and *main protection (PR + ci)* — the latter requires every change to go through a PR and `ci` to pass (strict mode: the branch must be up to date with `main`). No bypass actors; admins are not exempt. Inspect with `gh api /repos/chrischall/ofw-mcp/rulesets`.
 
 <!-- pr-workflow:v3 -->
 ## Pull requests & release notes


### PR DESCRIPTION
Follow-up to the fleet-policy dedup.

The dedup collapsed ofw's branch-protection paragraph down to a single ruleset name, dropping detail that isn't recorded anywhere else in the repo:

- there are **two** rulesets, not one (*Block force-push and deletion on main* as well as *main protection (PR + ci)*)
- `ci` runs in **strict mode** — the branch must be up to date with `main`
- **no bypass actors; admins are not exempt**
- they can be inspected with `gh api /repos/chrischall/ofw-mcp/rulesets`

Found by re-auditing all 40 swept repos for dropped content, prompted by auto-review catching the identical class of loss in nullnet-app/nullnet#20. ofw was the only other genuine loss; everything else the audit flagged was fleet policy that was deliberately removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Div7Yto4QhW7M8i8i5wG6r