### PR TITLE
docs: repair sentences the connector de-naming left behind

### DIFF
--- a/src/cache/store.ts
+++ b/src/cache/store.ts
@@ -598,8 +598,8 @@ export class OFWCacheCore {
   }
 
   /**
-   * Batch read — one query for a whole page of drafts. Where the cache is remote
-   * backend each cache call is a subrequest, so a per-draft lookup would spend
+   * Batch read — one query for a whole page of drafts. Where the cache is
+   * remote each cache call is a subrequest, so a per-draft lookup would spend
    * the caller's sync budget on bookkeeping.
    */
   getDraftLineageByIds(ids: number[]): DraftLineageRow[] {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -364,8 +364,8 @@ async function walkPages(
     }
 
     // Flush the page's rows in one transaction/RPC. Skipped entirely when the
-    // page held nothing new: where the cache is remote this call is an RPC,
-    // and a DO RPC counts against the same subrequest budget as an OFW fetch.
+    // page held nothing new: where the cache is remote this call is a round
+    // trip, counting against the same subrequest budget as an OFW fetch.
     // A deep re-walk crosses page after page of already-cached messages, so an
     // unconditional "no-op" write spends the caller's budget to store nothing.
     if (toUpsert.length > 0) await store.upsertMessages(toUpsert);

--- a/src/tools/lifecycle.ts
+++ b/src/tools/lifecycle.ts
@@ -228,10 +228,10 @@ export async function probeIds(
   ids: number[],
   opts: { allowMarkRead: boolean },
 ): Promise<{ items: LifecycleItem[]; requests: number }> {
-  // THREE cache reads for the whole batch, not three per id. Where the
-  // Object backend every cache call is a subrequest counting against the same
-  // hosting cap as the OFW fetches, so a per-id lookup would spend the caller's
-  // budget on bookkeeping before a single probe ran.
+  // THREE cache reads for the whole batch, not three per id. Where the cache
+  // is remote every call is a subrequest counting against the same hosting cap
+  // as the OFW fetches, so a per-id lookup would spend the caller's budget on
+  // bookkeeping before a single probe ran.
   const draftsById = new Map((await store.getDrafts(ids)).map((d) => [d.id, d]));
   const messagesById = new Map((await store.getMessages(ids)).map((m) => [m.id, m]));
 
@@ -370,9 +370,9 @@ export async function resolveDraftKey(
 }
 
 /**
- * Mint a new stable draft identity. Uses the Web Crypto global, which both
- * Node ≥19 provides natively — a `node:crypto` import would not
- * bundle for a hosted deployment.
+ * Mint a new stable draft identity. Uses the Web Crypto global, which Node ≥19
+ * provides natively — a `node:crypto` import would not bundle for a hosted
+ * deployment.
  */
 export function newDraftKey(): string {
   return `dk_${crypto.randomUUID()}`;


### PR DESCRIPTION
Four comments lost a word when the Cloudflare/Durable-Object names came out of them in the connector retirement, and the result reads as nonsense rather than as prose with a name missing:

- `src/cache/store.ts` — *"Where the cache is remote **backend** each cache call is a subrequest"*
- `src/tools/lifecycle.ts` — *"Where the **Object** backend every cache call is a subrequest"*
- `src/tools/lifecycle.ts` — a dangling *"which **both** Node ≥19 provides"*, left over from when two runtimes were named
- `src/sync.ts` — *"a **DO** RPC"*, an abbreviation whose expansion had been de-named out of the surrounding text

Each now says what it always meant — a remote cache spends the caller's subrequest budget — without naming a backend that is no longer there.

Comments only; 28 suites / 837 tests pass.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)