### PR TITLE
ci: stop dependabot proposing agents past the connector's peer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,23 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      # `agents` is a PEER of @chrischall/mcp-connector, and the connector — not
+      # this repo — decides which versions are supported. Its published peer range
+      # is `>=0.17.3 <0.20.0`, so a bump to 0.20.x cannot install here at all:
+      # npm dies with ERESOLVE before a single test runs.
+      #
+      # This is not hypothetical. agents 0.19.0 met the connector's then-peer of
+      # `^0.17.3` and took out every consumer's dependabot PR simultaneously
+      # (chrischall/mcp-connector#11 widened the peer to fix it). The ceiling
+      # below mirrors that peer so dependabot stops proposing bumps the harness
+      # cannot accept — versions inside the window still flow normally.
+      #
+      # When the connector widens its peer, raise this ceiling in the same pass:
+      # every consumer is listed in that repo's CLAUDE.md blast-radius section.
+      - dependency-name: agents
+        versions:
+          - ">=0.20.0"
     groups:
       dev-dependencies:
         dependency-type: development


### PR DESCRIPTION
The durable fix for the collision that just cost the fleet eight red dependabot PRs.

### The loop being broken

`agents` is a **peer** of `@chrischall/mcp-connector`, so the *connector* — not this repo — decides which versions are supported. Its published peer is:

```
agents: >=0.17.3 <0.20.0
```

A bump to 0.20.x therefore cannot install here at all; npm dies with `ERESOLVE` before a single test runs.

That already happened. `agents@0.19.0` met the connector's then-peer of `^0.17.3` and took out **every consumer's dependabot PR simultaneously** — each one needing a published connector release (`mcp-connector#11` → 1.1.1) *plus* a per-repo lockfile lift to clear. Bumping the range in each consumer was never the fix.

And caret ranges guarantee a repeat: on `0.x` a caret pins the **minor**, so every `agents` minor falls outside the declared range, dependabot proposes a bump, and that bump fails whenever the connector's window hasn't moved first. Left alone, `agents@0.20.0` reruns the whole incident across twelve repos.

### The fix

An ignore ceiling mirroring the connector's peer. Dependabot stops proposing what the harness cannot accept; versions **inside** the window still flow normally, so this is not a blanket ignore and security patches are unaffected.

When the connector widens its peer, raise this ceiling in the same pass — the full consumer list is in that repo's `CLAUDE.md` blast-radius section, and the comment in this file says so.

### Scope

Config-only. No dependency versions change, `groups` and the `github-actions` entry are untouched, and the file parses (`yq` verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192uEspWXpH2cczjKKi6YtM