### PR TITLE
docs(readme): npm test now typechecks before running vitest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ MCP server for OurFamilyWizard (OFW). Reads/writes messages, calendar, expenses,
 
 ```bash
 npm run build        # tsc → dist/, then esbuild bundle → dist/bundle.js
-npm test             # vitest run (all tests)
+npm test             # tsc typecheck + vitest run (all tests)
 npm run test:watch   # vitest in watch mode
 npm run dev          # node --env-file=.env dist/index.js (requires built dist)
 ```
@@ -190,7 +190,9 @@ When adding a new endpoint call, define a loose schema next to the call site and
 ## Testing
 
 ```bash
-npm test           # vitest run
+npm test           # tsc typecheck + vitest run — a green suite is not a
+                   #   green typecheck on its own (vitest transpiles with
+                   #   esbuild and never invokes tsc)
 ```
 
 `vitest.config.ts` enforces 100% line/branch/function/statement coverage on `src/**` (excluding `src/index.ts`, the stdio entry point). Failing coverage fails CI. No real API calls — `OFWClient.request` is mocked via `vi.spyOn`.

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Calendar events sit between the two message tiers: they have no draft stage (a c
 ## Development
 
 ```bash
-npm test         # run the vitest suite
+npm test         # tsc typecheck, then the vitest suite
 npm run build    # tsc → dist/, then esbuild bundle → dist/bundle.js
 npm run dev      # node --env-file=.env dist/index.js (requires built dist)
 ```


### PR DESCRIPTION
## Why

The typecheck gate chained `npm run typecheck` into `test` (and `test:coverage`), and the README's commands block still described it as a plain vitest run.

This is the same drift as the `CLAUDE.md` fix, one file over — auto-review caught it there, then caught the README on the fix itself. So this time I swept **every gated repo's README**, not only the ones a reviewer happened to flag, which is what let it recur in the first place.

## Scope

Comment text in the commands block only. No scripts, no behaviour.
