### PR TITLE
refactor(auth): take the path ordering from resolveAuthPattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,15 +120,21 @@ The allowlist covers the freshness/sync bookkeeping fields (`lastServerSyncAt`, 
 
 `.env` (project root) is loaded by `client.ts` via dynamic `dotenv` import (silently skipped if unavailable, e.g. inside the mcpb bundle). Real env vars take precedence (`override: false`).
 
-## Auth resolution (Pattern A template)
+## Auth resolution (Pattern A, on the shared resolver)
 
-`src/auth.ts` is the canonical "browser-bootstrap + Node-direct" auth shape used across our MCP servers. Six sibling MCPs model their auth on this file — keep the structure flat, the path-selection explicit, the error messages actionable. Three paths in priority order:
+`src/auth.ts` used to BE the canonical "browser-bootstrap + Node-direct" shape, and this section told six sibling MCPs to model their auth on it. That shape now lives in **`resolveAuthPattern`** (`@chrischall/mcp-utils`), which owns the one thing every copy had to agree on — the priority order `token → oauth → sessionScrape → fetchproxy` — and nothing else. `resolveAuth()` declares which paths are *configured* and the shared resolver runs the first one; the precedence is no longer an if/else here.
+
+What stays local is what is genuinely OFW's: how each path obtains a token, and what to say when none can. In particular the "nothing configured" error is raised here rather than letting the shared resolver throw its generic one, because OFW's names both fixes side by side.
+
+The migration waited on somewhere to put the expiry: the shared result carried `{ credential, source }` only, so adopting it meant discarding the `tokenExpiry` this file reads from the browser tab — which is the whole reason it reads it. `PatternResult.expiresAt` closed that gap (mcp-utils#148). If you migrate a sibling MCP, that field is why it is now lossless.
+
+Three paths in priority order:
 
 1. **Env-var credentials** (`OFW_USERNAME` + `OFW_PASSWORD`) → `src/auth-password.ts` does the legacy Spring Security form login. Unchanged from pre-fetchproxy behavior.
 2. **fetchproxy fallback** → `@fetchproxy/bootstrap` snapshots `localStorage["auth"]` + `localStorage["tokenExpiry"]` from a signed-in `ourfamilywizard.com` tab in ~one round-trip, then closes the bridge. All subsequent OFW API calls go out via direct Node fetch — fetchproxy is NOT in the hot path.
 3. **Error** → tells the user how to fix it (set creds, OR install the extension and sign in).
 
-The split into `auth.ts` + `auth-password.ts` is deliberate: tests mock `auth-password.js` and `@fetchproxy/bootstrap` at the module boundary, so path-selection logic in `resolveAuth()` stays independent of either implementation. Sibling MCPs should copy this split.
+The split into `auth.ts` + `auth-password.ts` is deliberate: tests mock `auth-password.js` and `@fetchproxy/bootstrap` at the module boundary, so path-selection logic in `resolveAuth()` stays independent of either implementation. Sibling MCPs should copy this split — and take the ordering from `resolveAuthPattern` rather than re-deriving it.
 
 ## Message Cache
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.11.0",
       "license": "MIT",
       "dependencies": {
-        "@chrischall/mcp-utils": "^0.17.1",
+        "@chrischall/mcp-utils": "0.18.0",
         "@fetchproxy/bootstrap": "^2.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@chrischall/mcp-utils": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.17.1.tgz",
-      "integrity": "sha512-p1Sn8BmUNax69WDPSjNwpRzmJWWXP1BcxLIqlYA6411oPoiJo1kbiNfJL530gKrFHeeODSPQ8X9LVJc2ftc+3g==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.18.0.tgz",
+      "integrity": "sha512-he6MrmIKjJOAXjEL8NLig4B5DvHqmSGBw88Xr3CR9MIJAFq0WKWd/0BuMt4/8mMLV+0piJWzpjQYCUlyf+3Xeg==",
       "license": "MIT",
       "peerDependencies": {
         "@fetchproxy/server": "*",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@chrischall/mcp-utils": "^0.17.1",
+    "@chrischall/mcp-utils": "^0.18.0",
     "@fetchproxy/bootstrap": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,16 +1,23 @@
 // ────────────────────────────────────────────────────────────────────────────
-// Auth resolution — Pattern A template
+// Auth resolution — Pattern A, on the shared resolver
 // ────────────────────────────────────────────────────────────────────────────
 //
-// This file is the canonical shape for "browser-bootstrap + Node-direct"
-// auth used across our MCP servers. The other six MCPs in this family
-// (resy-mcp, opentable-mcp, splitwise-mcp, …) will model their auth
-// resolution after this one — keep the structure flat, the path-selection
-// explicit, and the error messages actionable.
+// This file used to BE the canonical shape, and said so: the other MCPs in
+// this family were told to model their resolution on it. That shape now lives
+// in `resolveAuthPattern` (@chrischall/mcp-utils), which owns the one thing
+// every copy of it had to agree on — the priority order — and nothing else.
+// What stays here is what is genuinely OFW's: how each path gets a token, and
+// what to say when it cannot.
 //
-// THE THREE PATHS, in priority order:
+// The migration waited on somewhere to put the expiry. The shared result
+// carried `{ credential, source }` only, so adopting it meant discarding the
+// `tokenExpiry` this file reads from the browser tab — which is the whole
+// reason it reads it. `PatternResult.expiresAt` closed that (mcp-utils#148).
 //
-//   1. Env-var credentials (existing behavior)
+// THE THREE PATHS, in priority order — now expressed by which resolvers are
+// PROVIDED, since `resolveAuthPattern` runs the first configured one:
+//
+//   1. Env-var credentials (`sessionScrape`)
 //      OFW_USERNAME + OFW_PASSWORD set → POST the login form, get a token.
 //      This is the legacy path. It runs unchanged when both vars are set
 //      so existing users (Claude Desktop with mcpb env config, etc.) are
@@ -46,7 +53,7 @@
 //     specifically so it can be mocked here too. This keeps the
 //     selection logic independent of either implementation.
 
-import { parseBoolEnv, readEnvVar } from '@chrischall/mcp-utils';
+import { parseBoolEnv, readEnvVar, resolveAuthPattern, type AuthPattern } from '@chrischall/mcp-utils';
 import { bootstrap } from '@fetchproxy/bootstrap';
 import { classifyBridgeError, FetchproxyBridgeDownError } from '@chrischall/mcp-utils/fetchproxy';
 import { loginWithPassword } from './auth-password.js';
@@ -76,72 +83,97 @@ function fetchproxyDisabled(): boolean {
  * The field exists for logging / future cache-keying only.
  */
 export async function resolveAuth(): Promise<ResolvedAuth> {
-  // ── Path 1: env-var credentials (unchanged from pre-fetchproxy behavior).
+  // Which paths are CONFIGURED. `resolveAuthPattern` runs the first one
+  // provided, in the fleet's fixed priority order (token → oauth →
+  // sessionScrape → fetchproxy), so "env beats fetchproxy" is expressed by
+  // which keys exist rather than by an if/else here.
+  const pattern: AuthPattern = {};
+
+  // ── Path 1 (sessionScrape): env-var credentials.
   // `readEnvVar` trims and treats blank / `"undefined"` / `"null"` /
   // `${UNEXPANDED}` placeholders as unset — defends against MCP hosts that
   // pass `.mcp.json` env blocks through without variable expansion.
   const username = readEnvVar('OFW_USERNAME');
   const password = readEnvVar('OFW_PASSWORD');
   if (username && password) {
-    const { token, expiresAt } = await loginWithPassword(username, password);
-    return { token, expiresAt, source: 'env' };
+    pattern.sessionScrape = async () => {
+      const { token, expiresAt } = await loginWithPassword(username, password);
+      return { credential: token, source: 'env', expiresAt };
+    };
   }
 
-  // ── Path 2: fetchproxy fallback (new).
+  // ── Path 2 (fetchproxy): lift the session out of a signed-in browser tab.
   if (!fetchproxyDisabled()) {
-    try {
-      const session = await bootstrap({
-        serverName: pkg.name,
-        version: pkg.version,
-        // OFW serves both ofw.ourfamilywizard.com and www.ourfamilywizard.com;
-        // the API + auth token live on the apex. The extension matches on
-        // suffix, so listing the apex covers both.
-        domains: ['ourfamilywizard.com'],
-        declare: {
-          cookies: [],
-          // The web app stores the Bearer token in localStorage["auth"] and
-          // its expiry (ISO string) in localStorage["tokenExpiry"]. Mirroring
-          // both means our 401-replay logic can be slightly smarter, and the
-          // expiry surfaces correctly in diagnostics.
-          localStorage: ['auth', 'tokenExpiry'],
-          sessionStorage: [],
-          captureHeaders: [],
-        },
-      });
+    pattern.fetchproxy = async () => {
+      try {
+        const session = await bootstrap({
+          serverName: pkg.name,
+          version: pkg.version,
+          // OFW serves both ofw.ourfamilywizard.com and www.ourfamilywizard.com;
+          // the API + auth token live on the apex. The extension matches on
+          // suffix, so listing the apex covers both.
+          domains: ['ourfamilywizard.com'],
+          declare: {
+            cookies: [],
+            // The web app stores the Bearer token in localStorage["auth"] and
+            // its expiry (ISO string) in localStorage["tokenExpiry"]. Mirroring
+            // both means our 401-replay logic can be slightly smarter, and the
+            // expiry surfaces correctly in diagnostics.
+            localStorage: ['auth', 'tokenExpiry'],
+            sessionStorage: [],
+            captureHeaders: [],
+          },
+        });
 
-      const token = session.localStorage['auth'];
-      const expiryRaw = session.localStorage['tokenExpiry'];
-      if (!token) {
+        const token = session.localStorage['auth'];
+        const expiryRaw = session.localStorage['tokenExpiry'];
+        if (!token) {
+          throw new Error(
+            'localStorage["auth"] missing on ourfamilywizard.com. ' +
+              'Sign into OFW in your browser (with the fetchproxy extension installed) and retry.',
+          );
+        }
+        return {
+          credential: token,
+          source: 'fetchproxy',
+          ...(expiryRaw ? { expiresAt: new Date(expiryRaw) } : {}),
+        };
+      } catch (e) {
+        // FetchproxyBridgeDownError only escapes bootstrap() after the lazy-revive retry fails — surface .hint verbatim (actionable "click toolbar icon" copy).
+        if (classifyBridgeError(e) === 'bridge_down') {
+          const downErr = e as FetchproxyBridgeDownError;
+          throw new Error(
+            `OFW auth: fetchproxy bridge is down (extension service worker unreachable after retry). ${downErr.hint}`,
+          );
+        }
+        const msg = e instanceof Error ? e.message : String(e);
         throw new Error(
-          'localStorage["auth"] missing on ourfamilywizard.com. ' +
-            'Sign into OFW in your browser (with the fetchproxy extension installed) and retry.',
+          `OFW auth: no OFW_USERNAME/OFW_PASSWORD set, and fetchproxy fallback failed: ${msg}`,
         );
       }
-      return {
-        token,
-        expiresAt: expiryRaw ? new Date(expiryRaw) : undefined,
-        source: 'fetchproxy',
-      };
-    } catch (e) {
-      // FetchproxyBridgeDownError only escapes bootstrap() after the lazy-revive retry fails — surface .hint verbatim (actionable "click toolbar icon" copy).
-      if (classifyBridgeError(e) === 'bridge_down') {
-        const downErr = e as FetchproxyBridgeDownError;
-        throw new Error(
-          `OFW auth: fetchproxy bridge is down (extension service worker unreachable after retry). ${downErr.hint}`,
-        );
-      }
-      const msg = e instanceof Error ? e.message : String(e);
-      throw new Error(
-        `OFW auth: no OFW_USERNAME/OFW_PASSWORD set, and fetchproxy fallback failed: ${msg}`,
-      );
-    }
+    };
   }
 
-  // ── Path 3: nothing configured. Surface both fixes side-by-side so the
-  //    user can pick whichever fits their setup.
-  throw new Error(
-    'OFW auth: set OFW_USERNAME + OFW_PASSWORD, ' +
-      'or install the fetchproxy extension and sign into ourfamilywizard.com ' +
-      '(unset OFW_DISABLE_FETCHPROXY if it is set).',
-  );
+  // ── Path 3: nothing configured. Raised HERE rather than letting
+  // `resolveAuthPattern` throw its generic "no auth configured" message,
+  // because this one names OFW's own two fixes side-by-side and the generic
+  // one cannot.
+  if (!pattern.sessionScrape && !pattern.fetchproxy) {
+    throw new Error(
+      'OFW auth: set OFW_USERNAME + OFW_PASSWORD, ' +
+        'or install the fetchproxy extension and sign into ourfamilywizard.com ' +
+        '(unset OFW_DISABLE_FETCHPROXY if it is set).',
+    );
+  }
+
+  // Errors from the winning path propagate UNWRAPPED, which is what keeps the
+  // bridge-down `.hint` above intact.
+  const { credential, source, expiresAt } = await resolveAuthPattern(pattern);
+  return {
+    token: credential,
+    // The pattern's `source` is a free-form string; ours is a two-value union,
+    // and both resolvers above set it to a member of that union.
+    source: source as ResolvedAuth['source'],
+    ...(expiresAt ? { expiresAt } : {}),
+  };
 }


### PR DESCRIPTION
## Why

`src/auth.ts` opened by declaring itself the canonical shape:

> This file is the canonical shape for "browser-bootstrap + Node-direct" auth used across our MCP servers. The other six MCPs in this family will model their auth resolution after this one.

Six copies of an ordering rule is six chances to disagree about it. `resolveAuthPattern` (`@chrischall/mcp-utils`) now owns exactly that rule — `token → oauth → sessionScrape → fetchproxy` — and nothing else. `resolveAuth()` declares which paths are *configured*; the shared resolver runs the first one.

Everything genuinely OFW's stays local: the Spring Security form login, the `localStorage` bootstrap, the bridge-down `.hint`, and the "nothing configured" error — which is deliberately still raised here, because it names both fixes side by side and the shared generic message cannot.

## Why it could not be done until now

The wave this was part of never happened, and the module header blamed a bridge-down hint gap that had already been closed. The real blocker was different: the shared result carried `{ credential, source }` only, while this file reads `localStorage["tokenExpiry"]` beside the token — deliberately, because *"our 401-replay logic can be slightly smarter, and the expiry surfaces correctly in diagnostics."* Adopting the shared resolver meant throwing that away.

mcp-utils#148 added `PatternResult.expiresAt`. **This PR is its first consumer**, and the migration is now lossless.

`resolveAuthPattern` had zero users before this, despite being written explicitly as "the Pattern A template (canvas / IC)".

## The evidence that this is a refactor

**All 886 tests pass, and not one test was changed.** The existing suite already pinned every behaviour that mattered: env precedence over fetchproxy, expiry on both paths, expiry absent when the tab has none, env-var sanitization (`""` / `"null"` / `"undefined"` / `${...}`) falling through to fetchproxy, the bridge-down hint surfacing verbatim, non-Error rejections, and `OFW_DISABLE_FETCHPROXY`. A green run against untouched tests is the argument.

`tsc` clean.

## One judgement call, flagged rather than hidden

This carries a first-party dependency bump (`@chrischall/mcp-utils` `^0.17.1` → `^0.18.0`), and the fleet rule is that first-party bumps use `feat:`/`fix:` because they *"deliver a real fix or feature through us"* rather than hiding under `chore:`.

I used `refactor:` anyway, because here the bump delivers **nothing user-visible** — it is the enabler for an internal change, and 886 unchanged tests say behaviour is identical. Calling it `feat:` would cut a minor release for a change no OFW user can observe.

Retitle to `feat:` if you read the rule as unconditional; I did not want to pick silently.