### PR TITLE
feat(deps): take @fetchproxy/server 2.2.0 so the concentrator can bind its sandbox address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@chrischall/mcp-utils": "^0.18.0",
-        "@fetchproxy/bootstrap": "^2.0.0",
+        "@fetchproxy/bootstrap": "^2.2.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
         "zod": "^4.4.3"
@@ -480,29 +480,29 @@
       }
     },
     "node_modules/@fetchproxy/bootstrap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-2.1.0.tgz",
-      "integrity": "sha512-eVJaEY5YmQVS04Pu3XIQgYHUV1nTedy0AjU7256dZB1ndwZaVIE5YqQd33W9eRGQ9M8vj3t625pPHkGlUrUfBw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/bootstrap/-/bootstrap-2.2.0.tgz",
+      "integrity": "sha512-R9zURaA6ZNCp3djbxhMVyU5M41ZpiaMuz+tdTr1Lg1fzWUYCzOehoqDyxN3GeqQLoPeZEVNOBhRtfQ7tEjcnvA==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^2.1.0",
-        "@fetchproxy/server": "^2.1.0"
+        "@fetchproxy/protocol": "^2.2.0",
+        "@fetchproxy/server": "^2.2.0"
       }
     },
     "node_modules/@fetchproxy/protocol": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-2.1.0.tgz",
-      "integrity": "sha512-0TjtgRRwzvKi3DzegkY9x4m6Wx+npkDbjzVx0cn7cjpIfixOB8qiSHuLtgRjsg7gJCP8rNhydKNhm35e8FQaoQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/protocol/-/protocol-2.2.0.tgz",
+      "integrity": "sha512-C0l5SU7g4m2cSv21w10kqmJuET2xq0JC2FceIFx5hfnLACEDAFQ0IdadEYs/xbHHNL1/TLMZleYKBaw2Yj5hyQ==",
       "license": "MIT"
     },
     "node_modules/@fetchproxy/server": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-2.1.0.tgz",
-      "integrity": "sha512-nRp8NMN4zWBDBY3SijrWExnHK5idAnSt/KyxX09NzOx5hgxC917abe/CY3eixE/MvzoMVGfiVl/dbVhnqfiDFQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@fetchproxy/server/-/server-2.2.0.tgz",
+      "integrity": "sha512-a4pCv1UrTdO5fIH3yXRBJ9GutDK89Q4AOmb0OhTCzPZcjH32wN/W6ne3fU33hNpJry9AY3BHXfaqBaLY1jih3w==",
       "license": "MIT",
       "dependencies": {
-        "@fetchproxy/protocol": "^2.1.0",
-        "ws": "^8.21.1"
+        "@fetchproxy/protocol": "^2.2.0",
+        "ws": "^8.21.3"
       }
     },
     "node_modules/@hono/node-server": {
@@ -3502,9 +3502,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@chrischall/mcp-utils": "^0.18.0",
-    "@fetchproxy/bootstrap": "^2.0.0",
+    "@fetchproxy/bootstrap": "^2.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",
     "zod": "^4.4.3"


### PR DESCRIPTION
@fetchproxy/server 2.2.0 reads FETCHPROXY_WS_HOST, which mcp-host's gVisor sandbox sets to the child's veth address so the runner's bridge agent can reach a sandboxed concentrator; a child on an older release is refused its spawn there. This repo declares @fetchproxy/bootstrap, bumped to ^2.2.0, which resolves @fetchproxy/server 2.2.0 in the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01KwjqwXjyStXgQqVXgKeFvS