### PR TITLE
test: add supportsDisk to worker-cache stubAttachmentIO

### DIFF
--- a/tests/worker-cache.test.ts
+++ b/tests/worker-cache.test.ts
@@ -22,6 +22,7 @@ import type { AttachmentIO, ResolvedUpload } from '../src/tools/attachments.js';
 const CACHE = (env as unknown as { CACHE_DO: DurableObjectNamespace<OFWCacheDO> }).CACHE_DO;
 
 const stubAttachmentIO: AttachmentIO = {
+  supportsDisk: false,
   resolveUpload(): Promise<ResolvedUpload> {
     return Promise.reject(new Error('not used'));
   },


### PR DESCRIPTION
## Summary

Follow-up to #172, addressing the auto-review nit tracked in #173.

PR #172 added a new required `supportsDisk` field to the `AttachmentIO` interface and updated two of the three test stubs (`tests/worker.test.ts`'s `stubAttachmentIO` and the hosted `hostedIO` in `tests/tools/messages.test.ts`). The third stub in `tests/worker-cache.test.ts` was missed, so that object literal no longer satisfied `AttachmentIO`.

This adds the one-line `supportsDisk: false,` for consistency with the other two stubs.

## Why it wasn't a live bug

Latent type-correctness gap only:
- `tsconfig.json`'s `include` is `src/**/*`, so test files aren't type-checked by `npm run build`.
- `vitest.workers.config.ts` transpiles via esbuild with no type-check pass.
- The one test using this stub never calls `ofw_download_attachment`, so `.supportsDisk` is never read.

CI stayed green on #172, and the Workers-pool suite (`npm run worker:test`) passes with this change.

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1NwzzsVA8SqAhNydGciTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1NwzzsVA8SqAhNydGciTJ)_