### PR TITLE
docs: correct the tokenManager comment left stale by the session cache

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -69,9 +69,9 @@ export class OFWClient {
   // Bearer-token lifecycle is delegated to the shared, race-safe TokenManager
   // (proactive refresh inside the skew window, single-flight refresh so a burst
   // of concurrent callers coalesces onto ONE `resolveAuth()`, and a 401-replay
-  // guarded against double-refresh). It is created lazily, seeded with an
-  // already-expired placeholder token so the first request drives the refresh
-  // callback — i.e. the original "log in on first request" behavior.
+  // guarded against double-refresh). It is created lazily, and mints on first
+  // use through the function form of `initial` — see `mint` below for why that
+  // form rather than a seeded placeholder.
   private tokenManager: TokenManager | undefined;
 
   // Optional injected auth resolver. When set, the refresh callback uses it


### PR DESCRIPTION
Closes #245.

The `tokenManager` field's comment still described the eager expired-placeholder seeding that #244 replaced, contradicting the note above `mint` four lines down. The nit is right, and it's the same stale-doc class that's come up repeatedly in this series — I changed the code around the comment without re-reading it.

Checked the two neighbouring `placeholder` mentions while here: the sentinel comment at `client.ts:64` is still accurate (the sentinel is still what keeps the refresh path live), and the one inside `mint` is a deliberate historical reference.

886 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeTmnw2MTeKZViGhYYWZ3Y