### PR TITLE
ci: typecheck in the test script, so CI actually checks types

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
     "build": "tsc && npm run bundle",
     "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --external:dotenv --banner:js='import { createRequire as __createRequire } from \"module\"; const require = __createRequire(import.meta.url);' --outfile=dist/bundle.js",
     "dev": "node --env-file=.env dist/index.js",
-    "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
-    "test:watch": "vitest"
+    "test": "npm run typecheck && vitest run",
+    "test:coverage": "npm run typecheck && vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@chrischall/mcp-utils": "^0.17.1",


### PR DESCRIPTION
## Why

`npm test` here was `vitest run`. vitest transpiles with **esbuild**, which strips types without checking them — it never invokes `tsc`. CI's `test-command` runs that script and nothing else, so **a TypeScript error in this repo reaches `main` green**: neither a local `npm test` nor CI would catch it.

A sweep of the fleet found this in **62 of 64 repos** — only `gemini-mcp` and `skill-mcp` already chained a typecheck into their test script.

## Why it is safe

All 62 repos typecheck clean today, so the gate turns on with nothing to repair. (Four repos appeared to have errors on a first pass; every one was stale local `node_modules` — an old `@chrischall/mcp-utils` against a `^0.15.0` dependency — and all four were clean after `npm ci`.)

## The change

- `typecheck` script (`tsc -p tsconfig.json --noEmit`) where the repo lacked one.
- Chained into **both** `test` and `test:coverage`. CI calls one or the other depending on the repo; gating only `test` would have left 18 of the fleet unguarded.

Per fleet convention the gate goes in the **test script**, not the workflow file — a PR touching `.github/workflows/*` cannot be auto-reviewed and would need a manual merge.

`npm test` green with the gate in place.
