### PR TITLE
fix(deps): bump @fetchproxy/* to 1.7.0 and @chrischall/mcp-utils to 0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.9.1",
       "license": "MIT",
       "dependencies": {
-        "@chrischall/mcp-utils": "^0.13.0",
-        "@fetchproxy/bootstrap": "^1.3.0",
+        "@chrischall/mcp-utils": "^0.14.0",
+        "@fetchproxy/bootstrap": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
         "zod": "^4.4.3"
@@ -443,9 +443,9 @@
       }
     },
     "node_modules/@chrischall/mcp-utils": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.13.3.tgz",
-      "integrity": "sha512-egP6UItXFmXTL+5/Ajs/8uiTqmnf53pv9W8PY/3kl0pybsjIdzQb5LO0ylO4oT5f9Q4uYeS/jywjeXKSMiWdNQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.14.0.tgz",
+      "integrity": "sha512-QZNXGHCzBsvjTXRMPJ0c5TLb/59FQbZXIMu77PGHqbXck6Gg+hYVmBt/gMtly1ubRmdSilou13wCa8tSoTrEZg==",
       "license": "MIT",
       "peerDependencies": {
         "@fetchproxy/server": "*",
@@ -1124,28 +1124,28 @@
       }
     },
     "node_modules/@fetchproxy/bootstrap": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-1.6.1.tgz",
-      "integrity": "sha512-xhEWrQ6pKHjgC+Tx4hf9YEPf6YoCGemP1riR1l2ufJ/QEaSL5MUxiDTrrj9lP4gM0+kvFh0b+YgSNhgwBpmI5w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-1.7.0.tgz",
+      "integrity": "sha512-09+eoKYOJEWTT6NeKyWkLGEWU0Ep7IgUrG3zE7jaj9l03oZ6XW2MeHOJ+mSQldBS0p1PEMF1gmWcFFLVU7Z0Aw==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^1.6.1",
-        "@fetchproxy/server": "^1.6.1"
+        "@fetchproxy/protocol": "^1.7.0",
+        "@fetchproxy/server": "^1.7.0"
       }
     },
     "node_modules/@fetchproxy/protocol": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-1.6.1.tgz",
-      "integrity": "sha512-T7p7McIt1tR6qz4p91KQ+qTFwYvBkQmIiTK8afsczi5AczCRsWNF46DnuMx3O9HHe2+HvCD9hOduyrk2R0joWQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-1.7.0.tgz",
+      "integrity": "sha512-2mEWgLvMgKvN7H1yAzEazMVkmdcdIdh8Ly/+pekrfmZ6spmyNCMqqH5+yqgabV4fQhEoe+PPqiKT5kKbBDrKOg==",
       "license": "MIT"
     },
     "node_modules/@fetchproxy/server": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-1.6.1.tgz",
-      "integrity": "sha512-9TvUuDr4gJfKJHsEgBVn7qiEsEuHn+ms/+DdpkvoyUeEJrryST47+6vWwJW1pzNZqzrgrxGDCQ7reKn0VZuiRA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-1.7.0.tgz",
+      "integrity": "sha512-V63Z8kgvFp5x4nOxkkzkg02BbUq9slDCH2mxNV4YZuJJf0PQxswaOwbjRHeT8RT1JLtozdr3XQXdlExkFjQnBg==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^1.6.1",
+        "@fetchproxy/protocol": "^1.7.0",
         "ws": "^8.21.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.9.1",
   "license": "MIT",
   "mcpName": "io.github.chrischall/ofw-mcp",
-  "description": "OurFamilyWizard MCP server for Claude — developed and maintained by AI (Claude Code)",
+  "description": "OurFamilyWizard MCP server for Claude \u2014 developed and maintained by AI (Claude Code)",
   "author": "Claude Code (AI) <https://www.anthropic.com/claude>",
   "repository": {
     "type": "git",
@@ -35,8 +35,8 @@
     "worker:test": "vitest run --config vitest.workers.config.ts"
   },
   "dependencies": {
-    "@chrischall/mcp-utils": "^0.13.0",
-    "@fetchproxy/bootstrap": "^1.3.0",
+    "@chrischall/mcp-utils": "^0.14.0",
+    "@fetchproxy/bootstrap": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",
     "zod": "^4.4.3"


### PR DESCRIPTION
First-party dependency bump.

- `@fetchproxy/*` -> `^1.7.0`
- `@chrischall/mcp-utils` -> `^0.14.0`

Rebuilds the published bundle against the current bridge server + mcp-utils. Local build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)