### PR TITLE
chore: group vitest with @vitest/* for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+        update-types:
+          - major
+          - minor
+          - patch
       dev-dependencies:
         dependency-type: development
         update-types:


### PR DESCRIPTION
## What

Adds a `vitest` group to `dependabot.yml`, listed **first** (the first matching group wins).

## Why

`vitest` and `@vitest/coverage-v8` peer-depend at an **exact** version. The stock `dev-dependencies` group covers only `minor` and `patch`, so a **major** escapes it and arrives as **two separate PRs** — each moving one half of a peer-locked pair. Both then fail `npm ci` with an unsatisfiable peer set, and re-running their jobs cannot help, because the failure is real rather than a wiring problem.

Grouping them means a major bump arrives as one PR that moves both halves together.

This is dormant until the next vitest major, at which point it would land red PRs across the fleet simultaneously — the fix is cheap now and awkward later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
