### PR TITLE
fix(ci): run the Workers test pool in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,5 @@ jobs:
     with:
       node-version: "26"
       build-command: npm run build
-      test-command: npm run test:coverage
+      test-command: npm run test:coverage && npm run worker:test
       gate-mode: status


### PR DESCRIPTION
## Problem

This repo has a second vitest pool — `vitest.workers.config.ts` — because the Worker connector imports `cloudflare:workers` and cannot load in the node pool.

But CI only ever invoked the node pool, so **the Workers tests never ran in CI**. A regression in the connector (OAuth props, login verification, agent wiring) would have merged green.

## Fix

Chains the Workers pool onto the CI `test-command`. Patched in `ci.yml` rather than `package.json` deliberately, so a local `npm test` stays fast and only CI pays for spinning up workerd.

## Verification

The Workers tests pass on `main` today, so this turns on a green suite rather than surfacing a pre-existing failure — checked before opening.

The same fix was verified end-to-end in `sixflags-mcp` (chrischall/sixflags-mcp#7), including planting a deliberately failing Workers test to confirm the chained command exits non-zero rather than passing on the node pool's success.

## Fleet-wide

All eight connector repos had this blind spot: artsonia, ofw, setlist, sixflags, splitwise, untappd, vibo, zola. This is that one-line fix; sixflags is already done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Div7Yto4QhW7M8i8i5wG6r