### PR TITLE
fix: correct three misleading messages and skip an empty cache RPC

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -359,8 +359,12 @@ async function walkPages(
       }
     }
 
-    // Flush the page's rows in one transaction/RPC. Empty array is a no-op.
-    await store.upsertMessages(toUpsert);
+    // Flush the page's rows in one transaction/RPC. Skipped entirely when the
+    // page held nothing new: on the Worker this call is a Durable-Object RPC,
+    // and a DO RPC counts against the same subrequest budget as an OFW fetch.
+    // A deep re-walk crosses page after page of already-cached messages, so an
+    // unconditional "no-op" write spends the caller's budget to store nothing.
+    if (toUpsert.length > 0) await store.upsertMessages(toUpsert);
 
     if (pageBudgetHit) {
       // Paused mid-page. Resume at THIS page: the partial rows are cached, so

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -556,10 +556,13 @@ export function registerMessageTools(
     try {
       server = await fetchServerDraft(client, draftId);
     } catch (e) {
-      // fetchServerDraft funnels every non-404 failure into DraftFreshnessError,
-      // so anything landing here means the check could not RUN. That is not
-      // permission to proceed: a transient 5xx must not degrade into a blind
-      // overwrite.
+      // Anything landing here means the check could not RUN. Most failures
+      // arrive as DraftFreshnessError from fetchServerDraft, but not all of
+      // them: a strict parseLenient mismatch on the server draft throws
+      // McpToolError instead. Both are caught, and both abort — which is the
+      // point. A failed check is not permission to proceed: a transient 5xx
+      // must not degrade into a blind overwrite. (The cast below only reads
+      // `.message`, which every Error carries.)
       const reason = (e as DraftFreshnessError).message;
       if (force) {
         return { ok: true, note: `WARNING: force:true — proceeded with ${action} on draft ${draftId} even though its current state could not be read from OurFamilyWizard (${reason}). Any newer server-side version was destroyed and is NOT recoverable from this response.` };
@@ -752,8 +755,17 @@ export function registerMessageTools(
       // silent normalization becomes a visible warning rather than a surprise.
       if (resolvedReplyTo !== null && effectiveReplyTo !== resolvedReplyTo) {
         const rewrittenFrom = requestedReplyTo !== resolvedReplyTo ? ` (rewritten from ${requestedReplyTo})` : '';
+        // Two different outcomes reach this branch, and they need different
+        // warnings. OFW either DROPPED the link (null) or RE-TARGETED it to
+        // another message in the thread. Describing both as "did not thread
+        // this draft (its inReplyTo/showContext will be empty)" contradicted
+        // the non-null inReplyTo the same response echoes — and a warning the
+        // caller can see is false is a warning it learns to skip.
+        const outcome = effectiveReplyTo === null
+          ? 'OurFamilyWizard did not thread this draft (its inReplyTo/showContext will be empty). The subject and body were saved; only the reply linkage was dropped.'
+          : `OurFamilyWizard re-targeted the reply to message ${effectiveReplyTo} instead. The draft IS threaded — to that message, not the one requested — and the inReplyTo in this response reflects where it actually landed.`;
         warnings.push(
-          `replyToId was requested as ${resolvedReplyTo}${rewrittenFrom} but the saved draft came back with replyToId ${effectiveReplyTo === null ? 'null' : effectiveReplyTo} — OurFamilyWizard did not thread this draft (its inReplyTo/showContext will be empty). The subject and body were saved; only the reply linkage was dropped. If threading matters, verify on ourfamilywizard.com.`,
+          `replyToId was requested as ${resolvedReplyTo}${rewrittenFrom} but the saved draft came back with replyToId ${effectiveReplyTo === null ? 'null' : effectiveReplyTo} — ${outcome} If threading matters, verify on ourfamilywizard.com.`,
         );
       }
       // Only warn on recipients/attachments when the detail actually reported
@@ -1111,7 +1123,13 @@ export function registerMessageTools(
           ? (await cache.listDraftIds()).length
           : await cache.countMessages({ folder });
         const state = await cache.getSyncState(folder);
-        const historyComplete = state !== null && state.resumePage === null;
+        // Never synced at all is a DIFFERENT state from "backfill in progress",
+        // and both leave historyComplete false. Conflating them told the caller
+        // that older history was still being backfilled for a folder whose
+        // backfill had never started — advice that reads as "wait it out" when
+        // the real answer is "run a sync".
+        const neverSynced = state === null;
+        const historyComplete = !neverSynced && state.resumePage === null;
         // A partially backfilled folder legitimately holds fewer messages than
         // the server, so a count mismatch there proves nothing. Report both
         // numbers and leave the verdict null rather than crying wolf for the
@@ -1130,7 +1148,9 @@ export function registerMessageTools(
           ...(inSync === null
             ? { note: serverCount === null
               ? 'OFW did not report a count for this folder, so cached-vs-server cannot be compared. Use the per-id check instead.'
-              : 'Older history is still being backfilled, so a lower cachedCount is expected and does not indicate drift.' }
+              : neverSynced
+                ? 'This folder has never been synced, so the cache holds nothing to compare. Run ofw_sync_messages.'
+                : 'Older history is still being backfilled, so a lower cachedCount is expected and does not indicate drift.' }
             : {}),
         });
       }

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -825,6 +825,30 @@ describe('syncMessageFolder — bounded + resumable (budget)', () => {
     expect(listPages).toEqual(['1', '2', '3']);
   });
 
+  it('writes nothing for an all-cached page, so a deep re-walk spends no cache RPC', async () => {
+    // On the Worker every store call is a Durable-Object RPC, counted against
+    // the same subrequest budget as an OFW fetch. A deep re-walk crosses page
+    // after page of already-cached messages; an unconditional "empty array is a
+    // no-op" write spends that budget to store nothing.
+    seedCachedSent(1);
+    seedCachedSent(2);
+    const client = new OFWClient();
+    vi.spyOn(client, 'request')
+      .mockResolvedValueOnce(listResponse([{ id: 1 }, { id: 2 }])) // page 1: all cached
+      .mockResolvedValueOnce(listResponse([]));                    // page 2: empty
+    const upsertSpy = vi.spyOn(cache, 'upsertMessages');
+
+    const result = await syncMessageFolder(
+      client, 'sent', '222',
+      { fetchUnreadBodies: false, deep: true, budget: makeBudget(Number.POSITIVE_INFINITY) },
+      store(),
+    );
+
+    expect(result.done).toBe(true);
+    expect(result.synced).toBe(0);
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+
   it('pauses MID-page and resumes the same page, skipping the rows it already cached', async () => {
     // Budget funds list page 1 + one detail, then runs out on the second item.
     const c1 = new OFWClient();

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -1705,6 +1705,40 @@ describe('ofw_save_draft — threading & field preservation (Defects 1 & 3)', ()
     expect(result.content[0].text).toMatch(/See warnings above/);
     expect(result.content[0].text).toMatch(/did not thread this draft/);
   });
+
+  it('says the reply was RE-TARGETED, not dropped, when OFW threads it elsewhere', async () => {
+    // OFW normalizes a reply to the thread tip rather than dropping it. The
+    // old warning called that "did not thread this draft (its inReplyTo will
+    // be empty)" while the same response echoed inReplyTo: 205 — a warning the
+    // caller can see is false is a warning it learns to skip.
+    upsertDraft({
+      id: 860, subject: 'S', body: 'B', recipients: [], replyToId: 200,
+      modifiedAt: '2026-07-19T12:42:00Z', listData: {},
+    });
+    const client = new OFWClient();
+    vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({ subject: 'S', body: 'B', replyToId: 200, recipients: [] }) // guard FRESH
+      .mockResolvedValueOnce({ entityId: 861 })
+      .mockResolvedValueOnce({
+        id: 861, subject: 'S', body: 'B',
+        date: { dateTime: '2026-07-20T00:00:00Z' },
+        replyToId: 205, // re-targeted to the thread tip, NOT dropped
+      })
+      .mockResolvedValueOnce({});
+    setup(client);
+
+    const result = await handlers.get('ofw_save_draft')!({
+      subject: 'S', body: 'B', messageId: 860, replyToId: 200,
+    });
+    const text = result.content[0].text;
+
+    expect(text).toMatch(/re-targeted the reply to message 205/);
+    expect(text).toMatch(/The draft IS threaded/);
+    expect(text).not.toMatch(/did not thread this draft/);
+    expect(text).not.toMatch(/inReplyTo\/showContext will be empty/);
+    // …and the response's own echo agrees with the warning.
+    expect(JSON.parse(text.slice(text.indexOf('{'))).inReplyTo).toBe(205);
+  });
 });
 
 describe('draft reads expose revision + cacheStatus', () => {
@@ -3607,6 +3641,22 @@ describe('ofw_check_freshness', () => {
     expect(parsed.folders[0].historyComplete).toBe(false);
     expect(parsed.folders[0].inSync).toBeNull();
     expect(parsed.folders[0].note).toMatch(/backfilled/);
+  });
+
+  it('tells a never-synced folder to sync instead of calling it mid-backfill', async () => {
+    // No sync state at all. That leaves historyComplete false for the same
+    // reason a parked backfill does, but the advice is the opposite: waiting
+    // out a backfill that never started gets the caller nowhere.
+    setup(makeClient(foldersPayload()));
+
+    const parsed = JSON.parse(
+      (await handlers.get('ofw_check_freshness')!({ folders: ['inbox'] })).content[0].text,
+    );
+
+    expect(parsed.folders[0].historyComplete).toBe(false);
+    expect(parsed.folders[0].inSync).toBeNull();
+    expect(parsed.folders[0].note).toMatch(/never been synced/);
+    expect(parsed.folders[0].note).not.toMatch(/backfilled/);
   });
 
   it('withholds a verdict when OFW reports no count for the folder', async () => {


### PR DESCRIPTION
Clears the remaining four auto-review follow-ups. Every one is a case where the code told the caller something untrue.

Closes #170
Closes #180
Closes #138
Closes #159

## #170 — a never-synced folder was called "mid-backfill"

`historyComplete` is false both when a backfill is parked *and* when no sync has ever run, and the note only described the first:

> Older history is still being backfilled, so a lower cachedCount is expected and does not indicate drift.

For a folder whose backfill never started, that reads as *wait it out* when the real answer is *run a sync*. The two states are now distinguished.

## #180 — the dropped-`replyToId` warning contradicted its own response

The branch fires whenever the saved draft's `replyToId` differs from the requested one — which covers OFW **dropping** the link and OFW **re-targeting** it to another message in the thread. Both got:

> OurFamilyWizard did not thread this draft (its inReplyTo/showContext will be empty).

…while the same response echoed a non-null `inReplyTo` two lines down. A warning the caller can see is false is a warning it learns to skip, and that costs us the drops that are real. The re-target case now says where the reply actually landed.

## #138 — an empty cache write on every all-cached page

The comment said *"Empty array is a no-op"*, and in the node cache it is. On the Worker, `store.upsertMessages` is a **Durable-Object RPC**, and a DO RPC counts against the same subrequest budget as an OFW fetch (`OFW_SYNC_MAX_REQUESTS=40`). A deep re-walk crosses page after page of already-cached messages, so the no-op spent the caller's bounded budget to store nothing.

## #159 — comment-only

The `guardDestructiveDraftOp` catch comment claimed `fetchServerDraft` "funnels every non-404 failure into `DraftFreshnessError`". A strict `parseLenient` mismatch throws `McpToolError` instead. Behaviour was already correct — both are caught, both abort — but a comment that overstates an invariant is how the next reader stops checking.

## Tests

- The sync guard is covered by a test I verified is load-bearing: reverting the one-line change makes it fail (`expected "upsertMessages" to not be called at all, but actually been called 1 times`).
- The two message fixes assert the new text **and** that the old, false text is gone — including that `inReplyTo` in the payload agrees with the warning.

671 tests, coverage at the 100% gate, Workers-pool suite and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DKSBmZAgtkp3wfCB4TgMm