### PR TITLE
docs: npm test now typechecks before running vitest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ MCP server for OurFamilyWizard (OFW). Reads/writes messages, calendar, expenses,
 
 ```bash
 npm run build        # tsc → dist/, then esbuild bundle → dist/bundle.js
-npm test             # vitest run (all tests)
+npm test             # tsc typecheck + vitest run (all tests)
 npm run test:watch   # vitest in watch mode
 npm run dev          # node --env-file=.env dist/index.js (requires built dist)
 ```
@@ -190,7 +190,9 @@ When adding a new endpoint call, define a loose schema next to the call site and
 ## Testing
 
 ```bash
-npm test           # vitest run
+npm test           # tsc typecheck + vitest run — a green suite is not a
+                   #   green typecheck on its own (vitest transpiles with
+                   #   esbuild and never invokes tsc)
 ```
 
 `vitest.config.ts` enforces 100% line/branch/function/statement coverage on `src/**` (excluding `src/index.ts`, the stdio entry point). Failing coverage fails CI. No real API calls — `OFWClient.request` is mocked via `vi.spyOn`.


### PR DESCRIPTION
Closes #248 — the follow-up on #247.

`npm test` now runs the typecheck first; CLAUDE.md described it as plain `vitest run` in **both** places it appears (the nit named one; the other was two lines of the same claim further down).

Stated *why* the ordering matters at the second one rather than only what it does: vitest transpiles with esbuild and never invokes `tsc`, so a green suite is not a green typecheck on its own — which is the reason the change was worth making.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeTmnw2MTeKZViGhYYWZ3Y