### PR TITLE
ci: list both Cloudflare secrets in the deploy-connector template comment

### DIFF
--- a/.github/workflows/deploy-connector.yml
+++ b/.github/workflows/deploy-connector.yml
@@ -15,9 +15,13 @@
 #       ref: ${{ needs.release-please.outputs.tag_name }}
 #     secrets:
 #       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+#       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 #
-# Requires a `CLOUDFLARE_API_TOKEN` repo secret (`set-fleet-secrets` adds it to
-# repos carrying a wrangler config).
+# Requires a `CLOUDFLARE_API_TOKEN` repo secret, and `CLOUDFLARE_ACCOUNT_ID` when
+# the token can reach more than one Cloudflare account (wrangler cannot
+# disambiguate on its own). `set-fleet-secrets` adds the token to repos carrying
+# a wrangler config. Both are passed through below; an absent one is not fatal —
+# the reusable workflow warns and skips rather than failing the release.
 #
 # NOTE: workflow_dispatch only appears in the Actions UI once this file is on the
 # repo's DEFAULT branch — you cannot trigger it from a PR branch.


### PR DESCRIPTION
The commented `release-please.yml` template in this file's header passed only `CLOUDFLARE_API_TOKEN`:

```yaml
#     secrets:
#       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
```

while the live `workflow_dispatch` job 30 lines below it passes **both**:

```yaml
    secrets:
      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
```

The header's whole purpose is to be copied into `release-please.yml`, so following it wires up a release deploy with no account id — and `CLOUDFLARE_ACCOUNT_ID` is exactly what wrangler needs when the token can reach more than one Cloudflare account. The prose underneath named only the one secret too.

The canonical template in `chrischall/workflows` (`templates/deploy-connector.yml`, and `templates/fragments/deploy-connector-job.yml`) **was already corrected** — these copies drifted from it. This syncs the header to the canonical text verbatim, including the note that a missing secret is warn-and-skip in the reusable workflow rather than fatal.

Closes #167 — the auto-review nit on that repo's copy.

### Verification

Comment-only; no workflow behaviour changes. Confirmed this repo's live job does pass both secrets (so the corrected comment matches reality here), and that the file still parses after the edit.