### PR TITLE
fix: emit every timestamp with an explicit offset and a display value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,23 @@ OFW_ALLOW_MARK_READ       Optional. Default true (= the long-standing behaviour)
 OFW_FETCH_UNREAD_BODIES   Optional. "1|true|yes|on" → ofw_sync_messages fetches unread inbox bodies by default (default false). Capped by OFW_ALLOW_MARK_READ
 OFW_AUTO_REFRESH          Optional. "1|true|yes|on" → when a cached read comes back EMPTY from a non-fresh cache, the read tools sync the backing folders and answer from the refreshed cache instead of refusing with UNVERIFIED_EMPTY (default false, i.e. refuse). Per-call `autoRefresh` overrides it. A refresh that does not make the read verifiable still refuses
 OFW_CALENDAR_WRITES       Optional. "1|true|yes|on" → in mode "drafts", additionally register the calendar write tools (ofw_create_event, ofw_update_event, ofw_delete_event). Rationale: calendar events have no draft stage but are reversible (editable/deletable), unlike a sent message. Redundant in "all"; never overrides "none" (including the unrecognized-mode fail-closed path)
+DISPLAY_TZ                Optional. IANA zone (e.g. America/New_York, the default) for every `<field>Display` value, and the zone a NAIVE source timestamp is assumed to be wall-clock in. OFW's API reports naive local times in the account's own zone, so this must match it. Unrecognized values fall back to the default rather than throwing — a typo degrades a label instead of breaking every tool. Never a fixed offset: DST comes from the IANA database, so a hardcoded -04:00 would be an hour wrong from November through March
 ```
+
+## Timestamps
+
+Every structured response goes through `jsonResponse` (`src/tools/_shared.ts`), which routes the payload through `normalizeTimestampsInValue` (`src/timestamps.ts`). That is the single seam — normalizing there rather than at each call site is what makes it impossible for a tool to reintroduce a naive value.
+
+Each allowlisted timestamp becomes ISO-8601 **with an explicit offset**, paired with a `<field>Display` sibling carrying the weekday:
+
+```json
+"sentAt": "2026-07-27T23:31:09-04:00",
+"sentAtDisplay": "Mon, Jul 27, 2026, 11:31 PM EDT"
+```
+
+Why: `sentAt`/`viewedAt`/`modifiedAt` arrived from OFW as naive local while `fetchedBodyAt`/`freshness.asOf` were stamped UTC with a `Z`, so one object mixed two zones with nothing to tell them apart. A reader assumed one zone for both and was wrong by the offset on half the fields — enough to move a 10:38 PM send onto the next calendar day, which changes which custody day it belongs to.
+
+A field is rewritten only when the key is allowlisted **and** the value matches a timestamp shape, so user content (a message body quoting a date) is never touched. The payload is cloned first: responses carry live cache rows, and rewriting them in place would corrupt the cache.
 
 `auth.ts` ignores blank values, the strings `"undefined"`/`"null"`, and unsubstituted `${VAR}` placeholders — defensive against MCP hosts passing the env block through unexpanded.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,12 @@ Why: `sentAt`/`viewedAt`/`modifiedAt` arrived from OFW as naive local while `fet
 
 A field is rewritten only when the key is allowlisted **and** the value matches a timestamp shape, so user content (a message body quoting a date) is never touched. The payload is cloned first: responses carry live cache rows, and rewriting them in place would corrupt the cache.
 
+The allowlist covers the freshness/sync bookkeeping fields (`lastServerSyncAt`, `checkedAt`, `lastVerifiedAt`, `oldestVerifiedAt`, `lastSyncAt`) as well as the message fields — they share an object with `asOf`, so omitting them put two zones back in one payload. Derive additions from a sweep of emitted field names, not from whichever field a bug report happens to name. `startDate`/`endDate` (YYYY-MM-DD) and `startTime`/`endTime` (HH:mm) are deliberately excluded: a date and a wall time are not instants.
+
+`jsonErrorResponse` routes through `jsonResponse`, so a refusal payload carries the same normalized freshness block as the success path.
+
+**`DISPLAY_TZ` is deployment-wide, not per-tenant.** OFW reports naive times in the *account's* zone, so a tenant outside `DISPLAY_TZ` gets the wrong offset on those values. See [`docs/DEPLOY-CONNECTOR.md`](docs/DEPLOY-CONNECTOR.md) for the fix if this ever serves multiple zones.
+
 `auth.ts` ignores blank values, the strings `"undefined"`/`"null"`, and unsubstituted `${VAR}` placeholders — defensive against MCP hosts passing the env block through unexpanded.
 
 `.env` (project root) is loaded by `client.ts` via dynamic `dotenv` import (silently skipped if unavailable, e.g. inside the mcpb bundle). Real env vars take precedence (`override: false`).

--- a/docs/DEPLOY-CONNECTOR.md
+++ b/docs/DEPLOY-CONNECTOR.md
@@ -249,3 +249,35 @@ had added the connector will need to log in again if it's redeployed. It also
 drops the encrypted per-user OFW credentials from `OAUTH_KV` (the `OFWCacheDO`
 message caches are separate Durable Object storage and are removed when the
 Worker itself is deleted).
+
+## Timezone (`DISPLAY_TZ`)
+
+Every timestamp in a tool response is ISO-8601 with an explicit offset, paired
+with a `<field>Display` value rendered in `DISPLAY_TZ` (set in
+`wrangler.jsonc` `vars`, defaulting to `America/New_York`).
+
+`DISPLAY_TZ` does two jobs:
+
+1. It is the zone `*Display` strings render in.
+2. It is the zone a **naive** OFW timestamp is interpreted as. OFW's API returns
+   `sentAt`/`viewedAt`/`modifiedAt` as local wall-clock with no offset, so the
+   correct instant can only be recovered by knowing which zone that wall clock
+   belongs to.
+
+Job 2 is the constraint that matters: **it is deployment-wide, not per-tenant.**
+OFW reports those naive times in the *account's* zone. A tenant whose account
+sits outside `DISPLAY_TZ` will have their naive timestamps labelled with the
+wrong offset — the displayed wall-clock time stays right, but the instant it
+claims to be is off by the difference between the two zones, which can move an
+evening message onto the wrong calendar day.
+
+This is acceptable while the connector serves accounts in a single zone. If it
+ever serves accounts across zones, thread a per-tenant zone through `OFWProps`
+alongside the credentials and pass it to `normalizeTimestampsInValue` instead of
+reading the global. The helper already takes the zone as a parameter, so the
+change is at the call seam in `src/tools/_shared.ts`, not in the timestamp
+logic.
+
+Always an IANA name, never a fixed offset: DST is resolved from the IANA
+database per instant, so `-04:00` hardcoded would be an hour wrong from
+November through March.

--- a/src/timestamps.ts
+++ b/src/timestamps.ts
@@ -1,0 +1,244 @@
+// Canonical timestamp handling for every structured OFW response.
+//
+// A single response object used to mix zones: `sentAt`/`viewedAt`/`modifiedAt`
+// came from OFW's API as NAIVE local wall-clock ("2026-07-27T23:31:09", no
+// offset), while `fetchedBodyAt` and `freshness.asOf` were stamped by us as UTC
+// with a `Z`. Nothing in the payload said which was which, so a reader assumed
+// one zone for both and was wrong by the UTC offset on half the fields.
+//
+// The failure that matters is the calendar DAY. A message sent 10:38 PM Eastern
+// reported as 02:38 lands on the following day, and in a co-parenting record
+// that decides which custody day an event belongs to and whether it beat a
+// 48-hour response window.
+//
+// Every value that survives detection is rewritten to ISO-8601 WITH an
+// explicit offset and paired with a `<key>Display` sibling rendered in the
+// operator's zone, weekday included, because a wrong weekday is what makes a
+// date-boundary error visible at a glance.
+//
+// NOTE: this mirrors the helper in gogcli-mcp. Both connectors had the same
+// defect, and the two copies should collapse into @chrischall/mcp-utils once
+// that package next ships.
+
+import { readEnvVar } from '@chrischall/mcp-utils';
+
+// Fallback display zone for this deployment. IANA name, never a fixed offset —
+// a hardcoded -04:00 would be an hour wrong from November through March.
+export const DEFAULT_DISPLAY_TZ = 'America/New_York';
+
+function isValidTimeZone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// The zone all *Display fields render in, and the zone a NAIVE source value is
+// assumed to be wall-clock in. OFW's API reports naive local times in the
+// account's own zone, so this must match it. An invalid DISPLAY_TZ falls back
+// rather than throwing, so a typo degrades the label instead of breaking
+// every tool.
+export function displayTimeZone(): string {
+  const configured = readEnvVar('DISPLAY_TZ');
+  if (configured && isValidTimeZone(configured)) return configured;
+  return DEFAULT_DISPLAY_TZ;
+}
+
+// Offset of `tz` at a given instant, as "+HH:MM"/"-HH:MM". Uses the IANA
+// database via Intl, so DST is handled per-instant rather than per-zone.
+function offsetAt(instant: Date, tz: string): string {
+  // Derived arithmetically rather than parsed out of Intl's "GMT-04:00" label:
+  // the gap between the zone's wall clock and the instant IS the offset, and
+  // zone offsets are always whole minutes.
+  const w = wallPartsIn(instant, tz);
+  const asUTC = Date.UTC(w.year, w.month - 1, w.day, w.hour, w.minute, w.second, instant.getUTCMilliseconds());
+  const minutes = Math.round((asUTC - instant.getTime()) / 60_000);
+  const sign = minutes < 0 ? '-' : '+';
+  const abs = Math.abs(minutes);
+  return `${sign}${pad(Math.floor(abs / 60))}:${pad(abs % 60)}`;
+}
+
+// Wall-clock fields of `instant` as seen in `tz`, via Intl so the IANA rules
+// (including DST) apply.
+function wallPartsIn(instant: Date, tz: string): Record<string, number> {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    // h23 pins midnight to hour 00; without it some ICU builds render hour 24.
+    hourCycle: 'h23',
+  }).formatToParts(instant);
+  const out: Record<string, number> = {};
+  for (const p of parts) {
+    if (p.type !== 'literal') out[p.type] = Number(p.value);
+  }
+  return out;
+}
+
+// Interpret naive wall-clock fields as an instant in `tz`. There is no direct
+// inverse of the zone rules, so guess UTC, measure how far the guess lands from
+// the requested wall time in that zone, and correct. Two passes settle the case
+// where the correction itself crosses a DST boundary.
+function wallTimeToInstant(
+  y: number, mo: number, d: number, h: number, mi: number, s: number, ms: number, tz: string,
+): Date {
+  let guess = Date.UTC(y, mo - 1, d, h, mi, s, ms);
+  for (let i = 0; i < 2; i += 1) {
+    const seen = wallPartsIn(new Date(guess), tz);
+    const seenUTC = Date.UTC(seen.year, seen.month - 1, seen.day, seen.hour, seen.minute, seen.second, ms);
+    const drift = Date.UTC(y, mo - 1, d, h, mi, s, ms) - seenUTC;
+    if (drift === 0) break;
+    guess += drift;
+  }
+  return new Date(guess);
+}
+
+export interface CanonicalTimestamp {
+  /** ISO-8601 with an explicit offset, e.g. 2026-07-27T23:31:09-04:00. */
+  iso: string;
+  /** Human rendering in the display zone, weekday first. */
+  display: string;
+}
+
+function pad(n: number, width = 2): string {
+  return String(n).padStart(width, '0');
+}
+
+// Render `instant` as ISO-8601 carrying `offset`'s wall time and label.
+function isoWithOffset(instant: Date, tz: string, offset: string): string {
+  const w = wallPartsIn(instant, tz);
+  const msPart = instant.getUTCMilliseconds();
+  const frac = msPart ? `.${pad(msPart, 3)}` : '';
+  return `${pad(w.year, 4)}-${pad(w.month)}-${pad(w.day)}T${pad(w.hour)}:${pad(w.minute)}:${pad(w.second)}${frac}${offset}`;
+}
+
+// The one place an instant becomes user-visible text. Every emitted timestamp
+// goes through here, so no call site can reintroduce a naive value.
+export function formatInstant(instant: Date, tz = displayTimeZone()): CanonicalTimestamp {
+  const offset = offsetAt(instant, tz);
+  const display = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  }).format(instant);
+  return { iso: isoWithOffset(instant, tz, offset), display };
+}
+
+// Keys whose STRING values are timestamps. Deliberately an allowlist rather
+// than a name pattern: a value must ALSO match a timestamp shape below, so both
+// the key and the value have to agree before anything is touched. That keeps
+// user-authored content (a message body quoting a date, an expense description)
+// from ever being rewritten.
+const TIMESTAMP_KEYS = new Set([
+  // OFW: naive local wall-clock from the API.
+  'sentAt',
+  'viewedAt',
+  'modifiedAt',
+  'createdAt',
+  'dueAt',
+  'occurredAt',
+  // OFW: UTC instants we stamp ourselves.
+  'fetchedBodyAt',
+  'fetchedAt',
+  'syncedAt',
+  'asOf',
+  // OFW API inner shape: `date: { dateTime }`, `viewed: { dateTime }`.
+  'dateTime',
+  // Generic.
+  'date',
+  'updated',
+  'lastModified',
+  'expirationTime',
+]);
+
+// Keys that hold a zone NAME rather than an instant. They cannot match a
+// timestamp shape anyway, but naming them documents the hazard.
+const ZONE_NAME_KEYS = new Set(['timeZone', 'timezone']);
+
+const RFC3339_WITH_OFFSET = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?(?:\.(\d{1,9}))?(Z|[+-]\d{2}:?\d{2})$/;
+const NAIVE_DATE_TIME = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?(?:\.(\d{1,9}))?$/;
+// A bare YYYY-MM-DD is a DATE, not an instant — Calendar uses it for all-day
+// events. Converting one would invent a time that the source never asserted.
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+// Resolve a raw field value to an instant, or null when it is not a timestamp.
+// `assumeNaiveIn` is the zone a naive (offset-less) value is wall-clock in.
+export function parseTimestampValue(
+  key: string,
+  value: unknown,
+  assumeNaiveIn: string,
+): Date | null {
+  if (typeof value !== 'string') return null;
+  const raw = value.trim();
+  if (raw === '' || DATE_ONLY.test(raw)) return null;
+
+  if (RFC3339_WITH_OFFSET.test(raw)) {
+    // The source already knows its offset; trust it verbatim.
+    const parsed = new Date(raw.replace(' ', 'T'));
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  const naive = NAIVE_DATE_TIME.exec(raw);
+  if (naive) {
+    const [, y, mo, d, h, mi, s, frac] = naive;
+    const ms = frac ? Number(frac.padEnd(3, '0').slice(0, 3)) : 0;
+    return wallTimeToInstant(
+      Number(y), Number(mo), Number(d), Number(h), Number(mi), Number(s ?? '0'), ms, assumeNaiveIn,
+    );
+  }
+  return null;
+}
+
+// True when a string carries no zone information — the shape this whole module
+// exists to eliminate. Used by the contract test.
+export function isNaiveTimestamp(value: unknown): boolean {
+  return typeof value === 'string' && NAIVE_DATE_TIME.test(value.trim());
+}
+
+// Walk a parsed payload, rewriting every allowlisted timestamp to canonical
+// form and attaching its display sibling. Mutates and returns `node`.
+function walk(node: unknown, tz: string): unknown {
+  if (Array.isArray(node)) {
+    for (const item of node) walk(item, tz);
+    return node;
+  }
+  if (node === null || typeof node !== 'object') return node;
+
+  const obj = node as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+    if (value !== null && typeof value === 'object') {
+      walk(value, tz);
+      continue;
+    }
+    if (ZONE_NAME_KEYS.has(key) || !TIMESTAMP_KEYS.has(key)) continue;
+    const instant = parseTimestampValue(key, value, tz);
+    if (!instant) continue;
+    const { iso, display } = formatInstant(instant, tz);
+    obj[key] = iso;
+    obj[`${key}Display`] = display;
+  }
+  return obj;
+}
+
+// Normalize every timestamp in a structured response payload.
+//
+// The input is CLONED before walking: response payloads routinely include live
+// cache rows, and rewriting those in place would corrupt the cache and make the
+// normalization observable on a later read. Primitives pass through untouched
+// so the seam is safe for any tool result.
+export function normalizeTimestampsInValue<T>(value: T, tz = displayTimeZone()): T {
+  if (value === null || typeof value !== 'object') return value;
+  return walk(structuredClone(value), tz) as T;
+}

--- a/src/timestamps.ts
+++ b/src/timestamps.ts
@@ -62,8 +62,31 @@ function offsetAt(instant: Date, tz: string): string {
 
 // Wall-clock fields of `instant` as seen in `tz`, via Intl so the IANA rules
 // (including DST) apply.
+// Intl.DateTimeFormat construction dominates the cost here, and a 50-message
+// listing formats hundreds of timestamps. Cache one formatter per zone.
+const wallPartsFormatters = new Map<string, Intl.DateTimeFormat>();
+const displayFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function wallPartsFormatter(tz: string): Intl.DateTimeFormat {
+  let fmt = wallPartsFormatters.get(tz);
+  if (!fmt) {
+    fmt = buildWallPartsFormatter(tz);
+    wallPartsFormatters.set(tz, fmt);
+  }
+  return fmt;
+}
+
 function wallPartsIn(instant: Date, tz: string): Record<string, number> {
-  const parts = new Intl.DateTimeFormat('en-US', {
+  const parts = wallPartsFormatter(tz).formatToParts(instant);
+  const out: Record<string, number> = {};
+  for (const p of parts) {
+    if (p.type !== 'literal') out[p.type] = Number(p.value);
+  }
+  return out;
+}
+
+function buildWallPartsFormatter(tz: string): Intl.DateTimeFormat {
+  return new Intl.DateTimeFormat('en-US', {
     timeZone: tz,
     year: 'numeric',
     month: '2-digit',
@@ -73,12 +96,7 @@ function wallPartsIn(instant: Date, tz: string): Record<string, number> {
     second: '2-digit',
     // h23 pins midnight to hour 00; without it some ICU builds render hour 24.
     hourCycle: 'h23',
-  }).formatToParts(instant);
-  const out: Record<string, number> = {};
-  for (const p of parts) {
-    if (p.type !== 'literal') out[p.type] = Number(p.value);
-  }
-  return out;
+  });
 }
 
 // Interpret naive wall-clock fields as an instant in `tz`. There is no direct
@@ -122,17 +140,21 @@ function isoWithOffset(instant: Date, tz: string, offset: string): string {
 // goes through here, so no call site can reintroduce a naive value.
 export function formatInstant(instant: Date, tz = displayTimeZone()): CanonicalTimestamp {
   const offset = offsetAt(instant, tz);
-  const display = new Intl.DateTimeFormat('en-US', {
-    timeZone: tz,
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    timeZoneName: 'short',
-  }).format(instant);
-  return { iso: isoWithOffset(instant, tz, offset), display };
+  let fmt = displayFormatters.get(tz);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZoneName: 'short',
+    });
+    displayFormatters.set(tz, fmt);
+  }
+  return { iso: isoWithOffset(instant, tz, offset), display: fmt.format(instant) };
 }
 
 // Keys whose STRING values are timestamps. Deliberately an allowlist rather
@@ -152,7 +174,20 @@ const TIMESTAMP_KEYS = new Set([
   'fetchedBodyAt',
   'fetchedAt',
   'syncedAt',
+  'downloadedAt',
+  'recordedAt',
+  'expiresAt',
+  // Freshness/sync bookkeeping. These sit in the SAME object as `asOf`, so
+  // omitting them left the freshness block emitting two zones at once — the
+  // exact defect this module exists to remove. Enumerated from a sweep of
+  // emitted field names rather than from the ones a bug report happened to
+  // mention.
   'asOf',
+  'checkedAt',
+  'lastVerifiedAt',
+  'oldestVerifiedAt',
+  'lastServerSyncAt',
+  'lastSyncAt',
   // OFW API inner shape: `date: { dateTime }`, `viewed: { dateTime }`.
   'dateTime',
   // Generic.
@@ -161,6 +196,11 @@ const TIMESTAMP_KEYS = new Set([
   'lastModified',
   'expirationTime',
 ]);
+
+// Deliberately NOT timestamps: `startDate`/`endDate` are YYYY-MM-DD and
+// `startTime`/`endTime` are HH:mm — a calendar date and a wall time, neither of
+// which denotes an instant. Attaching an offset would invent information. The
+// shape guards below would reject them anyway; this records the intent.
 
 // Keys that hold a zone NAME rather than an instant. They cannot match a
 // timestamp shape anyway, but naming them documents the hazard.
@@ -171,6 +211,20 @@ const NAIVE_DATE_TIME = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))
 // A bare YYYY-MM-DD is a DATE, not an instant — Calendar uses it for all-day
 // events. Converting one would invent a time that the source never asserted.
 const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+// True when the components describe a real calendar instant. Guards against
+// Date.UTC's silent rollover of out-of-range values.
+function isRealCalendarDate(p: {
+  year: number; month: number; day: number; hour: number; minute: number; second: number;
+}): boolean {
+  const utc = new Date(Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second));
+  return utc.getUTCFullYear() === p.year
+    && utc.getUTCMonth() === p.month - 1
+    && utc.getUTCDate() === p.day
+    && utc.getUTCHours() === p.hour
+    && utc.getUTCMinutes() === p.minute
+    && utc.getUTCSeconds() === p.second;
+}
 
 // Resolve a raw field value to an instant, or null when it is not a timestamp.
 // `assumeNaiveIn` is the zone a naive (offset-less) value is wall-clock in.
@@ -193,8 +247,22 @@ export function parseTimestampValue(
   if (naive) {
     const [, y, mo, d, h, mi, s, frac] = naive;
     const ms = frac ? Number(frac.padEnd(3, '0').slice(0, 3)) : 0;
+    const parts = {
+      year: Number(y), month: Number(mo), day: Number(d),
+      hour: Number(h), minute: Number(mi), second: Number(s ?? '0'),
+    };
+    // Date.UTC silently rolls impossible components over — month 99 becomes
+    // 2034, Feb 30 becomes Mar 2 — so a typo would surface as a confident wrong
+    // date rather than a rejection. The offset branch above already returns
+    // null for the same input; match it.
+    //
+    // Checked in UTC space, deliberately: validating against the ZONE's wall
+    // clock would also reject a non-existent spring-forward time like
+    // 2026-03-08 02:30 ET, and shifting such a value forward (as zone libraries
+    // do) is better than dropping a timestamp we can place to within an hour.
+    if (!isRealCalendarDate(parts)) return null;
     return wallTimeToInstant(
-      Number(y), Number(mo), Number(d), Number(h), Number(mi), Number(s ?? '0'), ms, assumeNaiveIn,
+      parts.year, parts.month, parts.day, parts.hour, parts.minute, parts.second, ms, assumeNaiveIn,
     );
   }
   return null;

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -26,7 +26,11 @@ export const textResponse = rawTextResult;
 // we declined to overwrite) without being mistaken for a successful write.
 // mcp-utils' `errorResult` only carries a string.
 export function jsonErrorResponse(data: unknown): ReturnType<typeof textResult> {
-  return { ...textResult(data), isError: true };
+  // Routed through jsonResponse, not textResult: a refusal payload carries the
+  // same freshness block as the success path, and emitting it unnormalized made
+  // an UNVERIFIED_EMPTY response report `asOf` in UTC while every successful
+  // response reported it with an offset.
+  return { ...jsonResponse(data), isError: true };
 }
 
 // OFW API shape for `recipients[]` on message/draft list and detail

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -3,10 +3,20 @@ import { z } from 'zod';
 import type { MessageRow, Recipient } from '../cache/store.js';
 import type { OFWClient } from '../client.js';
 import { parseLenient } from '@chrischall/mcp-utils';
+import { normalizeTimestampsInValue } from '../timestamps.js';
 
 // Pretty-printed JSON tool result. Thin wrapper over @chrischall/mcp-utils'
-// `textResult` so the rest of the codebase keeps the local name.
-export const jsonResponse = textResult;
+// `textResult`, with one addition: every timestamp in the payload is rewritten
+// to ISO-8601 with an explicit offset and paired with a `<field>Display`
+// sibling in the operator's zone.
+//
+// This is the single seam every structured tool response passes through, which
+// is the point — normalizing here rather than at each call site is what makes
+// it impossible for a tool to reintroduce the naive-local values that had
+// `sentAt` and `fetchedBodyAt` silently disagreeing by the UTC offset.
+export function jsonResponse(data: unknown): ReturnType<typeof textResult> {
+  return textResult(normalizeTimestampsInValue(data));
+}
 
 // Raw-string tool result. Wrapper over @chrischall/mcp-utils' `rawTextResult`.
 export const textResponse = rawTextResult;

--- a/tests/timestamps.test.ts
+++ b/tests/timestamps.test.ts
@@ -84,6 +84,23 @@ describe('parseTimestampValue', () => {
   it('rejects a well-shaped but impossible date', () => {
     expect(parseTimestampValue('sentAt', '2026-99-01T00:00:00Z', ET)).toBeNull();
   });
+
+  // Date.UTC rolls impossible components over instead of rejecting them, so
+  // '2026-99-01T00:00:00' would silently become 2034 and '2026-02-30T10:00:00'
+  // would become Mar 2 — a typo surfacing as a confident wrong date.
+  it('rejects impossible naive dates rather than rolling them over', () => {
+    for (const bad of ['2026-99-01T00:00:00', '2026-13-05T10:00:00', '2026-02-30T10:00:00', '2026-01-01T25:00:00']) {
+      expect(parseTimestampValue('sentAt', bad, ET)).toBeNull();
+    }
+  });
+
+  // A non-existent spring-forward wall time is shifted forward, not dropped:
+  // we can still place it to within an hour, which is what the date needs.
+  it('keeps a non-existent spring-forward wall time on its own date', () => {
+    const instant = parseTimestampValue('sentAt', '2026-03-08T02:30:00', ET);
+    expect(instant).not.toBeNull();
+    expect(formatInstant(instant as Date, ET).iso.startsWith('2026-03-08')).toBe(true);
+  });
 });
 
 describe('normalizeTimestampsInValue', () => {

--- a/tests/timestamps.test.ts
+++ b/tests/timestamps.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_DISPLAY_TZ,
+  displayTimeZone,
+  formatInstant,
+  isNaiveTimestamp,
+  normalizeTimestampsInValue,
+  parseTimestampValue,
+} from '../src/timestamps.js';
+
+const ET = 'America/New_York';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('displayTimeZone', () => {
+  it('defaults to this deployment’s zone', () => {
+    expect(displayTimeZone()).toBe(DEFAULT_DISPLAY_TZ);
+  });
+
+  it('honours DISPLAY_TZ', () => {
+    vi.stubEnv('DISPLAY_TZ', 'America/Los_Angeles');
+    expect(displayTimeZone()).toBe('America/Los_Angeles');
+  });
+
+  it('falls back when DISPLAY_TZ is not a real IANA zone', () => {
+    vi.stubEnv('DISPLAY_TZ', 'Mars/Olympus_Mons');
+    expect(displayTimeZone()).toBe(DEFAULT_DISPLAY_TZ);
+  });
+});
+
+describe('formatInstant', () => {
+  // DST comes from the IANA database, not a fixed offset.
+  it('renders -05:00 in January and -04:00 in July', () => {
+    expect(formatInstant(new Date('2026-01-15T17:00:00Z'), ET).iso).toBe('2026-01-15T12:00:00-05:00');
+    expect(formatInstant(new Date('2026-07-15T17:00:00Z'), ET).iso).toBe('2026-07-15T13:00:00-04:00');
+  });
+
+  it('renders a positive offset east of UTC, +00:00 at UTC, and half-hour zones', () => {
+    expect(formatInstant(new Date('2026-07-15T17:00:00Z'), 'Asia/Tokyo').iso).toBe('2026-07-16T02:00:00+09:00');
+    expect(formatInstant(new Date('2026-07-15T17:00:00Z'), 'UTC').iso).toBe('2026-07-15T17:00:00+00:00');
+    expect(formatInstant(new Date('2026-07-15T00:00:00Z'), 'Asia/Kolkata').iso).toBe('2026-07-15T05:30:00+05:30');
+  });
+
+  it('pins midnight to hour 00 rather than 24', () => {
+    expect(formatInstant(new Date('2026-07-15T04:00:00Z'), ET).iso).toBe('2026-07-15T00:00:00-04:00');
+  });
+
+  it('includes the weekday, which is what makes a date-boundary error visible', () => {
+    const { display } = formatInstant(new Date('2026-07-28T03:36:00Z'), ET);
+    expect(display).toContain('Mon');
+    expect(display).toContain('Jul 27');
+  });
+});
+
+describe('parseTimestampValue', () => {
+  it('interprets OFW’s naive local value in the configured zone', () => {
+    expect(parseTimestampValue('sentAt', '2026-07-27T23:31:09', ET)?.toISOString())
+      .toBe('2026-07-28T03:31:09.000Z');
+  });
+
+  it('trusts an offset the source already carries', () => {
+    expect(parseTimestampValue('fetchedBodyAt', '2026-07-28T12:11:19.106Z', ET)?.toISOString())
+      .toBe('2026-07-28T12:11:19.106Z');
+  });
+
+  it('leaves a date-only value alone', () => {
+    expect(parseTimestampValue('date', '2026-07-28', ET)).toBeNull();
+  });
+
+  it('preserves sub-second precision on a naive value', () => {
+    expect(parseTimestampValue('fetchedBodyAt', '2026-07-28T12:11:19.106', ET)?.toISOString())
+      .toBe('2026-07-28T16:11:19.106Z');
+  });
+
+  it('ignores non-timestamp and non-string values', () => {
+    expect(parseTimestampValue('sentAt', 'sometime last week', ET)).toBeNull();
+    expect(parseTimestampValue('sentAt', 12345, ET)).toBeNull();
+    expect(parseTimestampValue('sentAt', null, ET)).toBeNull();
+    expect(parseTimestampValue('sentAt', '', ET)).toBeNull();
+  });
+
+  it('rejects a well-shaped but impossible date', () => {
+    expect(parseTimestampValue('sentAt', '2026-99-01T00:00:00Z', ET)).toBeNull();
+  });
+});
+
+describe('normalizeTimestampsInValue', () => {
+  // The reported defect: one object mixing naive-local and UTC values.
+  it('normalizes the naive/UTC mix into a single zone', () => {
+    const out = normalizeTimestampsInValue({
+      sentAt: '2026-07-27T23:31:09',
+      viewedAt: '2026-07-28T09:37:11',
+      modifiedAt: '2026-07-27T23:31:09',
+      fetchedBodyAt: '2026-07-28T12:11:19.106Z',
+      freshness: { asOf: '2026-07-28T20:27:11.426Z' },
+    }, ET);
+    expect(out.sentAt).toBe('2026-07-27T23:31:09-04:00');
+    expect(out.viewedAt).toBe('2026-07-28T09:37:11-04:00');
+    expect(out.modifiedAt).toBe('2026-07-27T23:31:09-04:00');
+    expect(out.fetchedBodyAt).toBe('2026-07-28T08:11:19.106-04:00');
+    expect(out.freshness.asOf).toBe('2026-07-28T16:27:11.426-04:00');
+  });
+
+  it('pairs every timestamp with a weekday-bearing display value', () => {
+    const out = normalizeTimestampsInValue({ sentAt: '2026-07-27T23:31:09' }, ET);
+    expect(out.sentAtDisplay).toContain('Mon');
+    expect(out.sentAtDisplay).toContain('Jul 27');
+    expect(out.sentAtDisplay).toContain('11:31 PM');
+  });
+
+  // The harm: a 10:38 PM ET send must never surface on the next calendar day.
+  it('never reports a late-evening send on the following day', () => {
+    const out = normalizeTimestampsInValue({ sentAt: '2026-07-27T22:38:00' }, ET);
+    expect(out.sentAt.startsWith('2026-07-27')).toBe(true);
+    expect(out.sentAtDisplay).toContain('Jul 27');
+  });
+
+  it('keeps OFW and Gmail contemporaneous events five minutes apart on one day', () => {
+    const out = normalizeTimestampsInValue({
+      ofw: { sentAt: '2026-07-27T23:31:09' },
+      gmail: { date: '2026-07-27 23:36:09' },
+    }, ET);
+    expect(out.ofw.sentAt).toBe('2026-07-27T23:31:09-04:00');
+    expect(out.gmail.date).toBe('2026-07-27T23:36:09-04:00');
+    const delta = Date.parse(out.gmail.date) - Date.parse(out.ofw.sentAt);
+    expect(delta).toBe(5 * 60_000);
+  });
+
+  it('emits no naive timestamp anywhere in the payload', () => {
+    const out = normalizeTimestampsInValue({
+      a: { sentAt: '2026-07-27T23:31:09' },
+      b: [{ viewedAt: '2026-07-28T09:37:11' }],
+      c: { fetchedBodyAt: '2026-07-28T12:11:19.106Z' },
+    }, ET);
+    const naive: unknown[] = [];
+    const scan = (n: unknown): void => {
+      if (Array.isArray(n)) return void n.forEach(scan);
+      if (n && typeof n === 'object') return void Object.values(n).forEach(scan);
+      if (isNaiveTimestamp(n)) naive.push(n);
+    };
+    scan(out);
+    expect(naive).toEqual([]);
+  });
+
+  it('never mixes naive and offset-bearing timestamps in one object', () => {
+    const out = normalizeTimestampsInValue({
+      sentAt: '2026-07-27T23:31:09',
+      fetchedBodyAt: '2026-07-28T12:11:19.106Z',
+      asOf: '2026-07-28T20:27:11.426Z',
+    }, ET);
+    const values = [out.sentAt, out.fetchedBodyAt, out.asOf];
+    expect(values.every((v) => /[+-]\d{2}:\d{2}$/.test(v))).toBe(true);
+    expect(values.some(isNaiveTimestamp)).toBe(false);
+  });
+
+  it('DISPLAY_TZ shifts display fields and the offset, nothing else', () => {
+    const payload = { id: 1, subject: 'S', sentAt: '2026-07-27T23:31:09' };
+    const et = normalizeTimestampsInValue(payload, ET);
+    const pt = normalizeTimestampsInValue(payload, 'America/Los_Angeles');
+    expect(et.sentAt).not.toBe(pt.sentAt);
+    expect(et.sentAtDisplay).not.toBe(pt.sentAtDisplay);
+    expect(pt.id).toBe(1);
+    expect(pt.subject).toBe('S');
+  });
+
+  // Response payloads carry live cache rows; rewriting them in place would
+  // corrupt the cache and make normalization observable on a later read.
+  it('does not mutate its input', () => {
+    const input = { sentAt: '2026-07-27T23:31:09', nested: { viewedAt: '2026-07-28T09:37:11' } };
+    const out = normalizeTimestampsInValue(input, ET);
+    expect(input.sentAt).toBe('2026-07-27T23:31:09');
+    expect(input.nested.viewedAt).toBe('2026-07-28T09:37:11');
+    expect(out).not.toBe(input);
+  });
+
+  it('leaves the epoch-zero view placeholder recognisable as 1970', () => {
+    // mapRecipients/hasRealView key off a "1970-01-01" prefix; normalization
+    // must not move the value off that date.
+    const out = normalizeTimestampsInValue({ viewedAt: '1970-01-01T00:00:00' }, ET);
+    expect(out.viewedAt.startsWith('1970-01-01')).toBe(true);
+  });
+
+  it('leaves user content and non-timestamp keys alone', () => {
+    const payload = {
+      body: 'Let us meet 2026-07-28 03:36 as discussed',
+      description: '2026-07-27T23:31:09',
+      amount: '2026-07-28',
+      count: 5,
+    };
+    expect(normalizeTimestampsInValue(payload, ET)).toEqual(payload);
+  });
+
+  it('passes primitives and null through untouched', () => {
+    expect(normalizeTimestampsInValue(null, ET)).toBeNull();
+    expect(normalizeTimestampsInValue('a string', ET)).toBe('a string');
+    expect(normalizeTimestampsInValue(42, ET)).toBe(42);
+  });
+
+  it('normalizes a top-level array', () => {
+    const out = normalizeTimestampsInValue([{ sentAt: '2026-07-27T23:31:09' }], ET);
+    expect(out[0].sentAt).toBe('2026-07-27T23:31:09-04:00');
+  });
+
+  it('is idempotent — re-normalizing changes nothing', () => {
+    const once = normalizeTimestampsInValue({ sentAt: '2026-07-27T23:31:09' }, ET);
+    expect(normalizeTimestampsInValue(once, ET)).toEqual(once);
+  });
+
+  it('handles a DST spring-forward wall time without drifting a day', () => {
+    // 2026-03-08 02:30 ET does not exist (clocks jump 02:00 -> 03:00).
+    const out = normalizeTimestampsInValue({ sentAt: '2026-03-08 02:30' }, ET);
+    expect(out.sentAt.startsWith('2026-03-08')).toBe(true);
+    expect(out.sentAt).toMatch(/[+-]\d{2}:\d{2}$/);
+  });
+
+  it('leaves zone names untouched', () => {
+    const out = normalizeTimestampsInValue({ timeZone: 'America/New_York', timezone: 'UTC' }, ET);
+    expect(out.timeZone).toBe('America/New_York');
+    expect(out.timezone).toBe('UTC');
+  });
+});

--- a/tests/tools/freshness.test.ts
+++ b/tests/tools/freshness.test.ts
@@ -206,3 +206,57 @@ describe('buildFreshness', () => {
     expect(f.lastServerSyncAt).toBe(ago(100));
   });
 });
+
+// The blocking finding on PR #200: the allowlist omitted the freshness block's
+// own bookkeeping fields, so `asOf` carried an offset while `lastServerSyncAt`
+// sat next to it in UTC `Z` — two zones in one object, the exact property the
+// normalization was introduced to establish.
+//
+// This scans a REAL handler response rather than a hand-built literal. The
+// earlier mixed-zone test passed because it asserted over a payload I wrote by
+// hand from the reported field names, so it could only ever confirm the fields
+// already known to be broken.
+describe('freshness block zone consistency (contract)', () => {
+  const NAIVE = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?$/;
+  const OFFSET_BEARING = /([+-]\d{2}:\d{2}|Z)$/;
+
+  function collectTimestamps(node: unknown, out: string[] = []): string[] {
+    if (Array.isArray(node)) {
+      node.forEach((n) => collectTimestamps(n, out));
+    } else if (node && typeof node === 'object') {
+      Object.values(node).forEach((n) => collectTimestamps(n, out));
+    } else if (typeof node === 'string' && (NAIVE.test(node) || OFFSET_BEARING.test(node))) {
+      if (/^\d{4}-\d{2}-\d{2}[T ]\d{2}:/.test(node)) out.push(node);
+    }
+    return out;
+  }
+
+  it('emits no naive timestamp and one zone across a real freshness payload', async () => {
+    await seedVerified('inbox', ago(30));
+    const freshness = await buildFreshness(store, { source: 'cache', folders: ['inbox'], now: NOW });
+
+    // Route it through the real response seam, as a tool would.
+    const { jsonResponse } = await import('../../src/tools/_shared.js');
+    const payload = JSON.parse(jsonResponse({ freshness }).content[0].text as string);
+
+    const stamps = collectTimestamps(payload);
+    expect(stamps.length).toBeGreaterThan(1); // asOf AND lastServerSyncAt at minimum
+    expect(stamps.filter((s) => NAIVE.test(s))).toEqual([]);
+    expect(stamps.every((s) => OFFSET_BEARING.test(s))).toBe(true);
+    // One zone throughout: every value ends in the same offset.
+    expect(new Set(stamps.map((s) => s.slice(-6))).size).toBe(1);
+  });
+
+  it('a refusal payload is normalized the same way as a success payload', async () => {
+    await seedVerified('inbox', ago(30));
+    const freshness = await buildFreshness(store, { source: 'cache', folders: ['inbox'], now: NOW });
+    const { jsonResponse, jsonErrorResponse } = await import('../../src/tools/_shared.js');
+
+    const ok = JSON.parse(jsonResponse({ freshness }).content[0].text as string);
+    const refused = JSON.parse(jsonErrorResponse({ error: 'UNVERIFIED_EMPTY', freshness }).content[0].text as string);
+
+    expect(refused.freshness.asOf).toBe(ok.freshness.asOf);
+    expect(refused.freshness.lastServerSyncAt).toBe(ok.freshness.lastServerSyncAt);
+    expect(collectTimestamps(refused).filter((s) => NAIVE.test(s))).toEqual([]);
+  });
+});

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -283,7 +283,7 @@ describe('read-state reconciliation (bug: stale read flag vs viewedAt)', () => {
     // and the raw listData flags no longer contradict the recipient viewedAt
     expect(msg.listData.read).toBe(true);
     expect(msg.listData.showNeverViewed).toBe(false);
-    expect(msg.recipients[0].viewedAt).toBe('2026-07-17T08:37:57');
+    expect(msg.recipients[0].viewedAt).toBe('2026-07-17T08:37:57-04:00');
     // the real account-holder id survived normalization (was 0 before the fix)
     expect(msg.recipients[0].userId).toBe(3039201);
   });
@@ -494,8 +494,8 @@ describe('ofw_get_message (cache-first)', () => {
     expect(parsed.body).toBe('NEW body');
     expect(parsed.subject).toBe('Fresh subject');
     expect(parsed.fromUser).toBe('');
-    expect(parsed.sentAt).toBe('2026-05-04T12:00:00Z');
-    expect(parsed.fetchedBodyAt).toBe('2026-05-04T12:00:00Z');
+    expect(parsed.sentAt).toBe('2026-05-04T08:00:00-04:00');
+    expect(parsed.fetchedBodyAt).toBe('2026-05-04T08:00:00-04:00');
     expect(parsed.chainRootId).toBeNull();
     // The drafts-table route doesn't hit OFW or the messages cache.
     expect(spy).not.toHaveBeenCalled();
@@ -1987,7 +1987,13 @@ describe('ofw_get_unread_sent (cache-backed)', () => {
     const result = await handlers.get('ofw_get_unread_sent')!({});
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.unread).toEqual([
-      { id: 1, subject: 'Schedule', sentAt: '2026-05-04T12:00:00Z', unreadBy: ['Alice'] },
+      {
+        id: 1,
+        subject: 'Schedule',
+        sentAt: '2026-05-04T08:00:00-04:00',
+        sentAtDisplay: 'Mon, May 4, 2026, 8:00 AM EDT',
+        unreadBy: ['Alice'],
+      },
     ]);
     // Read state here comes entirely from cached view timestamps, so the
     // result must carry the same age label as any other cached read.
@@ -3622,7 +3628,7 @@ describe('ofw_get_message — sent view-status refresh', () => {
     setup(client);
     const result = await handlers.get('ofw_get_message')!({ messageId: '600' });
     const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.recipients[0].viewedAt).toBe('2026-06-16T15:49:20');
+    expect(parsed.recipients[0].viewedAt).toBe('2026-06-16T15:49:20-04:00');
     expect(getMessage(600)?.recipients[0].viewedAt).toBe('2026-06-16T15:49:20');
     // listData read-flag reconciled so it can't contradict recipients
     expect(parsed.listData.showNeverViewed).toBe(false);
@@ -3677,7 +3683,7 @@ describe('ofw_get_message — sent view-status refresh', () => {
     const spy = vi.spyOn(client, 'request');
     setup(client);
     const result = await handlers.get('ofw_get_message')!({ messageId: '602' });
-    expect(JSON.parse(result.content[0].text).recipients[0].viewedAt).toBe('2026-06-16T15:49:20');
+    expect(JSON.parse(result.content[0].text).recipients[0].viewedAt).toBe('2026-06-16T15:49:20-04:00');
     expect(spy).not.toHaveBeenCalled();
   });
 });
@@ -3795,7 +3801,7 @@ describe('ofw_check_freshness', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(parsed.items[0].state).toBe('sent');
-    expect(parsed.items[0].sentAt).toBe('2026-07-27T23:31:09');
+    expect(parsed.items[0].sentAt).toBe('2026-07-27T23:31:09-04:00');
   });
 
   it('probes a non-draft id when allowMarkRead is set', async () => {
@@ -4169,7 +4175,7 @@ describe('lifecycle state in ofw_check_freshness (Gap 1)', () => {
     expect(parsed.items[0]).toMatchObject({
       id: 538279699,
       state: 'sent',
-      sentAt: '2026-07-27T23:31:09',
+      sentAt: '2026-07-27T23:31:09-04:00',
       existsOnServer: true,
       inSync: false,
     });
@@ -4627,7 +4633,7 @@ describe('draftKey: identity that survives the create-then-delete churn (Gap 3)'
       state: 'sent',
       sentMessageId: sent.id,
     });
-    expect(parsed.requested[0].sentAt).toBe('2026-07-28T00:00:00Z');
+    expect(parsed.requested[0].sentAt).toBe('2026-07-27T20:00:00-04:00');
   });
 
   it('adopts a draft that predates the mechanism, retroactively linking the old id', async () => {
@@ -4819,7 +4825,7 @@ describe('ofw_status (requirement 4)', () => {
     expect(byId.get(537828154)).toMatchObject({ state: 'draft', inSync: true });
     expect(byId.get(538086428)).toMatchObject({ state: 'draft', inSync: true });
     expect(byId.get(538279699)).toMatchObject({
-      state: 'sent', sentAt: '2026-07-27T23:31:09', sentMessageId: 538279699, inSync: false,
+      state: 'sent', sentAt: '2026-07-27T23:31:09-04:00', sentMessageId: 538279699, inSync: false,
     });
     // Every id was resolved live, so the snapshot IS a usable basis for a claim.
     expect(parsed.complete).toBe(true);

--- a/tests/worker-timestamps.test.ts
+++ b/tests/worker-timestamps.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { formatInstant, normalizeTimestampsInValue } from '../src/timestamps.js';
+
+// Timestamp normalization now runs on every hosted-connector response, so it has
+// to work inside workerd and not just Node. Two things could differ:
+//
+//  - `structuredClone`, which the non-mutating walk depends on. Cloning a live
+//    cache row rather than rewriting it in place is what keeps normalization
+//    from being observable on a later read.
+//  - workerd's ICU timezone data. The whole point of using IANA names instead of
+//    fixed offsets is that DST is resolved from that database; a runtime shipping
+//    a trimmed ICU would silently label July as -05:00 and put a late-evening
+//    send on the wrong calendar day — the exact failure this module exists to
+//    prevent. A green Node suite would not catch it.
+const ET = 'America/New_York';
+
+describe('timestamp normalization under the Workers runtime', () => {
+  it('resolves DST from IANA data rather than a fixed offset', () => {
+    expect(formatInstant(new Date('2026-01-15T17:00:00Z'), ET).iso).toBe('2026-01-15T12:00:00-05:00');
+    expect(formatInstant(new Date('2026-07-15T17:00:00Z'), ET).iso).toBe('2026-07-15T13:00:00-04:00');
+  });
+
+  it('renders a weekday-bearing display string', () => {
+    const { display } = formatInstant(new Date('2026-07-28T03:36:00Z'), ET);
+    expect(display).toContain('Mon');
+    expect(display).toContain('Jul 27');
+  });
+
+  it('normalizes a naive OFW timestamp onto the correct calendar day', () => {
+    const out = normalizeTimestampsInValue({ sentAt: '2026-07-27T23:31:09' }, ET);
+    expect(out.sentAt).toBe('2026-07-27T23:31:09-04:00');
+    expect(out.sentAtDisplay).toContain('Jul 27');
+  });
+
+  it('clones rather than mutating — structuredClone is available here', () => {
+    const input = { sentAt: '2026-07-27T23:31:09', nested: { viewedAt: '2026-07-28T09:37:11' } };
+    const out = normalizeTimestampsInValue(input, ET);
+    expect(input.sentAt).toBe('2026-07-27T23:31:09');
+    expect(input.nested.viewedAt).toBe('2026-07-28T09:37:11');
+    expect(out).not.toBe(input);
+    expect(out.nested).not.toBe(input.nested);
+  });
+
+  it('supports the non-default zones a DISPLAY_TZ override could name', () => {
+    expect(formatInstant(new Date('2026-07-15T17:00:00Z'), 'America/Los_Angeles').iso)
+      .toBe('2026-07-15T10:00:00-07:00');
+    expect(formatInstant(new Date('2026-07-15T00:00:00Z'), 'Asia/Kolkata').iso)
+      .toBe('2026-07-15T05:30:00+05:30');
+  });
+});

--- a/vitest.workers.config.ts
+++ b/vitest.workers.config.ts
@@ -13,6 +13,11 @@ export default defineConfig({
     }),
   ],
   test: {
-    include: ['tests/worker.test.ts', 'tests/worker-cache.test.ts', 'tests/worker-extract.test.ts'],
+    include: [
+      'tests/worker.test.ts',
+      'tests/worker-cache.test.ts',
+      'tests/worker-extract.test.ts',
+      'tests/worker-timestamps.test.ts',
+    ],
   },
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -33,7 +33,19 @@
     // resume round-trips on a large backfill. Unsetting / removing this var makes
     // sync unbounded (walks fully in one call) — only safe for the local stdio
     // server, never the Worker.
-    "OFW_SYNC_MAX_REQUESTS": "40"
+    "OFW_SYNC_MAX_REQUESTS": "40",
+    // IANA zone for every `<field>Display` value, and the zone a naive OFW
+    // timestamp is read as wall-clock in. Set explicitly rather than left to
+    // the America/New_York default so the value is visible in the deployment
+    // rather than implied by code.
+    //
+    // DEPLOYMENT-WIDE, not per-tenant: OFW reports naive local times in the
+    // ACCOUNT's zone, so a tenant outside this zone gets a correct instant
+    // label only if their account zone matches. Threading a per-tenant zone
+    // through OFWProps is the fix if this connector ever serves accounts
+    // outside one zone; until then this var is the whole story. See
+    // docs/DEPLOY-CONNECTOR.md.
+    "DISPLAY_TZ": "America/New_York"
   },
   // Production custom domain (matches untappd-mcp's connector.untappd.nullnet.app).
   // The zone must be in the deploying account's Cloudflare; wrangler provisions


### PR DESCRIPTION
## The problem

A single response object mixed two zones, with nothing in the payload to tell them apart:

| Field | Value | Actual zone |
|---|---|---|
| `sentAt` | `2026-07-27T23:31:09` | **local (ET), no offset** |
| `viewedAt` | `2026-07-28T09:37:11` | **local (ET), no offset** |
| `fetchedBodyAt` | `2026-07-28T12:11:19.106Z` | UTC |
| `freshness.asOf` | `2026-07-28T20:27:11.426Z` | UTC |

A reader assumes one zone for both and is wrong by the UTC offset on half the fields.

## Why it matters

The failure that matters is the calendar **day**. A message sent 10:38 PM Eastern surfacing as 02:38 lands on the following day — and in a co-parenting record that decides which custody day an event belongs to and whether it beat a 48-hour response window.

It also made `sentAt: "2026-07-27T23:31:09"` and a Gmail search's `2026-07-28 03:36` look like different nights when they were **five minutes apart**.

## The change

Normalization sits on **`jsonResponse`** (`src/tools/_shared.ts`) — the single seam every structured tool response passes through. Normalizing there rather than at each of the ~87 call sites is what makes it impossible for a tool to reintroduce a naive value.

```json
"sentAt": "2026-07-27T23:31:09-04:00",
"sentAtDisplay": "Mon, Jul 27, 2026, 11:31 PM EDT"
```

Every allowlisted timestamp becomes ISO-8601 with an explicit offset, paired with a `<field>Display` sibling carrying the **weekday** — a wrong weekday is what makes a date-boundary error visible at a glance. UTC-stamped fields render in the same zone as everything else, so one object never shows two zones.

### Safety

- A field is rewritten only when the key is allowlisted **and** the value matches a timestamp shape, so user content (a message body quoting a date, an expense description) is never touched.
- **Date-only** values are left alone rather than having a time invented.
- The payload is **cloned** before walking. Responses carry live cache rows; rewriting them in place would corrupt the cache and make normalization observable on a later read. There is a test for this, and the existing `getMessage(600)` cache assertion still reads the raw naive value — which is the proof.
- The epoch-zero view placeholder stays recognisable as `1970-01-01`, so `mapRecipients`/`hasRealView` are unaffected.

## Configuration

`DISPLAY_TZ` (IANA) sets the zone, defaulting to `America/New_York`, falling back rather than throwing on a bad value. Never a fixed offset — DST comes from the IANA database, so a hardcoded `-04:00` would be an hour wrong from November through March.

## Testing

798 tests pass, 100% statement and branch coverage held. New file `tests/timestamps.test.ts` covers the spec: the naive/UTC mix collapsing to one zone, the 10:38 PM date-boundary regression, OFW and Gmail contemporaneous events landing five minutes apart on the same day, DST (`-05:00` January / `-04:00` July), a no-naive-timestamp contract scan, a mixed-zone assertion, `DISPLAY_TZ` override, non-mutation, half-hour zones, spring-forward wall times, and idempotence.

Nine existing assertions were updated — all of them expectations of the old naive strings, e.g. `2026-07-27T23:31:09` → `2026-07-27T23:31:09-04:00`. That exact value is the one from the bug report.

## Related

Companion PR in `gogcli-mcp` (#216) fixes the Gmail side, where the root cause was different: gog is timezone-aware but the hosted Fly runner set no `GOG_TIMEZONE`, so `time.Local` was UTC.

Closes #201