### PR TITLE
fix: narrow ofw mint.yaml egress and declare OFW_DEBUG_LOG

### DIFF
--- a/mint.yaml
+++ b/mint.yaml
@@ -69,6 +69,12 @@ env:
       field uses, and the zone a naive OFW timestamp is assumed to be in. Must
       match the OFW account's own zone. Never a fixed offset — that would be an
       hour wrong for half the year.
+  - name: OFW_DEBUG_LOG
+    required: false
+    help: >-
+      Set to 1 to write verbose request/response diagnostics to stderr. Off by
+      default; useful when a read is failing and you need to see the upstream
+      exchange.
   - name: OFW_AUTO_REFRESH
     required: false
     help: >-
@@ -122,4 +128,3 @@ egress:
     # Only hosts the SERVER process actually fetches. Hosts that appear
     # solely in a URL this server BUILDS and returns are excluded.
     - ofw.ourfamilywizard.com
-    - ourfamilywizard.com


### PR DESCRIPTION
The bare ourfamilywizard.com apex is never fetched server-side — only ofw.ourfamilywizard.com (BASE_URL) is; the apex is declared to the fetchproxy bridge, which the browser reaches rather than this process. OFW_DEBUG_LOG is a real documented variable read in src/client.ts and was inconsistently omitted.

Follow-up to the merged `mint.yaml` PR, addressing its auto-review findings.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)
