### PR TITLE
fix(deps): move to @fetchproxy/server 2.0.0 for the v3 handshake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@chrischall/mcp-utils": "^0.14.0",
-        "@fetchproxy/bootstrap": "^1.7.0",
+        "@fetchproxy/bootstrap": "^2.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
         "zod": "^4.4.3"
@@ -1124,28 +1124,28 @@
       }
     },
     "node_modules/@fetchproxy/bootstrap": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-1.7.0.tgz",
-      "integrity": "sha512-09+eoKYOJEWTT6NeKyWkLGEWU0Ep7IgUrG3zE7jaj9l03oZ6XW2MeHOJ+mSQldBS0p1PEMF1gmWcFFLVU7Z0Aw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-2.0.0.tgz",
+      "integrity": "sha512-v44fyRenlnqqaAm2RVzjkUHFRW1OeGAOiT33/Zy8obQqBLlzfVG5HNuVNOfQ8+QzgHTC39pi0X/qXhoe60cfQQ==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^1.7.0",
-        "@fetchproxy/server": "^1.7.0"
+        "@fetchproxy/protocol": "^2.0.0",
+        "@fetchproxy/server": "^2.0.0"
       }
     },
     "node_modules/@fetchproxy/protocol": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-1.7.0.tgz",
-      "integrity": "sha512-2mEWgLvMgKvN7H1yAzEazMVkmdcdIdh8Ly/+pekrfmZ6spmyNCMqqH5+yqgabV4fQhEoe+PPqiKT5kKbBDrKOg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-2.0.0.tgz",
+      "integrity": "sha512-JYarJSr0uF6lNSrB/O/ZNkjLi4pNG7JDfBzZlJ/RpNwbFsuCgRYc7CTYoBNZV8nQ2r0+hfyI9qG4eRMXzfA7ew==",
       "license": "MIT"
     },
     "node_modules/@fetchproxy/server": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-1.7.0.tgz",
-      "integrity": "sha512-V63Z8kgvFp5x4nOxkkzkg02BbUq9slDCH2mxNV4YZuJJf0PQxswaOwbjRHeT8RT1JLtozdr3XQXdlExkFjQnBg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-o4f72xR5fWvFwVwlC6cwWT/YwYomLOOATupQfHKVtWzZZ1a4IgkmRxYlS/z2pjUrawqo3ZzWVMx44KhPNo1Ufw==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^1.7.0",
+        "@fetchproxy/protocol": "^2.0.0",
         "ws": "^8.21.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@chrischall/mcp-utils": "^0.14.0",
-    "@fetchproxy/bootstrap": "^1.7.0",
+    "@fetchproxy/bootstrap": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",
     "zod": "^4.4.3"


### PR DESCRIPTION
fetchproxy 2.0.0 closes a MITM in the bridge handshake (advisory GHSA-j6jv-w774-77m6, fix in chrischall/fetchproxy#222): `ReadyFrame.sessionSig` now covers the extension's **ephemeral public key**, not just the two nonces. Under v2 a relay could forward the genuine hellos and the genuine signature, substitute an ephemeral key it held the private half of, derive the same shared secret, and read and rewrite the session — nothing either side checked committed to the key the ECDH actually used.

That is a wire break (`PROTOCOL_VERSION` 2 → 3), and `^1.7.0` cannot take a 2.x. Left alone, this MCP would keep speaking v2 and be **refused at the hello** by a v3 extension — loudly, at the handshake, not silently. The fleet and the sideloaded extension move together.

**No source change.** The break is inside the handshake; `FetchproxyServer`'s public API is unchanged. Verified by running this repo's own suite against 2.0.0.