### PR TITLE
build(deps): lift @chrischall/mcp-connector to 1.1.1 in the lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -431,15 +431,15 @@
       "license": "MIT"
     },
     "node_modules/@chrischall/mcp-connector": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@chrischall/mcp-connector/-/mcp-connector-1.1.0.tgz",
-      "integrity": "sha512-ohy3IIZoub8mgl8icvvgEUSZcN4OyounPkJBg4v/EFgjf1V5LTrgtpEYSmJay3Pppn/Re4IkHFSeGVkvDdfCrA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@chrischall/mcp-connector/-/mcp-connector-1.1.1.tgz",
+      "integrity": "sha512-ExAlLY8qWaqP+EchyTszQf07JvmqV4tww+7DlfIR+meq59y7pI622NC25ibcBZw0mwFZB8nYtMbnKQhf+91nEQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@cloudflare/workers-oauth-provider": "^0.8.1",
         "@modelcontextprotocol/sdk": "^1.27.0",
-        "agents": "^0.17.3"
+        "agents": ">=0.17.3 <0.20.0"
       }
     },
     "node_modules/@chrischall/mcp-utils": {


### PR DESCRIPTION
**Unblocks #178** (the `agents` 0.19.0 bump), which cannot merge on its own.

`@chrischall/mcp-connector@1.1.1` widens its `agents` peer to `>=0.17.3 <0.20.0` (chrischall/mcp-connector#11). At **1.1.0** that peer was `agents@^0.17.3`, so any lockfile pairing it with `agents@0.19.0` refuses to install:

```
npm error While resolving: @chrischall/mcp-connector@1.1.0
npm error Found: agents@0.19.0
npm error peer agents@"^0.17.3" from @chrischall/mcp-connector@1.1.0
```

### Why dependabot can't do this itself

Where the connector sits **outside** the dev-dependencies group's update scope, a `@dependabot recreate` re-resolves `agents` and leaves the connector untouched — so the conflict survives the rebuild. (`artsonia-mcp#78`, whose group did include the connector, self-healed and merged; the other consumers didn't.) The declared range already permits 1.1.1, so only the lockfile was holding it back.

### Scope

Lockfile-only, one package. Dev-only — the connector is a devDependency of the Worker build and is absent from the published bundle — hence `build:` rather than `fix:`: there is nothing to release.

### Verification

Tests  510 passed (510).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192uEspWXpH2cczjKKi6YtM