### PR TITLE
fix(messages): accept either spelling of folder.id, and stop double-fetching folders

### DIFF
--- a/src/tools/draft-freshness.ts
+++ b/src/tools/draft-freshness.ts
@@ -68,7 +68,20 @@ const ServerDraftSchema = z.looseObject({
   // Read for the LIFECYCLE answer (see tools/lifecycle.ts): which folder OFW
   // itself says this id lives in right now. `existsOnServer` alone cannot
   // distinguish "still a draft" from "was sent" — a sent draft still exists.
-  folder: z.looseObject({ id: z.number().optional(), name: z.string().optional() }).nullable().optional(),
+  // `id` accepts BOTH spellings deliberately. This schema is parsed in
+  // `mode: 'strict'` because it backs the destructive-draft guard, so a
+  // present-but-mistyped field THROWS — and OFW is already inconsistent about
+  // this exact field: the folders listing (`FoldersSchema` in sync.ts) types it
+  // `z.string()`, while message detail has been observed returning a number.
+  // Pinning one spelling here would turn a harmless representation change into
+  // a hard failure of ofw_save_draft / ofw_delete_draft, which is the opposite
+  // of what a strict boundary is for: it exists to stop us acting on a response
+  // we cannot interpret, not to reject one we can. `folderId` is normalized to
+  // a string below, so both spellings compare correctly downstream.
+  folder: z.looseObject({
+    id: z.union([z.string(), z.number()]).optional(),
+    name: z.string().optional(),
+  }).nullable().optional(),
   date: z.looseObject({ dateTime: z.string().optional() }).nullable().optional(),
 });
 

--- a/src/tools/lifecycle.ts
+++ b/src/tools/lifecycle.ts
@@ -1,5 +1,5 @@
 import type { OFWClient } from '../client.js';
-import type { CacheStore, DraftRow, MessageRow } from '../cache/store.js';
+import type { CacheStore, DraftRow, FolderName, MessageRow } from '../cache/store.js';
 import { resolveFolderIds } from '../sync.js';
 import { draftRevision, fetchMessageSnapshot } from './draft-freshness.js';
 import type { MessageSnapshot } from './draft-freshness.js';
@@ -34,13 +34,49 @@ export interface FolderIdMap {
   drafts: string | null;
 }
 
+/** OFW's `folderType` discriminator for each folder we track. */
+export const FOLDER_TYPE: Record<FolderName, string> = {
+  inbox: 'INBOX',
+  sent: 'SENT_MESSAGES',
+  drafts: 'DRAFTS',
+};
+
+/** Where each folder's id is persisted in the `meta` table. */
+const FOLDER_ID_META_KEY: Record<FolderName, string> = {
+  inbox: 'inbox_folder_id',
+  sent: 'sent_folder_id',
+  drafts: 'drafts_folder_id',
+};
+
+const FOLDERS: FolderName[] = ['inbox', 'sent', 'drafts'];
+
 /** Read whatever folder ids past syncs persisted. No requests. */
 export async function readFolderIdMap(store: CacheStore): Promise<FolderIdMap> {
   return {
-    inbox: await store.getMeta('inbox_folder_id'),
-    sent: await store.getMeta('sent_folder_id'),
-    drafts: await store.getMeta('drafts_folder_id'),
+    inbox: await store.getMeta(FOLDER_ID_META_KEY.inbox),
+    sent: await store.getMeta(FOLDER_ID_META_KEY.sent),
+    drafts: await store.getMeta(FOLDER_ID_META_KEY.drafts),
   };
+}
+
+/**
+ * Persist folder ids harvested from a folders listing the caller ALREADY
+ * fetched.
+ *
+ * `ofw_check_freshness` asked about folders and ids in one call hits
+ * `/pub/v1/messageFolders?includeFolderCounts=true` for the counts, and then
+ * `ensureFolderIdMap` hit the very same endpoint again to learn the ids. The
+ * response in hand already carries them; taking them makes the second call a
+ * no-op instead of a duplicate round trip.
+ */
+export async function persistFolderIds(
+  store: CacheStore,
+  systemFolders: Array<{ id: string; folderType: string }>,
+): Promise<void> {
+  for (const folder of FOLDERS) {
+    const entry = systemFolders.find((f) => f.folderType === FOLDER_TYPE[folder]);
+    if (entry !== undefined) await store.setMeta(FOLDER_ID_META_KEY[folder], entry.id);
+  }
 }
 
 /**

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -9,7 +9,7 @@ import {
   DraftFreshnessError, checkDraftFreshness, draftRevision, fetchServerDraft, staleDraftPayload,
 } from './draft-freshness.js';
 import type { DraftContent } from './draft-freshness.js';
-import { newDraftKey, probeIds, resolveDraftKey } from './lifecycle.js';
+import { FOLDER_TYPE, newDraftKey, persistFolderIds, probeIds, resolveDraftKey } from './lifecycle.js';
 import type { LifecycleItem } from './lifecycle.js';
 import type { CacheStore, MessageRow, DraftRow, FolderName } from '../cache/store.js';
 import { getFolderVerifiedAt } from '../sync.js';
@@ -62,7 +62,10 @@ const MessageDetailSchema = z.looseObject({
   // The detail payload carries its own owning folder ({id, name}). We read the
   // id to label a live-fetched message sent-vs-inbox instead of blindly
   // defaulting to inbox — see the folder derivation in ofw_get_message.
-  folder: z.looseObject({ id: z.number() }).optional(),
+  // Same union as ServerDraftSchema's, for the same reason — OFW types this id
+  // as a string on the folders listing and a number on message detail. Lenient
+  // here, so a mismatch only warns, but it would warn on EVERY live fetch.
+  folder: z.looseObject({ id: z.union([z.string(), z.number()]) }).optional(),
 });
 
 // Attachment-backfill detail fetch reads only `files`.
@@ -81,12 +84,6 @@ const FolderCountsSchema = z.looseObject({
     count: z.number().optional(),
   })).optional(),
 });
-
-const FOLDER_TYPE: Record<FolderName, string> = {
-  inbox: 'INBOX',
-  sent: 'SENT_MESSAGES',
-  drafts: 'DRAFTS',
-};
 
 /**
  * Cap on per-id probes in one ofw_check_freshness call.
@@ -1424,6 +1421,11 @@ export function registerMessageTools(
         { label: 'ofw-mcp', context: 'GET /pub/v1/messageFolders (ofw_check_freshness)' },
       );
       const sys = data.systemFolders ?? [];
+      // Take the folder ids while we have them. Without this a call asking
+      // about BOTH folders and ids, on a cache that has never synced, fetched
+      // this exact endpoint twice — once here for the counts and again inside
+      // probeIds' ensureFolderIdMap for the ids it already had in hand.
+      await persistFolderIds(cache, sys);
       for (const folder of wantFolders) {
         const entry = sys.find((x) => x.folderType === FOLDER_TYPE[folder]);
         const serverCount = entry?.totalCount ?? entry?.messageCount ?? entry?.count ?? null;

--- a/tests/tools/draft-freshness.test.ts
+++ b/tests/tools/draft-freshness.test.ts
@@ -3,6 +3,7 @@ import { OFWClient } from '../../src/client.js';
 import {
   draftRevision,
   fetchServerDraft,
+  fetchMessageSnapshot,
   checkDraftFreshness,
   staleDraftPayload,
   DraftFreshnessError,
@@ -71,6 +72,32 @@ describe('fetchServerDraft', () => {
       replyToId: 12,
       recipients: [{ userId: 42, name: 'Co Parent', viewedAt: null }],
     });
+  });
+
+  it('does not hard-fail on either spelling of folder.id (strict boundary)', async () => {
+    // This schema is parsed strict — a throw here ABORTS ofw_save_draft /
+    // ofw_delete_draft. OFW types this id as a string on the folders listing
+    // and a number on message detail, so both must parse, and both must
+    // normalize to the same string for comparison.
+    for (const id of ['3', 3]) {
+      const c = new OFWClient();
+      vi.spyOn(c, 'request').mockResolvedValue({
+        subject: 'Pickup', body: 'server body', replyToId: null, recipients: [],
+        folder: { id, name: 'Drafts' },
+      });
+      const snap = await fetchMessageSnapshot(c, 5);
+      expect(snap?.folderId).toBe('3');
+      expect(snap?.folderName).toBe('Drafts');
+    }
+  });
+
+  it('reports a null folderId when OFW omits the folder entirely', async () => {
+    const c = new OFWClient();
+    vi.spyOn(c, 'request').mockResolvedValue({ subject: 'S', body: 'B' });
+    const snap = await fetchMessageSnapshot(c, 5);
+    expect(snap?.folderId).toBeNull();
+    expect(snap?.folderName).toBeNull();
+    expect(snap?.dateTime).toBeNull();
   });
 
   it('treats an empty/null response body as missing rather than throwing', async () => {

--- a/tests/tools/lifecycle.test.ts
+++ b/tests/tools/lifecycle.test.ts
@@ -3,8 +3,8 @@ import { OFWClient } from '../../src/client.js';
 import { OFWCache } from '../../src/cache/node.js';
 import { sampleMessageRow } from '../_fixtures.js';
 import {
-  classifyState, ensureFolderIdMap, newDraftKey, probeIds, probeWouldStamp,
-  readFolderIdMap, resolveDraftKey,
+  classifyState, ensureFolderIdMap, newDraftKey, persistFolderIds, probeIds,
+  probeWouldStamp, readFolderIdMap, resolveDraftKey,
 } from '../../src/tools/lifecycle.js';
 import type { FolderIdMap } from '../../src/tools/lifecycle.js';
 import type { MessageSnapshot } from '../../src/tools/draft-freshness.js';
@@ -129,6 +129,29 @@ describe('readFolderIdMap / ensureFolderIdMap', () => {
   });
 });
 
+describe('persistFolderIds', () => {
+  it('harvests ids from an already-fetched listing, making ensureFolderIdMap free', async () => {
+    const client = new OFWClient();
+    const spy = vi.spyOn(client, 'request');
+
+    await persistFolderIds(cache, [
+      { id: '1', folderType: 'INBOX' },
+      { id: '2', folderType: 'SENT_MESSAGES' },
+      { id: '3', folderType: 'DRAFTS' },
+      { id: '9', folderType: 'SOMETHING_ELSE' },
+    ]);
+
+    expect(await readFolderIdMap(cache)).toEqual(MAP);
+    expect(await ensureFolderIdMap(client, cache)).toEqual({ map: MAP, requests: 0 });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('persists only the folders the listing actually reported', async () => {
+    await persistFolderIds(cache, [{ id: '3', folderType: 'DRAFTS' }]);
+    expect(await readFolderIdMap(cache)).toEqual({ inbox: null, sent: null, drafts: '3' });
+  });
+});
+
 describe('resolveDraftKey', () => {
   it('resolves to the chain tip and lists every id', async () => {
     await cache.recordDraftLineage({ id: 10, draftKey: 'dk_a', previousId: null, recordedAt: '2026-07-01T00:00:00Z' });
@@ -190,6 +213,24 @@ describe('probeIds', () => {
     });
     expect(items[0].cacheRevision).toBe(items[0].serverRevision);
     expect(items[0].note).toMatch(/was SENT/);
+  });
+
+  it('accepts a STRING folder id — the strict schema must not hard-fail on it', async () => {
+    // OFW types this id as a string on the folders listing and a number on
+    // message detail. ServerDraftSchema is parsed strict because it backs the
+    // destructive-draft guard, so pinning one spelling would turn a harmless
+    // representation change into a failed ofw_save_draft / ofw_delete_draft.
+    seedFolderIds();
+    await cache.upsertDraft(draftRow);
+    const client = new OFWClient();
+    vi.spyOn(client, 'request').mockResolvedValue({
+      subject: 'S', body: 'B', replyToId: null, recipients: [],
+      folder: { id: '2', name: 'Sent Messages' },
+      date: { dateTime: '2026-07-27T23:31:09' },
+    });
+
+    const { items } = await probeIds(client, cache, [500], { allowMarkRead: false });
+    expect(items[0]).toMatchObject({ id: 500, state: 'sent', sentAt: '2026-07-27T23:31:09' });
   });
 
   it('reports an id that OFW moved to the inbox as "received"', async () => {

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -4193,6 +4193,44 @@ describe('lifecycle state in ofw_check_freshness (Gap 1)', () => {
     expect(parsed.items[0]).toMatchObject({ id: 501, state: 'deleted', existsOnServer: false });
   });
 
+  it('fetches the folders endpoint ONCE when asked about folders and ids together', async () => {
+    // No sync has ever run, so the folder-id map is empty. The folder-count
+    // branch already fetches /pub/v1/messageFolders; harvesting the ids from
+    // that same response keeps probeIds' ensureFolderIdMap from re-fetching it.
+    upsertDraft({
+      id: 503, subject: 'D', body: 'b', recipients: [], replyToId: null,
+      modifiedAt: '2026-07-19T12:42:00Z', listData: {},
+    });
+    const client = new OFWClient();
+    const spy = vi.spyOn(client, 'request').mockImplementation(async (_m: string, path: string) => {
+      if (path.startsWith('/pub/v1/messageFolders')) {
+        return {
+          systemFolders: [
+            { id: '1', folderType: 'INBOX', totalCount: 10 },
+            { id: '2', folderType: 'SENT_MESSAGES', totalCount: 5 },
+            { id: '3', folderType: 'DRAFTS', totalCount: 1 },
+          ],
+        };
+      }
+      return { subject: 'D', body: 'b', replyToId: null, recipients: [], folder: { id: 3, name: 'Drafts' } };
+    });
+    setup(client);
+
+    const parsed = JSON.parse((await handlers.get('ofw_check_freshness')!({
+      folders: ['drafts'], messageIds: [503],
+    })).content[0].text);
+
+    const folderCalls = spy.mock.calls.filter(([, path]) => String(path).startsWith('/pub/v1/messageFolders'));
+    expect(folderCalls).toHaveLength(1);
+    // One folder fetch + one id probe — the map came free with the counts.
+    expect(parsed.requestsUsed).toBe(2);
+    expect(parsed.items[0].state).toBe('draft');
+    // And the ids are now persisted for every later call.
+    expect(cache.core.getMeta('drafts_folder_id')).toBe('3');
+    expect(cache.core.getMeta('sent_folder_id')).toBe('2');
+    expect(cache.core.getMeta('inbox_folder_id')).toBe('1');
+  });
+
   it('resolves the folder map live (one extra request) when no sync has ever run', async () => {
     upsertDraft({
       id: 502, subject: 'D', body: 'b', recipients: [], replyToId: null,


### PR DESCRIPTION
Both nits from the auto-review of #196 (verdict `warn`, tracked in #197).

Closes #197

## 1. `folder.id` on a strict schema could hard-fail the destructive-draft guard

`ServerDraftSchema` (`src/tools/draft-freshness.ts`) is parsed with `mode: 'strict'` precisely because it backs the destructive-draft guard — a present-but-mistyped field **throws**, aborting `ofw_save_draft` / `ofw_delete_draft`. #196 added `folder.id` to it as `z.number()`.

OFW is already inconsistent about that exact field: `FoldersSchema` in `sync.ts` types the folders listing's id as `z.string()`, while message detail has been observed returning a number (hence the existing `String(detail.folder.id) === sentFolderId` comparison). Pinning one spelling turned a harmless representation change into a hard failure on a write path.

A strict boundary exists to stop us acting on a response we **cannot interpret** — not to reject one we can. It now accepts `z.union([z.string(), z.number()])` and normalizes to a string in `folderId`, which is what every downstream comparison already used.

`MessageDetailSchema` in `messages.ts` gets the same union. It is parsed lenient, so a string would only warn rather than throw — but it would have warned on *every* live `ofw_get_message` fetch, which is its own kind of noise.

## 2. `ofw_check_freshness` fetched the folders endpoint twice

A call asking about **both** `folders` and `messageIds`, on a cache that had never synced, hit `/pub/v1/messageFolders?includeFolderCounts=true` twice: once in the folder-count branch, and again inside `probeIds` → `ensureFolderIdMap` for ids the first response already carried.

New `persistFolderIds` harvests them from the already-parsed listing, so `ensureFolderIdMap` becomes a no-op. Matters most on the hosted Worker, where every OFW fetch counts against the subrequest cap. Also de-duplicates the `folderType` map, which had been copied into `messages.ts` — it now lives in `lifecycle.ts` alongside the meta keys it pairs with.

## Tests

- Both spellings of `folder.id` parse through the strict boundary and normalize to the same string; an omitted `folder` still yields `folderId: null` rather than throwing.
- `persistFolderIds` makes a following `ensureFolderIdMap` cost zero requests, and persists only the folders the listing actually reported.
- `ofw_check_freshness({folders, messageIds})` on an unsynced cache makes exactly **one** `messageFolders` call (`requestsUsed: 2` — one folder fetch, one id probe) and leaves all three ids persisted.

769 node tests + 15 Workers tests, 100% coverage held, `tsc` and bundle build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bi5SkpKqtYzMXFAkmsokr
