### PR TITLE
test: fail the suite if anything writes to the real home directory

### DIFF
--- a/tests/_setup.ts
+++ b/tests/_setup.ts
@@ -14,8 +14,8 @@
 // A cache test opts in with `process.env.OFW_SESSION_CACHE = 'true'` and gets
 // the temp path for free.
 import { beforeEach, afterAll } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
 
 const CACHE_DIR = mkdtempSync(join(tmpdir(), 'ofw-test-cache-'));
@@ -27,4 +27,20 @@ beforeEach(() => {
 
 afterAll(() => {
   rmSync(CACHE_DIR, { recursive: true, force: true });
+
+  // The tripwire, and why the guards above are not enough on their own: both
+  // work through process.env, and a client that reads an INJECTED env bypasses
+  // them completely — the path resolver then falls back to os.homedir(), which
+  // no environment variable can redirect. Fixing exactly that plumbing in
+  // schoolpass-mcp is what created a real file under $HOME.
+  //
+  // So assert the outcome rather than the mechanism.
+  const leaked = join(homedir(), '.ofw-mcp');
+  if (existsSync(leaked)) {
+    throw new Error(
+      `A test wrote to ${leaked}. The suite must never touch the real home ` +
+        'directory — inject OFW_SESSION_CACHE=false (or a temp OFW_SESSION_FILE) ' +
+        'into the env that test hands the client.',
+    );
+  }
 });


### PR DESCRIPTION
Back-port from chrischall/schoolpass-mcp#13, where this class of bug actually bit.

## Why the existing guard isn't enough

`tests/_setup.ts` disables the cache and pins its path **through `process.env`**. That covers a client reading the ambient environment — but a client reading an **injected** env bypasses it completely, and the path resolver then falls back to `os.homedir()`, which no environment variable can redirect.

That's not hypothetical. In schoolpass-mcp, `createSessionCache` was mistakenly reading `process.env` instead of the client's injected env. The suite passed — because it was disabling the cache through exactly the channel the bug read. Fixing the plumbing immediately wrote a real `~/.schoolpass-mcp/session.json`.

So the guard now asserts the **outcome** rather than the mechanism: an `afterAll` tripwire that fails the suite if anything reached the developer's home directory, with a message naming the fix.

## Verified it fires

Not added on faith — a guard that can't fail is the same decorative problem in a new costume. With a stray directory present:

```
Error: A test wrote to ~/<dir>. The suite must never touch the real home
directory — inject <CACHE_VAR>=false (or a temp <FILE_VAR>) into the env that
test hands the client.
```

and the whole suite fails. Removed, it passes.

## Scope

Test-only. No production code, no behaviour change — the existing tests all pass untouched.

The `$HOME` trap has now fired four times across this rollout (skylight, ofw, canvas-parent, schoolpass). Each time I fixed the instance; this covers the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeTmnw2MTeKZViGhYYWZ3Y
