### PR TITLE
docs: list the cache env vars in server.json and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ OFW_PASSWORD=your-password
 # bodies by default (each one stamps a First Viewed time). Capped by
 # OFW_ALLOW_MARK_READ.
 # OFW_FETCH_UNREAD_BODIES=false
+
+# Optional: the session is cached between runs so a restart does not
+# re-authenticate. Set to false to turn that off.
+# OFW_SESSION_CACHE=false
+# Optional: where that cache lives. Defaults to $MCP_DATA_DIR/.ofw-mcp/session.json.
+# OFW_SESSION_FILE=/path/to/cache.json

--- a/server.json
+++ b/server.json
@@ -52,6 +52,18 @@
           "description": "Default \"false\". Whether ofw_sync_messages fetches unread inbox bodies by default (each fetch stamps a First Viewed time). Capped by OFW_ALLOW_MARK_READ.",
           "isRequired": false,
           "format": "string"
+        },
+        {
+          "name": "OFW_SESSION_CACHE",
+          "description": "Set to false to disable the on-disk session cache and re-authenticate on every process start. Defaults to enabled.",
+          "isRequired": false,
+          "format": "string"
+        },
+        {
+          "name": "OFW_SESSION_FILE",
+          "description": "Absolute path for the session cache file. Defaults to $MCP_DATA_DIR/.ofw-mcp/session.json.",
+          "isRequired": false,
+          "format": "string"
         }
       ]
     }


### PR DESCRIPTION
The session/token cache PR documented its two new env vars in `mint.yaml` and nowhere else. This adds them to the surfaces that also enumerate optional variables.

## Which surfaces, and which deliberately not

I checked the repo's own convention rather than adding them everywhere they'd fit:

- **`server.json`** — lists every variable including optional ones, so the cache vars belong here. This is the MCP registry surface, so an omission is user-visible.
- **`.env.example`** — documents optional vars as commented lines; same treatment.
- **`manifest.json` — deliberately NOT.** Its `user_config` carries only credentials; existing optional knobs aren't there either. Adding tuning flags would prompt for them at install, which isn't what they are.

## Verification

`server.json` diffs are **purely additive — zero deletions**, which took a second attempt: `json.dump` defaults to `ensure_ascii=True` and my first pass escaped every em-dash in the existing descriptions to `—`. Reverted and redone with `ensure_ascii=False`.

Full suite green, including the version-sync tests that read `server.json`.

Part of a sweep across the ten repos in the persistence rollout — I'd been updating `mint.yaml` consistently and everything else inconsistently, which two reviews flagged (chrischall/artsonia-mcp#114, chrischall/crowntowncompost-mcp#29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeTmnw2MTeKZViGhYYWZ3Y
