### PR TITLE
test: clean up the leaked file before the tripwire throws

### DIFF
--- a/tests/_setup.ts
+++ b/tests/_setup.ts
@@ -37,6 +37,11 @@ afterAll(() => {
   // So assert the outcome rather than the mechanism.
   const leaked = join(homedir(), '.ofw-mcp');
   if (existsSync(leaked)) {
+    // Remove it BEFORE throwing. Detecting the leak and leaving it behind
+    // pollutes the developer's home directory with the very file the guard
+    // exists to prevent — and the next run would then fail on the debris of
+    // the last one rather than on anything it did itself.
+    rmSync(leaked, { recursive: true, force: true });
     throw new Error(
       `A test wrote to ${leaked}. The suite must never touch the real home ` +
         'directory — inject OFW_SESSION_CACHE=false (or a temp OFW_SESSION_FILE) ' +


### PR DESCRIPTION
Follow-up nit from chrischall/schoolpass-mcp#14, fixed across every repo carrying the guard.

The `afterAll` tripwire detected a leaked real-home file and threw, but never removed it. Two problems with that:

- It leaves the developer's home directory polluted with **exactly the file the guard exists to prevent**.
- The next run then fails on the debris of the last one rather than on anything it did itself — so a single regression looks permanently broken until someone deletes the directory by hand.

It now removes the leak before throwing. The message is unchanged, so the actionable part still names the fix.

**Verified both halves still hold:** with a stray directory present the suite fails with the tripwire message, and the directory is gone afterwards. A guard that stopped firing would be worse than one that littered.

Test-only; no production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeTmnw2MTeKZViGhYYWZ3Y
