### PR TITLE
ci: use the fleet's reusable Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,9 +1,10 @@
 name: Claude Code
 
-# Ad-hoc dispatch: @claude mentions in issues, PR review threads, or
-# issue comments invoke anthropics/claude-code-action interactively.
-# Automated PR review lives in pr-auto-review.yml; this workflow is the
-# manual escape hatch ("@claude can you look at this specific thing?").
+# Thin stub — the job lives in chrischall/workflows.
+#
+# Ad-hoc dispatch: @claude mentions in issues, PR review threads, or issue
+# comments. Automated PR review lives in pr-auto-review.yml; this workflow is
+# the manual escape hatch, and the only review path available for fork PRs.
 
 on:
   issue_comment:
@@ -15,31 +16,15 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          # Auth via the user's Claude Max plan (OAuth token from
-          # `claude setup-token`). Counts against the Max subscription's
-          # quota instead of pay-per-token API billing.
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    uses: chrischall/workflows/.github/workflows/reusable-claude.yml@main
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Converts `claude.yml` to a thin stub calling [`chrischall/workflows#66`](https://github.com/chrischall/workflows/pull/66)'s `reusable-claude.yml` — the same shape `ci.yml`, `pr-auto-review.yml` and `auto-merge.yml` already use.

**This repo goes first of 59** because the bug was found here: the local copy checked out the **default branch** on `issue_comment`, so the `@claude` review of #175 read `main`'s `CLAUDE.md` and reported a stale doc line the PR had already fixed. The stub also inherits the author gate — the local copy would run for any GitHub user who typed `@claude`, on a job holding `CLAUDE_CODE_OAUTH_TOKEN` with `contents: write`.

## Verification plan

#175 is the test case, and a good one: a **fork PR with conflicts**. It exercises both the fork path (its head exists only as `refs/pull/N/head` in this repo) and the reason the reusable workflow uses `/head` rather than `/merge` (GitHub publishes no merge ref for a conflicted PR).

Once this merges I'll re-run `@claude review this` on #175 and confirm it reads the branch — the tell being whether it repeats the "CLAUDE.md still documents the old default" false positive, which is only true of main.

Then the remaining 58 go via `scripts/rollout.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DKSBmZAgtkp3wfCB4TgMm