### PR TITLE
fix(deps): require @chrischall/mcp-connector >=1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "ofw-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@chrischall/mcp-connector": "^1.0.0",
+        "@chrischall/mcp-connector": "^1.1.1",
         "@cloudflare/vitest-pool-workers": "^0.18.4",
         "@cloudflare/workers-oauth-provider": "^0.8.1",
         "@cloudflare/workers-types": "^5.20260708.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.7.0",
   "license": "MIT",
   "mcpName": "io.github.chrischall/ofw-mcp",
-  "description": "OurFamilyWizard MCP server for Claude — developed and maintained by AI (Claude Code)",
+  "description": "OurFamilyWizard MCP server for Claude \u2014 developed and maintained by AI (Claude Code)",
   "author": "Claude Code (AI) <https://www.anthropic.com/claude>",
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@chrischall/mcp-connector": "^1.0.0",
+    "@chrischall/mcp-connector": "^1.1.1",
     "@cloudflare/vitest-pool-workers": "^0.18.4",
     "@cloudflare/workers-oauth-provider": "^0.8.1",
     "@cloudflare/workers-types": "^5.20260708.1",


### PR DESCRIPTION
Raises the declared floor from `^1.0.0` to `^1.1.1`, and fixes a mistake of mine in the process.

### The floor is a real requirement, not bookkeeping

1.1.1 is the **first** release whose `agents` peer is `>=0.17.3 <0.20.0`. Every earlier 1.x advertises `agents@^0.17.3` and cannot be installed beside the `agents@0.19.0` this repo now uses. `^1.0.0` still permitted those versions, so the requirement lived only in the lockfile — a fresh resolution could legally pick a connector that does not work here.

### The mistake this corrects

The lockfile lift landed as `build(deps):`. `CLAUDE.md` explicitly forbids that for first-party bumps, because a hidden prefix does not trigger a release — and that is **not cosmetic here**:

```yaml
# release-please.yml
deploy-connector:
  if: needs.release-please.outputs.release_created == 'true'
```

The hosted Worker redeploys **only when a release is cut**. Hidden under `build(deps):`, the widened peer reached `main` and never reached production — the live Worker is still running connector **1.1.0**, the narrow-peer version this whole change exists to get away from. Caught by the auto-review on `vibo-mcp#44`, which was right.

`fix:` lets release-please cut the release that actually deploys it.

### Verification

Tests  510 passed (510), and the Workers-runtime suite (which exercises the connector) Tests  12 passed (12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192uEspWXpH2cczjKKi6YtM