### PR TITLE
refactor: hoist an import and stop a docstring overstating what it throws

### DIFF
--- a/src/extract/zip.ts
+++ b/src/extract/zip.ts
@@ -9,6 +9,8 @@
 // `node:zlib` here would break the Worker build; adding a userland inflate
 // dependency would bloat it. Neither is necessary.
 
+import { inflateBounded, MAX_DECOMPRESSED_BYTES } from './inflate.js';
+
 const EOCD_SIG = 0x06054b50;
 const CENTRAL_SIG = 0x02014b50;
 const LOCAL_SIG = 0x04034b50;
@@ -26,8 +28,6 @@ const ZIP64_SENTINEL = 0xffffffff;
  * 1 KB in front of a member that expands to a gigabyte.
  */
 export const ZIP_MAX_UNCOMPRESSED_BYTES = MAX_DECOMPRESSED_BYTES;
-
-import { inflateBounded, MAX_DECOMPRESSED_BYTES } from './inflate.js';
 
 interface ZipEntry {
   name: string;

--- a/src/tools/draft-freshness.ts
+++ b/src/tools/draft-freshness.ts
@@ -75,8 +75,13 @@ function isNotFound(e: unknown): boolean {
  * Read a draft's AUTHORITATIVE state straight from OFW, bypassing the cache.
  *
  * Returns `null` when the draft no longer exists (404). Any other failure
- * throws `DraftFreshnessError`: a freshness check that could not run must
- * abort the write, never wave it through — see the callers in messages.ts.
+ * throws, and the callers in messages.ts abort on ALL of them: a freshness
+ * check that could not run must never wave the write through.
+ *
+ * Most failures throw `DraftFreshnessError` from this function, but not all —
+ * a strict `parseLenient` mismatch on the response throws `McpToolError`
+ * instead. Callers must not assume the narrower type (the catch blocks read
+ * only `.message`, which every Error carries).
  */
 export async function fetchServerDraft(client: OFWClient, id: number): Promise<DraftContent | null> {
   let raw: unknown;


### PR DESCRIPTION
Closes #189
Closes #191

The two auto-review nits from #188 and #190. Both verified against `main` before changing anything; no behaviour change.

## #189 — import below the const that uses it

`src/extract/zip.ts` declared `ZIP_MAX_UNCOMPRESSED_BYTES = MAX_DECOMPRESSED_BYTES` and then imported `MAX_DECOMPRESSED_BYTES` two lines *below* it. ESM hoisting makes that work — which is precisely why it's worth fixing. Code that reads as though it cannot work, but does, costs the next reader a detour to prove it. Moved up with the other imports, matching the sibling modules (including `pdf.ts`, changed in the same PR).

## #191 — a docstring narrower than the truth

`fetchServerDraft`'s docstring claimed *"Any other failure throws `DraftFreshnessError`"*. A strict `parseLenient` mismatch on the response throws `McpToolError` instead.

This is the same overstatement #159 fixed at the `messages.ts` call site — the source of it was still here, one layer down, which is a decent argument for fixing the docstring rather than only the comment that quoted it. Behaviour was already correct (callers catch both and abort on both); the docstring now states the invariant that actually holds — everything throws, callers abort on all of it — instead of the narrower one that doesn't.

680 tests, coverage at the 100% gate, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DKSBmZAgtkp3wfCB4TgMm