### PR TITLE
feat(tools): add ofw_healthcheck

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.13.0",
       "license": "MIT",
       "dependencies": {
-        "@chrischall/mcp-utils": "^0.18.0",
+        "@chrischall/mcp-utils": "^0.19.2",
         "@fetchproxy/bootstrap": "^2.2.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@chrischall/mcp-utils": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.18.0.tgz",
-      "integrity": "sha512-he6MrmIKjJOAXjEL8NLig4B5DvHqmSGBw88Xr3CR9MIJAFq0WKWd/0BuMt4/8mMLV+0piJWzpjQYCUlyf+3Xeg==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.19.2.tgz",
+      "integrity": "sha512-C09OFzxB/bYrLMyzxQmoWtZ4Fh01+a28bZtOFtGgSzBkA/k1WFUDAD6q9tfWTcj55H3oXUS74dljSCSAeD5/PA==",
       "license": "MIT",
       "peerDependencies": {
         "@fetchproxy/server": "*",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@chrischall/mcp-utils": "^0.18.0",
+    "@chrischall/mcp-utils": "^0.19.2",
     "@fetchproxy/bootstrap": "^2.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -82,6 +82,26 @@ function fetchproxyDisabled(): boolean {
  * return value as opaque credentials — they should not branch on `source`.
  * The field exists for logging / future cache-keying only.
  */
+/**
+ * The message raised when NEITHER auth path is configured.
+ *
+ * Exported with {@link isNoAuthConfigured} because a second reader needs to
+ * tell this case apart from every other auth failure: "nothing is set up" and
+ * "the password was rejected" or "the bridge is down" need opposite advice, and
+ * `ofw_healthcheck` gives the wrong one if it confuses them. A prefix match on
+ * a copy of this string in the other module would pass its own test while
+ * silently stopping matching the day this wording changed.
+ */
+export const NO_AUTH_CONFIGURED =
+  'OFW auth: set OFW_USERNAME + OFW_PASSWORD, ' +
+  'or install the fetchproxy extension and sign into ourfamilywizard.com ' +
+  '(unset OFW_DISABLE_FETCHPROXY if it is set).';
+
+/** True for the {@link NO_AUTH_CONFIGURED} failure and nothing else. */
+export function isNoAuthConfigured(e: unknown): boolean {
+  return e instanceof Error && e.message === NO_AUTH_CONFIGURED;
+}
+
 export async function resolveAuth(): Promise<ResolvedAuth> {
   // Which paths are CONFIGURED. `resolveAuthPattern` runs the first one
   // provided, in the fleet's fixed priority order (token → oauth →
@@ -159,11 +179,7 @@ export async function resolveAuth(): Promise<ResolvedAuth> {
   // because this one names OFW's own two fixes side-by-side and the generic
   // one cannot.
   if (!pattern.sessionScrape && !pattern.fetchproxy) {
-    throw new Error(
-      'OFW auth: set OFW_USERNAME + OFW_PASSWORD, ' +
-        'or install the fetchproxy extension and sign into ourfamilywizard.com ' +
-        '(unset OFW_DISABLE_FETCHPROXY if it is set).',
-    );
+    throw new Error(NO_AUTH_CONFIGURED);
   }
 
   // Errors from the winning path propagate UNWRAPPED, which is what keeps the

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ type EmitFn = (event: string | symbol, ...args: unknown[]) => boolean;
 import { runMcp } from '@chrischall/mcp-utils';
 import { client } from './client.js';
 import { registerUserTools } from './tools/user.js';
+import { registerHealthcheckTools } from './tools/healthcheck.js';
 import { registerMessageTools } from './tools/messages.js';
 import { registerCalendarTools } from './tools/calendar.js';
 import { registerExpenseTools } from './tools/expenses.js';
@@ -42,6 +43,7 @@ await runMcp({
   version: '2.13.0', // x-release-please-version
   deps: client,
   tools: [
+    registerHealthcheckTools,
     registerUserTools,
     (server, deps) => registerMessageTools(server, deps, nodeCacheProvider, nodeAttachmentIO),
     registerCalendarTools,

--- a/src/tools/healthcheck.ts
+++ b/src/tools/healthcheck.ts
@@ -1,0 +1,77 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerCredentialHealthcheckTool } from '@chrischall/mcp-utils/healthcheck';
+import type { OFWClient } from '../client.js';
+import { resolveAuth, type ResolvedAuth } from '../auth.js';
+
+/**
+ * `ofw_healthcheck` — the one call that answers "is this connector working?".
+ *
+ * OFW had no such tool. `ofw_status` looks like one and is not: it is a
+ * heavyweight draft-inventory call, `readOnlyHint: false`, that answers "where
+ * do my drafts stand?". Asking it whether auth works spends a drafts sync and
+ * still cannot separate "no credential" from "OFW rejected it".
+ *
+ * The distinction matters most for the two-path auth here: the token comes
+ * from either OFW_USERNAME/OFW_PASSWORD or a signed-in browser tab via
+ * fetchproxy, and "which of those actually supplied it" is the first thing
+ * anyone needs when the connector misbehaves. That is why `source` is
+ * reported.
+ */
+export function registerHealthcheckTools(
+  server: McpServer,
+  client: OFWClient,
+  /** Seam: the auth resolver, injectable so tests need no network. */
+  resolve: () => Promise<ResolvedAuth> = resolveAuth,
+): void {
+  registerCredentialHealthcheckTool({
+    server,
+    prefix: 'ofw',
+    hostLabel: 'ourfamilywizard.com',
+    // The same read `ofw_get_profile` makes: authenticated, cheap, and it
+    // changes nothing. A healthcheck that marked a message read would be
+    // co-parent-visible and irreversible.
+    probePath: '/pub/v2/profiles',
+    resolveCredential: async () => {
+      try {
+        const auth = await resolve();
+        return {
+          source: auth.source,
+          // Never the token. Expiry is the fact that explains a connector
+          // that worked an hour ago and does not now.
+          detail: auth.expiresAt ? { expires_at: auth.expiresAt.toISOString() } : undefined,
+        };
+      } catch (e) {
+        // "Nothing is configured" is a CREDENTIAL state, not a failure to
+        // check — it earns the `no_credential` arm and its advice. Every
+        // other error (a rejected password, a bridge that is down) is a real
+        // failure and must keep its own message rather than being flattened
+        // into "no credential", which would send someone to set variables
+        // that are already set.
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.startsWith('OFW auth: set OFW_USERNAME + OFW_PASSWORD')) {
+          return { source: null };
+        }
+        throw e;
+      }
+    },
+    probeFn: () => client.request('GET', '/pub/v2/profiles'),
+    hints: {
+      // Covers TWO situations, because the shared helper cannot tell them
+      // apart: it collapses any `resolveCredential` throw into this arm with
+      // this static hint. So the hint must not assert which one happened —
+      // `error.message` is what distinguishes them, and it says so. (Teaching
+      // the helper to classify a resolver throw would fix this for every
+      // connector; noted as a follow-up rather than worked around here.)
+      no_credential:
+        'No usable OFW credential. Either nothing is configured — set OFW_USERNAME + ' +
+        'OFW_PASSWORD, or install the fetchproxy extension and sign in to ourfamilywizard.com ' +
+        'in a tab (unsetting OFW_DISABLE_FETCHPROXY if you set it) — or a configured path was ' +
+        'tried and failed. `error.message` says which: a bridge that is down or a rejected ' +
+        'password reads very differently from nothing being set up at all.',
+      credential_rejected:
+        'OurFamilyWizard rejected the credential. If it came from `env`, the password changed or ' +
+        'the account is locked; if from `fetchproxy`, the browser session expired — sign in again ' +
+        'in the tab. Retrying will not fix either.',
+    },
+  });
+}

--- a/src/tools/healthcheck.ts
+++ b/src/tools/healthcheck.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerCredentialHealthcheckTool } from '@chrischall/mcp-utils/healthcheck';
 import type { OFWClient } from '../client.js';
-import { resolveAuth, type ResolvedAuth } from '../auth.js';
+import { resolveAuth, isNoAuthConfigured, type ResolvedAuth } from '../auth.js';
 
 /**
  * `ofw_healthcheck` — the one call that answers "is this connector working?".
@@ -47,10 +47,11 @@ export function registerHealthcheckTools(
         // failure and must keep its own message rather than being flattened
         // into "no credential", which would send someone to set variables
         // that are already set.
-        const msg = e instanceof Error ? e.message : String(e);
-        if (msg.startsWith('OFW auth: set OFW_USERNAME + OFW_PASSWORD')) {
-          return { source: null };
-        }
+        // `isNoAuthConfigured` rather than a prefix match on a copy of the
+        // message: the copy would pass this module's own test while silently
+        // stopping matching the day auth.ts reworded it, and the failure mode
+        // is giving a rejected password the advice meant for a blank setup.
+        if (isNoAuthConfigured(e)) return { source: null };
         throw e;
       }
     },

--- a/tests/tools/healthcheck.test.ts
+++ b/tests/tools/healthcheck.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { createTestHarness, parseToolResult } from '@chrischall/mcp-utils/test';
+import { registerHealthcheckTools } from '../../src/tools/healthcheck.js';
+import type { OFWClient } from '../../src/client.js';
+import type { ResolvedAuth } from '../../src/auth.js';
+
+interface Result {
+  ok: boolean;
+  credential: { source: string | null; resolved: boolean; detail?: Record<string, unknown> };
+  error?: { kind: string; message: string };
+  hint: string;
+}
+
+const UNCONFIGURED =
+  'OFW auth: set OFW_USERNAME + OFW_PASSWORD, or install the fetchproxy extension and sign into ourfamilywizard.com (unset OFW_DISABLE_FETCHPROXY if it is set).';
+
+async function call(
+  resolve: () => Promise<ResolvedAuth>,
+  probe: () => Promise<unknown> = async () => ({ profiles: [] }),
+): Promise<Result> {
+  const client = { request: probe } as unknown as OFWClient;
+  const h = await createTestHarness((server) => registerHealthcheckTools(server, client, resolve));
+  const res = await h.client.callTool({ name: 'ofw_healthcheck', arguments: {} });
+  await h.close?.();
+  return parseToolResult<Result>(res as never);
+}
+
+describe('ofw_healthcheck', () => {
+  it('reports ok and WHICH path supplied the token', async () => {
+    const r = await call(async () => ({ token: 'secret-token', source: 'env' }));
+    expect(r.ok).toBe(true);
+    expect(r.credential.source).toBe('env');
+    expect(r.credential.resolved).toBe(true);
+  });
+
+  it('names the fetchproxy path when the token came from a browser tab', async () => {
+    const r = await call(async () => ({ token: 't', source: 'fetchproxy' }));
+    expect(r.credential.source).toBe('fetchproxy');
+  });
+
+  // The whole point of the tool: a healthcheck is what people paste into a
+  // chat when something is broken, so it must never carry the credential.
+  it('never echoes the token', async () => {
+    const r = await call(async () => ({
+      token: 'secret-token',
+      source: 'env',
+      expiresAt: new Date('2026-09-01T00:00:00.000Z'),
+    }));
+    expect(JSON.stringify(r)).not.toContain('secret-token');
+    expect(r.credential.detail).toEqual({ expires_at: '2026-09-01T00:00:00.000Z' });
+  });
+
+  it('treats "nothing configured" as no_credential and names both fixes', async () => {
+    const r = await call(async () => {
+      throw new Error(UNCONFIGURED);
+    });
+    expect(r.ok).toBe(false);
+    expect(r.credential.source).toBeNull();
+    expect(r.credential.resolved).toBe(false);
+    expect(r.hint).toMatch(/OFW_USERNAME/);
+    expect(r.hint).toMatch(/fetchproxy/i);
+  });
+
+  // A rejected password and a downed bridge are NOT "no credential". Flattening
+  // them into that arm sends someone to set variables that are already set.
+  it('keeps a real auth failure distinct from an unconfigured one', async () => {
+    const r = await call(async () => {
+      throw new Error('OFW auth: fetchproxy bridge is down (extension service worker unreachable after retry).');
+    });
+    expect(r.ok).toBe(false);
+    expect(r.credential.source).toBeNull();
+    // The real cause has to survive into the payload — this is the half the
+    // shared helper preserves. The hint cannot claim which case it is (the
+    // helper gives one static string to both), so it must point at the thing
+    // that can: error.message.
+    expect(r.error?.message).toMatch(/bridge is down/);
+    expect(r.hint).toMatch(/error\.message/);
+  });
+
+  it('reports a probe failure without blaming the credential', async () => {
+    const r = await call(
+      async () => ({ token: 't', source: 'env' }),
+      async () => {
+        throw Object.assign(new Error('OFW 503'), { status: 503 });
+      },
+    );
+    expect(r.ok).toBe(false);
+    expect(r.credential.resolved).toBe(true);
+  });
+});

--- a/tests/tools/healthcheck.test.ts
+++ b/tests/tools/healthcheck.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createTestHarness, parseToolResult } from '@chrischall/mcp-utils/test';
 import { registerHealthcheckTools } from '../../src/tools/healthcheck.js';
 import type { OFWClient } from '../../src/client.js';
-import type { ResolvedAuth } from '../../src/auth.js';
+import { NO_AUTH_CONFIGURED, resolveAuth, type ResolvedAuth } from '../../src/auth.js';
 
 interface Result {
   ok: boolean;
@@ -11,8 +11,10 @@ interface Result {
   hint: string;
 }
 
-const UNCONFIGURED =
-  'OFW auth: set OFW_USERNAME + OFW_PASSWORD, or install the fetchproxy extension and sign into ourfamilywizard.com (unset OFW_DISABLE_FETCHPROXY if it is set).';
+// Imported, never copied: a local copy of this string would keep this file
+// green on the day auth.ts reworded it, while production silently stopped
+// recognising the case.
+const UNCONFIGURED = NO_AUTH_CONFIGURED;
 
 async function call(
   resolve: () => Promise<ResolvedAuth>,
@@ -86,5 +88,33 @@ describe('ofw_healthcheck', () => {
     );
     expect(r.ok).toBe(false);
     expect(r.credential.resolved).toBe(true);
+  });
+});
+
+// The strings agreeing is not enough — the REAL resolver has to actually raise
+// this case, or the pair could agree perfectly about a message nothing throws.
+describe('the unconfigured case is what resolveAuth really raises', () => {
+  const VARS = ['OFW_USERNAME', 'OFW_PASSWORD', 'OFW_DISABLE_FETCHPROXY'] as const;
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const k of VARS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    // Fetchproxy off, so path 2 cannot be the one that answers.
+    process.env.OFW_DISABLE_FETCHPROXY = '1';
+  });
+  afterEach(() => {
+    for (const k of VARS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('raises exactly NO_AUTH_CONFIGURED, which the healthcheck then recognises', async () => {
+    await expect(resolveAuth()).rejects.toThrow(NO_AUTH_CONFIGURED);
+    const r = await call(() => resolveAuth());
+    expect(r.credential.source).toBeNull();
+    expect(r.error?.kind).toBe('no_credential');
   });
 });


### PR DESCRIPTION
## Why

OFW had no healthcheck. `ofw_status` **looks** like one and isn't: it's a heavyweight draft-inventory call with `readOnlyHint: false` that answers "where do my drafts stand?". Asking it whether auth works spends a drafts sync and still can't separate "no credential" from "OFW rejected it".

That naming gap is also why a survey of the connectors couldn't tell this one was uncovered — `ofw_status` and `kia_session_status` don't read as healthchecks, while every bridged connector's does.

## What it does

Resolves the credential, reports **which of the two paths** supplied it — `OFW_USERNAME`/`OFW_PASSWORD`, or a signed-in browser tab via fetchproxy — and probes `GET /pub/v2/profiles`.

That probe is the same authenticated read `ofw_get_profile` makes, chosen because **it changes nothing**. A healthcheck that marked a message read would be co-parent-visible and irreversible.

The token never appears in the payload (asserted); expiry does, because that's the fact explaining a connector that worked an hour ago and doesn't now.

## One limitation, stated rather than worked around

The shared `registerCredentialHealthcheckTool` collapses **any** `resolveCredential` throw into the `no_credential` arm with one static hint — so "nothing is configured" and "the fetchproxy bridge is down" land in the same place with advice that only fits the first.

Rather than contort OFW around it, the hint doesn't assert which happened and points at `error.message`, which does distinguish them. A test pins both halves. Teaching the helper to run `classifyThrown` on resolver throws would fix this for every connector using it — worth a follow-up in mcp-utils.

## Tests

Six rows: ok + source reported, the fetchproxy path named, **the token never echoed**, unconfigured → `no_credential` naming both fixes, a real auth failure keeping its own message, and a probe failure that doesn't blame the credential.

892/892, typecheck clean. Bumps `@chrischall/mcp-utils` to `^0.19.2` for the `/healthcheck` subpath.

Closes #265
