### PR TITLE
ci: sync the release-please stub from chrischall/workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,6 +39,23 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # A changelog line names the change and the PR, never the person. This
+      # amends the release PR's CHANGELOG so a contribution from outside the
+      # org reads "(thanks @user)". Runs after release-please and re-applies
+      # every run, because release-please regenerates the changelog and
+      # force-pushes its branch each time.
+      - uses: actions/checkout@v7
+        if: steps.release.outputs.pr != ''
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - uses: chrischall/workflows/.github/actions/credit-contributors@main
+        if: steps.release.outputs.pr != ''
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
+          pr: ${{ steps.release.outputs.pr }}
+
   publish:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'


### PR DESCRIPTION
Single-stub sync: regenerates `.github/workflows/release-please.yml` from fleet.json and the current template. Other workflow files are untouched.

## Why this change

Credit external contributors in the changelog (chrischall/workflows#168)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
