### PR TITLE
feat: cache the session token so a restart skips re-authenticating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,31 @@ npm run dev          # node --env-file=.env dist/index.js (requires built dist)
 
 `dist/` is gitignored — it is produced at build/release time and shipped in the npm package (`package.json` `files`).
 
+## Session cache
+
+`src/session-cache.ts` caches the bearer token at
+`$MCP_DATA_DIR/.ofw-mcp/session.json` (0600, `OFW_SESSION_FILE` overrides) via
+`createFileStatePersistence` + `resolveStateFile` (`@chrischall/mcp-utils/session`).
+
+OFW has no refresh grant — renewing IS logging in — so `mint()` serves as both
+`initial` and `refresh` on the `TokenManager`, and `isRefreshRevoked: () => false`
+turns off the library's re-mint-after-a-failed-refresh recovery, which here would
+just repeat the call that failed. The token lasts six hours, so on a scale-to-zero
+host the cache turns most cold starts into zero-cost ones.
+
+The cache is **disabled** in three cases, each deliberate: `OFW_SESSION_CACHE=false`;
+an injected `resolveAuth` (the per-user hosted path — this registration declares no
+`identity.perUserChild`, so one process can serve several people and a shared file
+would hand one user's session to the next); and no env credentials (the fetchproxy
+path authenticates from a browser tab, with nothing stable to bind a record to).
+
+The record is `boundTo` a salted digest of username+password, so rotating either
+discards it; neither value is written. A failed write is reported to stderr and is
+NOT fatal — OFW tokens are re-mintable from the environment.
+
+`tests/_setup.ts` forces the cache off and pins its path into a temp dir for the
+whole suite, so no test can reach the developer's real `~/.ofw-mcp`.
+
 ## Architecture
 
 ```

--- a/mint.yaml
+++ b/mint.yaml
@@ -116,13 +116,26 @@ env:
       the next call resumes where it left off. Set a positive integer when
       hosted, where a per-call request cap can otherwise truncate a deep
       backfill.
+  - name: OFW_SESSION_CACHE
+    required: false
+    help: >-
+      Set to false to disable the on-disk session cache and re-authenticate on
+      every process start. Defaults to enabled.
+  - name: OFW_SESSION_FILE
+    required: false
+    help: >-
+      Absolute path for the session cache file. Defaults to
+      $MCP_DATA_DIR/.ofw-mcp/session.json.
 state:
   dataDir: true
   reason: >-
-    The fetchproxy identity lives at $HOME/.fetchproxy/identity/<name>.json
-    and the pair code derives from it. Without a persistent $HOME every cold
-    start mints a fresh identity and re-prompts pairing in the browser; the
-    API refuses bridge without it.
+    Two things live here. The fetchproxy identity is at
+    $HOME/.fetchproxy/identity/<name>.json and the pair code derives from it —
+    without a persistent $HOME every cold start mints a fresh identity and
+    re-prompts pairing in the browser, and the API refuses bridge without it.
+    The session token is cached at $MCP_DATA_DIR/.ofw-mcp/session.json (0600);
+    OFW has no refresh grant, so without it every cold start re-runs the full
+    login for a token that was still good for up to six hours.
 egress:
   allow:
     # Only hosts the SERVER process actually fetches. Hosts that appear

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.11.0",
       "license": "MIT",
       "dependencies": {
-        "@chrischall/mcp-utils": "^0.15.0",
+        "@chrischall/mcp-utils": "^0.17.1",
         "@fetchproxy/bootstrap": "^2.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@chrischall/mcp-utils": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.15.0.tgz",
-      "integrity": "sha512-eXSt595EVAhWiHvLiMPqlowR/3Ef3cAFZaDUcuyYtZPheJ0+KW/WFcHJyxAzG4gdS/t982oqLamph5okJe6JlQ==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.17.1.tgz",
+      "integrity": "sha512-p1Sn8BmUNax69WDPSjNwpRzmJWWXP1BcxLIqlYA6411oPoiJo1kbiNfJL530gKrFHeeODSPQ8X9LVJc2ftc+3g==",
       "license": "MIT",
       "peerDependencies": {
         "@fetchproxy/server": "*",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@chrischall/mcp-utils": "^0.15.0",
+    "@chrischall/mcp-utils": "^0.17.1",
     "@fetchproxy/bootstrap": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,7 @@ import { TokenManager } from '@chrischall/mcp-utils/session';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { resolveAuth, type ResolvedAuth } from './auth.js';
+import { createSessionCache, reportCacheWriteFailure } from './session-cache.js';
 import { BASE_URL, OFW_PROTOCOL_HEADERS, OFW_TOKEN_TTL_MS, OFW_TOKEN_EXPIRY_SKEW_MS } from './protocol.js';
 
 // Load .env for local dev; silently skip if dotenv is unavailable (e.g. mcpb
@@ -87,22 +88,38 @@ export class OFWClient {
 
   private getTokenManager(): TokenManager {
     if (!this.tokenManager) {
+      // Minting and renewing are the SAME operation here — OFW has no refresh
+      // grant — so one function serves as both `initial` and `refresh`. It has
+      // to be the function form: the eager object form skips persistence, so
+      // the expired placeholder that used to sit here would have meant the
+      // cache was written but never read.
+      const mint = async (): Promise<{
+        accessToken: string;
+        refreshToken: string;
+        expiresAt: number;
+      }> => {
+        const { token, expiresAt } = await (this.authResolver ?? resolveAuth)();
+        return {
+          accessToken: token,
+          refreshToken: OFW_REFRESH_SENTINEL,
+          expiresAt: (expiresAt ?? new Date(Date.now() + OFW_TOKEN_TTL_MS)).getTime(),
+        };
+      };
       this.tokenManager = new TokenManager({
-        initial: { accessToken: '', refreshToken: OFW_REFRESH_SENTINEL, expiresAt: 0 },
+        initial: mint,
+        persistence:
+          createSessionCache({ injectedResolver: this.authResolver !== undefined }) ?? undefined,
+        onPersistError: reportCacheWriteFailure,
+        // A failed renewal IS a failed login here, so the library's
+        // re-mint-on-revoked recovery would just repeat the call that failed.
+        isRefreshRevoked: () => false,
         skewMs: OFW_TOKEN_EXPIRY_SKEW_MS,
         // Map OFW's mint/refresh onto the refresh callback. `resolveAuth()`
         // returns a token and a best-effort expiry; when the fetchproxy path
         // can't supply one we fall back to the same 6h estimate the password
         // path uses (the 401-replay covers a wrong guess). We re-arm the
         // sentinel so the manager can refresh again later.
-        refresh: async () => {
-          const { token, expiresAt } = await (this.authResolver ?? resolveAuth)();
-          return {
-            accessToken: token,
-            refreshToken: OFW_REFRESH_SENTINEL,
-            expiresAt: (expiresAt ?? new Date(Date.now() + OFW_TOKEN_TTL_MS)).getTime(),
-          };
-        },
+        refresh: mint,
       });
     }
     return this.tokenManager;

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -1,0 +1,97 @@
+import {
+  createFileStatePersistence,
+  resolveStateFile,
+  type BearerTokens,
+  type SyncStatePersistence,
+} from '@chrischall/mcp-utils/session';
+import { readEnvVar, parseBoolEnv } from '@chrischall/mcp-utils';
+
+/**
+ * Where the OFW session token is cached between runs.
+ *
+ * OFW has no OAuth refresh token — every renewal re-runs the full
+ * `resolveAuth()` (a password POST, or a fetchproxy snapshot). The token itself
+ * is good for six hours (`OFW_TOKEN_TTL_MS`), so on a scale-to-zero host, where
+ * children idle out after ten minutes and every start is a cold one, the same
+ * six-hour token was being re-minted many times over. Caching it turns those
+ * restarts into zero-cost ones; an expired token still costs exactly what it did
+ * before.
+ */
+export function sessionCachePath(env: NodeJS.ProcessEnv = process.env): string {
+  return resolveStateFile({
+    env,
+    envVar: 'OFW_SESSION_FILE',
+    subdir: '.ofw-mcp',
+    fileName: 'session.json',
+  });
+}
+
+/** Only a token pair is ever stored — never the username or password. */
+function isTokens(raw: unknown): raw is BearerTokens {
+  if (raw === null || typeof raw !== 'object') return false;
+  const t = raw as Partial<BearerTokens>;
+  return (
+    typeof t.accessToken === 'string' &&
+    t.accessToken !== '' &&
+    typeof t.expiresAt === 'number' &&
+    (t.refreshToken === undefined || typeof t.refreshToken === 'string')
+  );
+}
+
+/** Options for {@link createSessionCache}. */
+export interface SessionCacheOptions {
+  env?: NodeJS.ProcessEnv;
+  /** True when the caller supplied its own auth resolver — see below. */
+  injectedResolver?: boolean;
+}
+
+/**
+ * The session cache, or `null` when it must not be used.
+ *
+ * Three ways it comes back `null`, each deliberate:
+ *
+ *  - `OFW_SESSION_CACHE=false` — the operator opted out.
+ *  - **A caller-injected auth resolver.** That is the per-user hosted path, and
+ *    this registration declares no `identity.perUserChild`, so one process can
+ *    serve several people. A single cache file would hand one user's session to
+ *    the next; until the child is per-user, that path simply does not cache.
+ *  - **No env credentials.** The fetchproxy path authenticates from a signed-in
+ *    browser tab rather than a stored secret, so there is nothing stable to bind
+ *    a cached token to — and it is local-only, where cold starts are rare.
+ *
+ * When it is used, the record is bound to the credentials that minted it, so
+ * rotating either discards it. Only a salted digest is written.
+ */
+export function createSessionCache(
+  opts: SessionCacheOptions = {},
+): SyncStatePersistence<BearerTokens> | null {
+  const env = opts.env ?? process.env;
+  if (opts.injectedResolver === true) return null;
+  if (!parseBoolEnv('OFW_SESSION_CACHE', { env, default: true })) return null;
+  const username = readEnvVar('OFW_USERNAME', { env });
+  const password = readEnvVar('OFW_PASSWORD', { env });
+  if (username === undefined || password === undefined) return null;
+
+  return createFileStatePersistence<BearerTokens>({
+    filePath: sessionCachePath(env),
+    // Joined on a NUL, written as an escape rather than a literal byte: a
+    // password may contain spaces, so a space-joined pair could collide with
+    // a different pair by shifting the boundary between the two halves.
+    boundTo: [username.trim().toLowerCase(), password].join('\u0000'),
+    validate: (raw) => (isTokens(raw) ? raw : null),
+  });
+}
+
+/**
+ * Report a cache write that failed. Not fatal: OFW tokens are re-mintable from
+ * the credentials in the environment, so a lost write costs the next start a
+ * login rather than access. Still worth saying — a read-only data dir otherwise
+ * looks exactly like a server that never caches. stderr only; stdout is JSON-RPC.
+ */
+export function reportCacheWriteFailure(err: unknown): void {
+  const detail = err instanceof Error ? err.message : String(err);
+  console.error(
+    `[ofw-mcp] could not cache the session token (${detail}); continuing without the ` +
+      'cache — every restart will re-authenticate until this is fixed.',
+  );
+}

--- a/tests/_setup.ts
+++ b/tests/_setup.ts
@@ -1,0 +1,30 @@
+// Suite-wide guard: no test may touch the developer's real session cache.
+//
+// `createSessionCache` resolves its path from MCP_DATA_DIR/HOME, so any test
+// that happens to have OFW_USERNAME + OFW_PASSWORD set would read and write
+// ~/.ofw-mcp/session.json — making the suite non-hermetic, order-dependent, and
+// (worse) able to leave a real file behind. An earlier run of this branch did
+// exactly that before this file existed.
+//
+// Two independent guards, deliberately belt-and-braces:
+//   1. The cache is OFF by default, so the ordinary suite never constructs one.
+//   2. The path is pinned into a temp dir anyway, so a test that turns the cache
+//      ON to exercise it still cannot reach $HOME.
+//
+// A cache test opts in with `process.env.OFW_SESSION_CACHE = 'true'` and gets
+// the temp path for free.
+import { beforeEach, afterAll } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CACHE_DIR = mkdtempSync(join(tmpdir(), 'ofw-test-cache-'));
+
+beforeEach(() => {
+  process.env.OFW_SESSION_CACHE = 'false';
+  process.env.OFW_SESSION_FILE = join(CACHE_DIR, 'session.json');
+});
+
+afterAll(() => {
+  rmSync(CACHE_DIR, { recursive: true, force: true });
+});

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -845,6 +845,28 @@ describe('OFWClient — config/auth fallback branches', () => {
     await client.request('GET', '/pub/v1/x');
     expect(spy).toHaveBeenCalled();
   });
+
+  it('does not re-mint after a failed renewal', async () => {
+    // OFW has no refresh grant: renewing IS logging in. So a failed renewal
+    // must surface, not trigger the library's re-mint-on-revoked recovery,
+    // which would repeat the exact call that just failed against a login
+    // endpoint. (`isRefreshRevoked: () => false` is what turns that off.)
+    const auth = await import('../src/auth.js');
+    // The bootstrap must SUCCEED first — a failed bootstrap never reaches the
+    // recovery path, so mocking a straight rejection would exercise nothing.
+    // Hand back an already-expired token so the next request forces a renewal,
+    // and fail that.
+    const spy = vi
+      .spyOn(auth, 'resolveAuth')
+      .mockResolvedValueOnce({ token: 'expired', expiresAt: new Date(Date.now() - 1) })
+      .mockRejectedValue(new Error('OFW login failed — check OFW_USERNAME/OFW_PASSWORD'));
+    mockFetch([]);
+    const client = new OFWClient();
+    await expect(client.request('GET', '/pub/v1/x')).rejects.toThrow(/OFW login failed/);
+    // Twice: the bootstrap, then the one failed renewal. A third would be the
+    // re-mint this deliberately turns off.
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('OFWClient — injectable auth resolver', () => {

--- a/tests/session-cache.test.ts
+++ b/tests/session-cache.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  sessionCachePath,
+  createSessionCache,
+  reportCacheWriteFailure,
+} from '../src/session-cache.js';
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'ofw-cache-'));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/** A full env with credentials and the cache enabled. */
+const withCreds = (over: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => ({
+  OFW_USERNAME: 'user@example.com',
+  OFW_PASSWORD: 'pw1',
+  OFW_SESSION_CACHE: 'true',
+  ...over,
+});
+
+describe('sessionCachePath', () => {
+  it('prefers MCP_DATA_DIR, the variable mcp-host injects', () => {
+    expect(sessionCachePath({ MCP_DATA_DIR: '/data' })).toBe('/data/.ofw-mcp/session.json');
+  });
+
+  it('honours an explicit OFW_SESSION_FILE', () => {
+    expect(sessionCachePath({ OFW_SESSION_FILE: '/tmp/x.json', MCP_DATA_DIR: '/data' })).toBe(
+      '/tmp/x.json',
+    );
+  });
+
+  it('ignores a sentinel or placeholder override', () => {
+    // A relative "./null" would park the session under the process cwd.
+    expect(sessionCachePath({ OFW_SESSION_FILE: 'null', HOME: '/home/u' })).toBe(
+      '/home/u/.ofw-mcp/session.json',
+    );
+  });
+});
+
+describe('createSessionCache', () => {
+  it('round-trips a token through a 0600 file', () => {
+    const env = withCreds({ MCP_DATA_DIR: dir });
+    const p = createSessionCache({ env })!;
+    expect(p).not.toBeNull();
+    p.save({ accessToken: 'TOK', expiresAt: Date.now() + 3_600_000 });
+    const file = join(dir, '.ofw-mcp', 'session.json');
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+    expect(createSessionCache({ env })!.load()).toEqual(
+      expect.objectContaining({ accessToken: 'TOK' }),
+    );
+  });
+
+  it('discards the cache when the password is rotated', () => {
+    const env = withCreds({ MCP_DATA_DIR: dir });
+    createSessionCache({ env })!.save({ accessToken: 'TOK', expiresAt: 1 });
+    const rotated = createSessionCache({ env: withCreds({ MCP_DATA_DIR: dir, OFW_PASSWORD: 'pw2' }) })!;
+    expect(rotated.load()).toBeNull();
+  });
+
+  it('discards the cache when the account changes', () => {
+    const env = withCreds({ MCP_DATA_DIR: dir });
+    createSessionCache({ env })!.save({ accessToken: 'TOK', expiresAt: 1 });
+    const other = createSessionCache({
+      env: withCreds({ MCP_DATA_DIR: dir, OFW_USERNAME: 'someone@else.com' }),
+    })!;
+    expect(other.load()).toBeNull();
+  });
+
+  it('matches the username case-insensitively', () => {
+    const env = withCreds({ MCP_DATA_DIR: dir });
+    createSessionCache({ env })!.save({ accessToken: 'TOK', expiresAt: 1 });
+    const cased = createSessionCache({
+      env: withCreds({ MCP_DATA_DIR: dir, OFW_USERNAME: '  User@Example.COM ' }),
+    })!;
+    expect(cased.load()).toEqual(expect.objectContaining({ accessToken: 'TOK' }));
+  });
+
+  it('writes neither the username nor the password', () => {
+    const env = withCreds({ MCP_DATA_DIR: dir });
+    createSessionCache({ env })!.save({ accessToken: 'TOK', expiresAt: 1 });
+    const body = readFileSync(join(dir, '.ofw-mcp', 'session.json'), 'utf8');
+    expect(body).not.toContain('pw1');
+    expect(body).not.toContain('user@example.com');
+  });
+
+  it('rejects a stored record that is not a token', () => {
+    const env = withCreds({ MCP_DATA_DIR: dir });
+    createSessionCache({ env })!.save({ accessToken: 'TOK', expiresAt: 1 });
+    writeFileSync(join(dir, '.ofw-mcp', 'session.json'), JSON.stringify({ nope: 1 }), {
+      mode: 0o600,
+    });
+    expect(createSessionCache({ env })!.load()).toBeNull();
+  });
+
+  it.each([
+    ['null', null],
+    ['a primitive', 'nope'],
+    ['an array', []],
+    ['a missing accessToken', { expiresAt: 1 }],
+    ['an empty accessToken', { accessToken: '', expiresAt: 1 }],
+    ['a non-numeric expiresAt', { accessToken: 'T', expiresAt: 'soon' }],
+    ['a non-string refreshToken', { accessToken: 'T', refreshToken: 7, expiresAt: 1 }],
+  ])('rejects %s rather than handing it to the token manager', (_label, body) => {
+    const env = withCreds({ MCP_DATA_DIR: dir });
+    const file = join(dir, '.ofw-mcp', 'session.json');
+    createSessionCache({ env })!.save({ accessToken: 'seed', expiresAt: 1 });
+    // Swap only the STATE, keeping the envelope's salted binding intact.
+    // Overwriting the whole file would be rejected by the binding check before
+    // the shape guard ever ran — which is the wrong reason to pass this test.
+    const envelope = JSON.parse(readFileSync(file, 'utf8')) as { state: unknown };
+    envelope.state = body;
+    writeFileSync(file, JSON.stringify(envelope), { mode: 0o600 });
+    expect(createSessionCache({ env })!.load()).toBeNull();
+  });
+
+  it('accepts a record with no refreshToken', () => {
+    const env = withCreds({ MCP_DATA_DIR: dir });
+    const p = createSessionCache({ env })!;
+    p.save({ accessToken: 'TOK', expiresAt: 42 });
+    expect(p.load()).toEqual({ accessToken: 'TOK', expiresAt: 42 });
+  });
+
+  it.each([
+    ['an injected per-user resolver', { injectedResolver: true }, withCreds({ MCP_DATA_DIR: '/x' })],
+    ['OFW_SESSION_CACHE=false', {}, withCreds({ MCP_DATA_DIR: '/x', OFW_SESSION_CACHE: 'false' })],
+    ['no username', {}, { OFW_PASSWORD: 'pw', MCP_DATA_DIR: '/x' }],
+    ['no password', {}, { OFW_USERNAME: 'u', MCP_DATA_DIR: '/x' }],
+  ])('is disabled for %s', (_label, opts, env) => {
+    expect(createSessionCache({ ...opts, env })).toBeNull();
+  });
+
+  it('writes nothing at all when disabled', () => {
+    const env = withCreds({ MCP_DATA_DIR: dir, OFW_SESSION_CACHE: 'false' });
+    expect(createSessionCache({ env })).toBeNull();
+    expect(existsSync(join(dir, '.ofw-mcp'))).toBe(false);
+  });
+
+  it('does not share one file between two users of the same process', () => {
+    // The per-user hosted path injects its own resolver. With no
+    // identity.perUserChild on the registration, a shared file would hand one
+    // user's session to the next — so that path must not cache at all.
+    const env = withCreds({ MCP_DATA_DIR: dir });
+    createSessionCache({ env })!.save({ accessToken: 'ALICE', expiresAt: Date.now() + 3_600_000 });
+    expect(createSessionCache({ env, injectedResolver: true })).toBeNull();
+  });
+});
+
+describe('reportCacheWriteFailure', () => {
+  it.each([
+    ['an Error', new Error('EROFS'), 'EROFS'],
+    ['a non-Error', 'disk gone', 'disk gone'],
+  ])('names the cause for %s and stays on stderr', (_label, thrown, expected) => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const out = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      reportCacheWriteFailure(thrown);
+      expect(err).toHaveBeenCalledWith(expect.stringContaining(expected as string));
+      // stdout is the JSON-RPC channel; a stray write there corrupts the stream.
+      expect(out).not.toHaveBeenCalled();
+    } finally {
+      err.mockRestore();
+      out.mockRestore();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,9 @@ import { configDefaults, defineConfig } from 'vitest/config';
 // `npm test` stays coverage-free for fast local iteration.
 export default defineConfig({
   test: {
+    // Forces the session cache off and pins its path into a temp dir, so no
+    // test can read or write the developer's real ~/.ofw-mcp — see tests/_setup.ts.
+    setupFiles: ['./tests/_setup.ts'],
     exclude: [
       ...configDefaults.exclude,
       // Nested checkouts of this same repo — agent worktrees under


### PR DESCRIPTION
Step 4 of the persistence rollout — first of the repos that persisted nothing.

## Why it pays here

OFW has **no refresh grant**: every renewal re-runs the full `resolveAuth()`. The token itself is good for six hours, so on a scale-to-zero host — children idle out after ten minutes, every start is cold — the same six-hour token was being re-minted many times over.

`mint()` now serves as both `initial` and `refresh`. It has to be the **function** form of `initial`: the eager object form skips persistence entirely, so the expired placeholder that used to sit there would have meant a cache that was written and never read. `isRefreshRevoked` is off, because a failed renewal *is* a failed login here and the library's re-mint recovery would just repeat the call that failed.

## Where it deliberately does nothing

- `OFW_SESSION_CACHE=false`.
- **An injected `resolveAuth`.** That's the per-user hosted path, and this registration declares no `identity.perUserChild` — so one process can serve several people, and a single cache file would hand one user's session to the next.
- **No env credentials.** The fetchproxy path authenticates from a signed-in browser tab, so there's nothing stable to bind a record to, and it's local-only where cold starts are rare.

Bound to a salted digest of username+password, so rotating either discards it; neither value is written. A failed write reports to stderr and is **not** fatal — unlike freshbooks, these tokens are re-mintable from the environment.

## `tests/_setup.ts` is the part worth reading

With credentials in the environment the cache resolves to `~/.ofw-mcp`, and an earlier run of this branch **created a real `session.json` there** — 44 tests failed because they were reading a cached token instead of calling `resolveAuth`. Same trap the skylight adoption hit.

The setup file forces the cache off *and* pins its path into a temp dir for the whole suite, so no test can reach `$HOME` whether or not it enables the cache. One place rather than 44 edits, and it generalises to the remaining adoptions.

## Two tests that passed for the wrong reason

Both caught before opening this:

- The shape-guard cases overwrote the **whole** store file, so the binding check rejected them before `isTokens` ever ran. They now swap only the envelope's `state`, leaving the salted binding intact.
- The `isRefreshRevoked` case mocked a rejected bootstrap — which never reaches the recovery path that option governs. It now succeeds once with an already-expired token, then fails the renewal.

Coverage was the tell: both showed green while the target lines stayed uncovered.

## Verification

886 tests at **100% coverage**, build clean, `~/.ofw-mcp` absent after a full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeTmnw2MTeKZViGhYYWZ3Y