### PR TITLE
ci: deploy the connector Worker on release

### DIFF
--- a/.github/workflows/deploy-connector.yml
+++ b/.github/workflows/deploy-connector.yml
@@ -1,0 +1,47 @@
+# Copy to `.github/workflows/deploy-connector.yml` in an MCP repo that ships a
+# hosted connector Worker.
+#
+# This stub is ONLY the on-demand path — redeploy any ref without cutting a
+# release, or retry a release deploy that failed. The automatic path belongs in
+# `release-please.yml`, so the deploy is pinned to the release tag:
+#
+#   deploy-connector:
+#     needs: release-please
+#     if: needs.release-please.outputs.release_created == 'true'
+#     uses: chrischall/workflows/.github/workflows/reusable-mcp-connector-deploy.yml@main
+#     with:
+#       ref: ${{ needs.release-please.outputs.tag_name }}
+#     secrets: inherit
+#
+# Requires a `CLOUDFLARE_API_TOKEN` repo secret (`set-fleet-secrets` adds it to
+# repos carrying a wrangler config).
+#
+# NOTE: workflow_dispatch only appears in the Actions UI once this file is on the
+# repo's DEFAULT branch — you cannot trigger it from a PR branch.
+
+name: deploy-connector
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to deploy (branch, tag or SHA).
+        type: string
+        default: main
+        required: true
+
+permissions:
+  contents: read
+
+# No concurrency block here on purpose. A group declared in THIS file would only
+# serialise workflow_dispatch runs against each other — the release-triggered
+# deploy lives in release-please.yml and inherits that workflow's group instead,
+# so the two could still race onto the same Worker. The reusable workflow
+# declares one shared group per repository, which covers both entry points.
+
+jobs:
+  deploy:
+    uses: chrischall/workflows/.github/workflows/reusable-mcp-connector-deploy.yml@main
+    with:
+      ref: ${{ inputs.ref }}
+    secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -60,3 +60,16 @@ jobs:
           skill-path: skills/ofw/SKILL.md
           clawhub-token: ${{ secrets.CLAWHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Deploy the hosted connector Worker at the released tag, so what is live
+  # tracks the release instead of drifting behind main. Deliberately not
+  # `needs: publish` — the connector is independent of npm and the MCP registry,
+  # so a registry hiccup should not leave it stale. Serialisation against the
+  # workflow_dispatch stub is declared by the reusable workflow.
+  deploy-connector:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: chrischall/workflows/.github/workflows/reusable-mcp-connector-deploy.yml@main
+    with:
+      ref: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit


### PR DESCRIPTION
Adds automatic deployment of the hosted connector Worker on release.

- `release-please.yml` gains a `deploy-connector` job that runs after `release-please` when a release is created, deploying at the release tag so what is live matches what was released.
- New `.github/workflows/deploy-connector.yml` — a `workflow_dispatch` stub for redeploying any ref on demand (or retrying a failed release deploy). Note it only appears in the Actions UI once merged to the default branch.

Both entry points call the shared reusable workflow `chrischall/workflows/.github/workflows/reusable-mcp-connector-deploy.yml@main` rather than a local copy; the reusable workflow declares the shared concurrency group so the two paths cannot race onto the same Worker.

The job does not gate the release: it is deliberately not `needs: publish`, so a registry or npm hiccup cannot leave the connector stale, and a missing `CLOUDFLARE_API_TOKEN` warns and passes rather than failing an otherwise-good release. `CLOUDFLARE_API_TOKEN` is already set on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvYhHrXacyknC2L9knjjdb