### PR TITLE
fix(pagination): correct the offset base, envelope counting, and key precedence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ src/
     _shared.ts      recipient mapping, response helpers, path expansion
     delivery.ts     the attachment delivery ladder (image → extracted → raw bytes)
     freshness.ts    buildFreshness() — the `freshness` block every read tool returns (source/asOf/ageSeconds/staleness/warning)
-    pagination.ts   paging state that survives a lossy reader: pageState/offsetState/truncationSentinel/withPaginationFirst
+    pagination.ts   paging state that survives a lossy reader: pageState/offsetState/readUpstreamPaging/withPaginationFirst
     lifecycle.ts    "is this entity still what I think it is?" — classifyState/probeIds/resolveDraftKey/newDraftKey
     user.ts         ofw_get_profile, ofw_get_notifications
     messages.ts     folders, list, get, send, drafts, get_unread_sent, upload/download_attachment, sync_messages, check_freshness, status

--- a/src/tools/expenses.ts
+++ b/src/tools/expenses.ts
@@ -37,7 +37,7 @@ export function registerExpenseTools(server: McpServer, client: OFWClient): void
     // rather than inferred from a full page (verified live).
     const { returned, total, last } = readUpstreamPaging(data);
     const wrapped = withPaginationFirst({
-      state: offsetState({ start, max, returned, total, last }),
+      state: offsetState({ start, max, returned, total, last, base: 0 }),
       start, max, returned, total,
       hint: `Re-call ofw_list_expenses with start:${start + max}.`,
       payload: data,

--- a/src/tools/journal.ts
+++ b/src/tools/journal.ts
@@ -30,7 +30,7 @@ export function registerJournalTools(server: McpServer, client: OFWClient): void
     // rather than inferred from a full page (verified live).
     const { returned, total, last } = readUpstreamPaging(data);
     const wrapped = withPaginationFirst({
-      state: offsetState({ start, max, returned, total, last }),
+      state: offsetState({ start, max, returned, total, last, base: 1 }),
       start, max, returned, total,
       hint: `Re-call ofw_list_journal_entries with start:${start + max}.`,
       payload: data,

--- a/src/tools/pagination.ts
+++ b/src/tools/pagination.ts
@@ -80,9 +80,22 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 }
 
 /** Read the paging facts out of an OFW `{data, metadata}` list envelope. */
+function recordArray(root: Record<string, unknown>): unknown[] | null {
+  // `data` is the envelope both endpoints actually use, so it wins outright.
+  // Falling back to the first array-valued key matters because the alternative
+  // is silently publishing `returned: 0` and a "reaches the end of the list"
+  // note ALONGSIDE real records — the precise shape of lie this file exists to
+  // prevent, reintroduced by a backend rename.
+  if (Array.isArray(root.data)) return root.data;
+  for (const value of Object.values(root)) {
+    if (Array.isArray(value)) return value;
+  }
+  return null;
+}
+
 export function readUpstreamPaging(payload: unknown): UpstreamPaging {
   const root = asRecord(payload);
-  const rows = root !== null && Array.isArray(root.data) ? root.data : null;
+  const rows = root === null ? null : recordArray(root);
   const meta = root === null ? null : asRecord(root.metadata);
   const total = meta !== null && typeof meta.totalElements === 'number' && Number.isFinite(meta.totalElements)
     ? meta.totalElements
@@ -107,12 +120,22 @@ export function offsetState(input: {
   returned: number;
   total: number | null;
   last?: boolean | null;
+  /**
+   * The `start` value that addresses the FIRST record: 0 for
+   * `ofw_list_expenses`, 1 for `ofw_list_journal_entries`. Required to turn
+   * `start` into a consumed count — assuming 0 for a 1-based tool overstates
+   * consumption by one and hides the final record at the exactly-one-remaining
+   * boundary (start:1, max:10, returned:10, total:11 reported "no more" while
+   * record 11 existed).
+   */
+  base: 0 | 1;
 }): OffsetState {
   const last = input.last ?? null;
+  const consumed = input.start - input.base + input.returned;
   const hasMore = last !== null
     ? !last
     : input.total !== null
-      ? input.start + input.returned < input.total
+      ? consumed < input.total
       : input.returned >= input.max;
   return { hasMore, nextStart: hasMore ? input.start + input.max : null };
 }
@@ -122,6 +145,12 @@ export function offsetState(input: {
  *
  * The upstream object is spread in BEHIND the paging keys, so every key it had
  * stays exactly where a caller expects to find it — only the order changes.
+ * The head is then spread a SECOND time: a plain `{...head, ...body}` lets an
+ * upstream `hasMore`/`nextStart`/`paginationNote` overwrite the computed value
+ * while keeping the head's key position, which is worse than either — a paging
+ * field sitting in the paging slot, reading as ours, sourced from elsewhere.
+ * Re-spreading restores our values; keys keep their first-insertion position,
+ * so the order is unchanged.
  * Returns null when the payload is not a plain object and therefore cannot
  * carry sibling keys at all; the caller then passes it through untouched rather
  * than relocating it, so this can never change a response's top-level shape.
@@ -139,7 +168,7 @@ export function withPaginationFirst(input: {
   if (body === null) return null;
 
   const scope = input.total !== null ? ` of ${input.total}` : '';
-  return {
+  const head: Record<string, unknown> = {
     hasMore: input.state.hasMore,
     nextStart: input.state.nextStart,
     start: input.start,
@@ -150,6 +179,6 @@ export function withPaginationFirst(input: {
       ? `PARTIAL: this response holds ${input.returned} record(s) starting at ${input.start}${scope}. `
         + `${input.hint} Do not state a total or an absence from this response alone.`
       : `This response reaches the end of the list${scope === '' ? '' : ` (${input.total} record(s) in total)`}.`,
-    ...body,
   };
+  return { ...head, ...body, ...head };
 }

--- a/tests/tools/journal.test.ts
+++ b/tests/tools/journal.test.ts
@@ -28,7 +28,8 @@ afterEach(() => vi.restoreAllMocks());
 
 describe('ofw_list_journal_entries', () => {
   it('calls /pub/v1/journals with default pagination', async () => {
-    const entries = { entries: [{ id: 1, title: 'Today' }] };
+    // The envelope OFW actually returns, captured live.
+    const entries = { data: [{ id: 1, title: 'Today' }], metadata: { currentPage: 1, totalPages: 1, totalElements: 1, perPage: 10, first: true, last: true } };
     const client = makeClient(entries);
     setup(client);
     const result = await handlers.get('ofw_list_journal_entries')!({});
@@ -42,7 +43,9 @@ describe('ofw_list_journal_entries', () => {
     expect(parsed.hasMore).toBe(false);
     expect(parsed.nextStart).toBeNull();
     // Paging state must precede the records in the serialized JSON.
-    expect(Object.keys(parsed).indexOf('hasMore')).toBeLessThan(Object.keys(parsed).indexOf('entries'));
+    expect(parsed.returned).toBe(1);
+    expect(parsed.total).toBe(1);
+    expect(Object.keys(parsed).indexOf('hasMore')).toBeLessThan(Object.keys(parsed).indexOf('data'));
   });
 
   it('reports zero returned when the response carries no record array at all', async () => {

--- a/tests/tools/pagination.test.ts
+++ b/tests/tools/pagination.test.ts
@@ -34,12 +34,22 @@ describe('readUpstreamPaging', () => {
     })).toEqual({ returned: 0, total: null, last: true });
   });
 
+  it('counts records under a NON-`data` key rather than publishing returned:0 beside them', () => {
+    // A backend rename must not produce `returned: 0` and a "reaches the end
+    // of the list" note sitting next to real records.
+    expect(readUpstreamPaging({ entries: [{ id: 1 }, { id: 2 }] }))
+      .toEqual({ returned: 2, total: null, last: null });
+    // `data` still wins outright when both are present.
+    expect(readUpstreamPaging({ other: [1, 2, 3], data: [1] }).returned).toBe(1);
+  });
+
   it('counts the records it did find, and degrades to nulls on an unrecognised shape', () => {
     expect(readUpstreamPaging({ data: [1, 2, 3], metadata: { last: false } }))
       .toEqual({ returned: 3, total: null, last: false });
     expect(readUpstreamPaging({ data: [1], metadata: { totalElements: 'nine', last: 'yes' } }))
       .toEqual({ returned: 1, total: null, last: null });
     expect(readUpstreamPaging({ data: 'not an array' })).toEqual({ returned: 0, total: null, last: null });
+    expect(readUpstreamPaging({ metadata: { last: true } })).toEqual({ returned: 0, total: null, last: true });
     expect(readUpstreamPaging({ message: 'no records' })).toEqual({ returned: 0, total: null, last: null });
     expect(readUpstreamPaging([1, 2])).toEqual({ returned: 0, total: null, last: null });
     expect(readUpstreamPaging(null)).toEqual({ returned: 0, total: null, last: null });
@@ -50,22 +60,36 @@ describe('offsetState', () => {
   it("trusts OFW's own `last` over any inference", () => {
     // A FULL page that the server calls the last one is the last one — the
     // heuristic below would have said "probably more" and been wrong.
-    expect(offsetState({ start: 0, max: 20, returned: 20, total: null, last: true }))
+    expect(offsetState({ start: 0, max: 20, returned: 20, total: null, last: true, base: 0 }))
       .toEqual({ hasMore: false, nextStart: null });
     // And a SHORT page the server does not call last still continues.
-    expect(offsetState({ start: 0, max: 20, returned: 3, total: null, last: false }))
+    expect(offsetState({ start: 0, max: 20, returned: 3, total: null, last: false, base: 0 }))
       .toEqual({ hasMore: true, nextStart: 20 });
   });
 
   it('falls back to the total when there is no `last`', () => {
-    expect(offsetState({ start: 0, max: 20, returned: 20, total: 55, last: null })).toEqual({ hasMore: true, nextStart: 20 });
-    expect(offsetState({ start: 40, max: 20, returned: 15, total: 55, last: null })).toEqual({ hasMore: false, nextStart: null });
+    expect(offsetState({ start: 0, max: 20, returned: 20, total: 55, last: null, base: 0 })).toEqual({ hasMore: true, nextStart: 20 });
+    expect(offsetState({ start: 40, max: 20, returned: 15, total: 55, last: null, base: 0 })).toEqual({ hasMore: false, nextStart: null });
+  });
+
+  it('respects the offset BASE at the exactly-one-remaining boundary, for both tools', () => {
+    // ofw_list_expenses is 0-based: page 1 is start:0, covering records 0..9.
+    // ofw_list_journal_entries is 1-based: page 1 is start:1, covering 1..10.
+    // Assuming 0 for the 1-based tool overstates consumption by one and hides
+    // the final record. `last` is absent here so the total fallback decides.
+    const args = { max: 10, returned: 10, last: null };
+    expect(offsetState({ ...args, start: 0, total: 11, base: 0 })).toEqual({ hasMore: true, nextStart: 10 });
+    expect(offsetState({ ...args, start: 1, total: 11, base: 1 })).toEqual({ hasMore: true, nextStart: 11 });
+    // And exactly-none-remaining stays false on both, so the fix does not
+    // trade a dropped record for an endless empty page.
+    expect(offsetState({ ...args, start: 0, total: 10, base: 0 })).toEqual({ hasMore: false, nextStart: null });
+    expect(offsetState({ ...args, start: 1, total: 10, base: 1 })).toEqual({ hasMore: false, nextStart: null });
   });
 
   it('with neither, treats a FULL page as probably-more and a short page as the end', () => {
     // The bias is one-directional on purpose: a wasted call beats a hidden page.
-    expect(offsetState({ start: 0, max: 20, returned: 20, total: null })).toEqual({ hasMore: true, nextStart: 20 });
-    expect(offsetState({ start: 0, max: 20, returned: 3, total: null })).toEqual({ hasMore: false, nextStart: null });
+    expect(offsetState({ start: 0, max: 20, returned: 20, total: null, base: 0 })).toEqual({ hasMore: true, nextStart: 20 });
+    expect(offsetState({ start: 0, max: 20, returned: 3, total: null, base: 0 })).toEqual({ hasMore: false, nextStart: null });
   });
 });
 
@@ -73,7 +97,7 @@ describe('withPaginationFirst', () => {
   it('spreads the envelope in behind the paging keys, renaming and dropping nothing', () => {
     const payload = { data: [{ id: 1 }], metadata: { last: false, totalElements: 55 } };
     const out = withPaginationFirst({
-      state: offsetState({ start: 0, max: 20, returned: 1, total: 55, last: false }),
+      state: offsetState({ start: 0, max: 20, returned: 1, total: 55, last: false, base: 0 }),
       start: 0, max: 20, returned: 1, total: 55,
       hint: 'Re-call with start:20.', payload,
     }) as Record<string, unknown>;
@@ -93,7 +117,7 @@ describe('withPaginationFirst', () => {
 
   it('says plainly when the response reaches the end, with and without a total', () => {
     const withTotal = withPaginationFirst({
-      state: offsetState({ start: 0, max: 20, returned: 3, total: 3, last: true }),
+      state: offsetState({ start: 0, max: 20, returned: 3, total: 3, last: true, base: 0 }),
       start: 0, max: 20, returned: 3, total: 3, hint: 'x', payload: { data: [] },
     }) as Record<string, unknown>;
     expect(withTotal.hasMore).toBe(false);
@@ -102,18 +126,40 @@ describe('withPaginationFirst', () => {
     expect(withTotal.total).toBe(3);
 
     const noTotal = withPaginationFirst({
-      state: offsetState({ start: 0, max: 20, returned: 3, total: null, last: true }),
+      state: offsetState({ start: 0, max: 20, returned: 3, total: null, last: true, base: 0 }),
       start: 0, max: 20, returned: 3, total: null, hint: 'x', payload: { data: [] },
     }) as Record<string, unknown>;
     expect(noTotal.paginationNote).toMatch(/reaches the end/);
     expect(noTotal.total).toBeUndefined();
   });
 
+  it('never lets an upstream key overwrite a COMPUTED paging value', () => {
+    // {...head, ...body} would leave an upstream `hasMore` sitting in the
+    // paging slot, reading as ours but sourced from elsewhere — worse than
+    // either losing the field or moving it.
+    const out = withPaginationFirst({
+      state: offsetState({ start: 0, max: 20, returned: 1, total: null, last: false, base: 0 }),
+      start: 0, max: 20, returned: 1, total: null, hint: 'x',
+      payload: { hasMore: false, nextStart: 999, paginationNote: 'upstream lies', returned: 4242, data: [{ id: 1 }] },
+    }) as Record<string, unknown>;
+
+    expect(out.hasMore).toBe(true);
+    expect(out.nextStart).toBe(20);
+    expect(out.returned).toBe(1);
+    expect(out.paginationNote).toMatch(/PARTIAL/);
+    // Values are ours; key ORDER is still paging-first.
+    const keys = Object.keys(out);
+    expect(keys[0]).toBe('hasMore');
+    expect(keys.indexOf('paginationNote')).toBeLessThan(keys.indexOf('data'));
+    // Non-colliding upstream keys are untouched.
+    expect(out.data).toEqual([{ id: 1 }]);
+  });
+
   it('returns null for a payload that cannot carry sibling keys, so the caller passes it through', () => {
     // Never relocate records to add a field: a bare array or a scalar keeps
     // its exact top-level shape instead.
     const args = {
-      state: offsetState({ start: 0, max: 20, returned: 0, total: null }),
+      state: offsetState({ start: 0, max: 20, returned: 0, total: null, base: 0 }),
       start: 0, max: 20, returned: 0, total: null, hint: 'x',
     };
     expect(withPaginationFirst({ ...args, payload: [{ id: 1 }] })).toBeNull();


### PR DESCRIPTION
Addresses the auto-review follow-ups from #229 (#230) and #232 (#233). Both PRs auto-merged before these could ride along, so this is the follow-up PR the convention calls for.

Three of the four nits were **real latent bugs**, not style.

## 1. `offsetState` assumed a 0-based offset; journal is 1-based

`ofw_list_journal_entries` passes a 1-based `start` (default 1), but the total fallback computed consumption as `start + returned`. That overstates by one and drops the final record:

```
journal, start:1 max:10 returned:10 total:11   (records 1..10 shown, 11 remains)
  start + returned      = 11 < 11 → false   ← "no more", record 11 lost
  (start - base) + ret  = 10 < 11 → true    ← correct
```

The base is now an explicit `base: 0 | 1` the caller must declare — expenses `0`, journal `1` — so it can't be assumed wrong again silently. Boundary test covers both tools in both directions, including exactly-none-remaining, so the fix doesn't trade a dropped record for an endless empty page.

**Latent, not live:** `metadata.last` is present on both endpoints and takes precedence, so the fallback rarely fires today. It fires the moment OFW stops sending `last`.

## 2. `readUpstreamPaging` counted only a `data` envelope

Any other envelope published `returned: 0` and a *"reaches the end of the list"* note **alongside real records** — precisely the shape of lie this module exists to prevent, reintroducible by a single backend rename. It now falls back to the first array-valued key; `data` still wins outright when present.

## 3. Upstream keys could overwrite computed paging values

`{...head, ...body}` let an upstream `hasMore` / `nextStart` / `paginationNote` overwrite ours *while keeping the head's key position* — a paging field sitting in the paging slot, reading as ours, sourced from elsewhere. That's worse than either losing the field or moving it. Now `{...head, ...body, ...head}`: our values win, and keys keep their first-insertion position so the order is unchanged. Regression test feeds a hostile payload (`hasMore: false, nextStart: 999, returned: 4242`) and asserts the computed values survive.

## 4. Doc nit (#233)

`CLAUDE.md`'s architecture tree still listed `truncationSentinel` as a `pagination.ts` export; #232 removed it. Now names `readUpstreamPaging`.

The fourth item on #230 — a stale comment claiming the sentinel carried no `subject` — was already resolved on `main` by #232 (f16eaa2), which deleted the sentinel and that comment with it. Ticked, not redone.

## Also

The journal tool test asserted against an `{entries: [...]}` envelope **neither endpoint returns** — it was the fixture that made nit #2 observable. It now uses the live-captured `{data, metadata}` shape.

## Verification

`npx tsc --noEmit` clean · 860 tests pass · 100% line/branch/function/statement coverage held · `npm run build` clean.

Closes #230
Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rvigMEubEUT91WA15yQPz