### PR TITLE
ci: sync the ci,release-please stub(s) from chrischall/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: CI
 
 # Thin stub — the gate and steps live in chrischall/workflows.
 # Status-mode gate: un-armed PRs are blocked by a yellow `ci-gated: pending`
-# commit status (not a red failing job); the repo ruleset must require the
-# `ci-gated` status context (scripts/update-ruleset.sh flips it from `ci / ci`).
+# commit status (the `ci / ci` job is skipped, not a red or misleadingly green
+# job); the repo ruleset must require the `ci-gated` status context
+# (scripts/update-ruleset.sh flips it from `ci / ci`).
 # The permissions block is load-bearing: the reusable workflow posts the
 # `ci-gated` status with this token, and (a) callers pass read-only by default,
 # (b) dependabot-triggered runs are read-only unless permissions are explicit.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,7 +5,10 @@ name: release-please
 # in THIS file (not a reusable workflow) because npm trusted publishing and
 # mcp-publisher bind to this repo's workflow identity via OIDC.
 #
-# The release PR is the human review gate: add `release-ready` to ship it.
+# The release PR ships via `release-ready`: adding it starts the auto-review,
+# and a passing review arms `ready-to-merge` → deferred CI → auto-merge. CI does
+# not run until the review passes, so `release-ready` is "review then ship", not
+# an instant CI arm.
 # The PAT (not GITHUB_TOKEN) so the release PR's events trigger CI/review.
 
 on:
@@ -52,11 +55,6 @@ jobs:
         with:
           version: ${{ needs.release-please.outputs.version }}
           tag-name: ${{ needs.release-please.outputs.tag_name }}
-          # This repo ships TWO skills — skills/ofw (the MCP skill) and
-          # skills/ofw-fpx (the fpx-CLI sibling) — so the action's
-          # single-skills/*/SKILL.md auto-discovery can't pick one and hard-
-          # fails the release. skills/ofw is the one that pairs with this npm
-          # package; ofw-fpx documents reaching OFW without the server.
           skill-path: skills/ofw/SKILL.md
           clawhub-token: ${{ secrets.CLAWHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Regenerates `.github/workflows/{ci,release-please}.yml` from `chrischall/workflows` templates + `fleet.json`. Only the drifted files are touched; every other workflow is left alone.

Part of clearing chrischall/workflows#109 (27 repos had drifted from their rendered stubs). This repo's drift was classified before syncing — anything that was a real hand-edit was recorded in `fleet.json` first (chrischall/workflows#120, #121) so the sync renders it rather than reverting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01An34yRUKVAN1QTDexfdfme