### PR TITLE
fix(deps): mirror package.json's caret range in the lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.11.0",
       "license": "MIT",
       "dependencies": {
-        "@chrischall/mcp-utils": "0.18.0",
+        "@chrischall/mcp-utils": "^0.18.0",
         "@fetchproxy/bootstrap": "^2.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",


### PR DESCRIPTION
Follow-up to #255, whose `warn` verdict flagged this.

`npm i -E` wrote the **exact** version into the lockfile's root dependency spec while `package.json` kept `^0.18.0`, so the two disagreed about what this repo declares.

Nothing was broken by it — the resolved version was right, and `npm ci` installs from the resolved tree regardless. The cost is subtler: the lockfile misstated the declared range, and the next plain `npm install` anyone ran would have silently rewritten that line, showing up as unrelated diff noise in someone else's PR.

Regenerated with `npm install --package-lock-only`. One line; resolved version unchanged at 0.18.0; suite green.

Closes #256.