### PR TITLE
docs: list the session-cache env vars in the Environment block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,8 @@ OFW_PASSWORD              Optional. OFW password (legacy env-var auth path)
 OFW_DISABLE_FETCHPROXY    Optional. "1|true|yes|on" → skip the fetchproxy fallback (missing creds become a hard error)
 OFW_CACHE_IDENTITY        Optional. Explicit cache-key label; overrides OFW_USERNAME for fetchproxy-only multi-account setups
 OFW_CACHE_DIR             Optional. Overrides cache dir (default ~/.cache/ofw-mcp)
+OFW_SESSION_CACHE         Optional. "0|false|no|off" → do not cache the session between runs (default: cached). A restart then re-authenticates every time
+OFW_SESSION_FILE          Optional. Where that session cache lives (0600 file, default $MCP_DATA_DIR/.ofw-mcp/session.json)
 OFW_ATTACHMENTS_DIR       Optional. Where ofw_download_attachment writes (default ~/Downloads/ofw-mcp)
 OFW_INLINE_ATTACHMENTS    Optional. "1|true|yes|on" → return attachments as MCP content blocks by default
 OFW_DEBUG_LOG             Optional. "1|true|yes|on" → log every OFW request/response to stderr (Authorization redacted). Diagnostic only.


### PR DESCRIPTION
Closes #254.

`OFW_SESSION_CACHE` and `OFW_SESSION_FILE` were already described in prose in the auth section, but absent from `## Environment` — the block where the other fifteen variables are listed, and the one someone actually scans to find out what they can set.

Two rows, in the existing format, next to `OFW_CACHE_DIR` (the *response* cache, which they're easy to confuse with — worth having them adjacent so the distinction is visible).

Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeTmnw2MTeKZViGhYYWZ3Y