### PR TITLE
chore: restore literal em-dash in package.json description

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.9.1",
   "license": "MIT",
   "mcpName": "io.github.chrischall/ofw-mcp",
-  "description": "OurFamilyWizard MCP server for Claude \u2014 developed and maintained by AI (Claude Code)",
+  "description": "OurFamilyWizard MCP server for Claude — developed and maintained by AI (Claude Code)",
   "author": "Claude Code (AI) <https://www.anthropic.com/claude>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Restores the literal em-dash in the package.json `description`. The @fetchproxy/@chrischall dep-bump rewrote package.json via a JSON serializer with ensure_ascii, which escaped `—` to `\u2014`. Semantically identical, but an unfocused change — reverting to keep the file clean before release. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)