### PR TITLE
feat(tools): classify a downed bridge as transport, not a missing credential

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.13.0",
       "license": "MIT",
       "dependencies": {
-        "@chrischall/mcp-utils": "^0.19.2",
+        "@chrischall/mcp-utils": "^0.19.3",
         "@fetchproxy/bootstrap": "^2.2.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@chrischall/mcp-utils": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.19.2.tgz",
-      "integrity": "sha512-C09OFzxB/bYrLMyzxQmoWtZ4Fh01+a28bZtOFtGgSzBkA/k1WFUDAD6q9tfWTcj55H3oXUS74dljSCSAeD5/PA==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.19.3.tgz",
+      "integrity": "sha512-3iuAzuoGllSZGoIUMwBJx18q8lt/siA7nmHyB2NZX36lxHdN1vG7uUwpgsgBQ2dKvmeX1U1MTpE6XmWTO4RUww==",
       "license": "MIT",
       "peerDependencies": {
         "@fetchproxy/server": "*",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@chrischall/mcp-utils": "^0.19.2",
+    "@chrischall/mcp-utils": "^0.19.3",
     "@fetchproxy/bootstrap": "^2.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -97,6 +97,23 @@ export const NO_AUTH_CONFIGURED =
   'or install the fetchproxy extension and sign into ourfamilywizard.com ' +
   '(unset OFW_DISABLE_FETCHPROXY if it is set).';
 
+/**
+ * Prefix of the message raised when the fetchproxy bridge is unreachable.
+ *
+ * A PREFIX rather than a whole constant because the upstream `.hint` — the
+ * actionable "click the toolbar icon" copy — is appended per failure. Exported
+ * with {@link isBridgeDown} for the reason {@link NO_AUTH_CONFIGURED} is: a
+ * reader that matched a copy of this text would keep its own test green on the
+ * day the wording changed, while silently misreporting a downed bridge as an
+ * unconfigured server.
+ */
+export const BRIDGE_DOWN_PREFIX = 'OFW auth: fetchproxy bridge is down';
+
+/** True for the {@link BRIDGE_DOWN_PREFIX} failure and nothing else. */
+export function isBridgeDown(e: unknown): boolean {
+  return e instanceof Error && e.message.startsWith(BRIDGE_DOWN_PREFIX);
+}
+
 /** True for the {@link NO_AUTH_CONFIGURED} failure and nothing else. */
 export function isNoAuthConfigured(e: unknown): boolean {
   return e instanceof Error && e.message === NO_AUTH_CONFIGURED;
@@ -163,7 +180,7 @@ export async function resolveAuth(): Promise<ResolvedAuth> {
         if (classifyBridgeError(e) === 'bridge_down') {
           const downErr = e as FetchproxyBridgeDownError;
           throw new Error(
-            `OFW auth: fetchproxy bridge is down (extension service worker unreachable after retry). ${downErr.hint}`,
+            `${BRIDGE_DOWN_PREFIX} (extension service worker unreachable after retry). ${downErr.hint}`,
           );
         }
         const msg = e instanceof Error ? e.message : String(e);

--- a/src/tools/healthcheck.ts
+++ b/src/tools/healthcheck.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerCredentialHealthcheckTool } from '@chrischall/mcp-utils/healthcheck';
 import type { OFWClient } from '../client.js';
-import { resolveAuth, isNoAuthConfigured, type ResolvedAuth } from '../auth.js';
+import { resolveAuth, isNoAuthConfigured, isBridgeDown, type ResolvedAuth } from '../auth.js';
 
 /**
  * `ofw_healthcheck` — the one call that answers "is this connector working?".
@@ -56,19 +56,30 @@ export function registerHealthcheckTools(
       }
     },
     probeFn: () => client.request('GET', '/pub/v2/profiles'),
+    // A downed bridge is not a missing credential, and since mcp-utils 0.19.3
+    // the helper consults this for a `resolveCredential` failure too — so it
+    // gets its own arm instead of the `no_credential` copy. That copy could
+    // previously only hedge across both cases and point at `error.message`;
+    // now each answer names one cause and one fix.
+    classifyThrown: (err: unknown) =>
+      isBridgeDown(err)
+        ? {
+            kind: 'transport',
+            // The upstream `.hint` rides along in `error.message` — it carries
+            // the actionable "click the toolbar icon" copy this cannot know.
+            hint:
+              'The fetchproxy bridge is down, so the browser path could not be tried. This is ' +
+              'not a credential problem: OFW_USERNAME/OFW_PASSWORD, if set, were not reached ' +
+              'either. See error.message for the extension-specific fix.',
+          }
+        : undefined,
     hints: {
-      // Covers TWO situations, because the shared helper cannot tell them
-      // apart: it collapses any `resolveCredential` throw into this arm with
-      // this static hint. So the hint must not assert which one happened —
-      // `error.message` is what distinguishes them, and it says so. (Teaching
-      // the helper to classify a resolver throw would fix this for every
-      // connector; noted as a follow-up rather than worked around here.)
+      // Now means exactly what it says: nothing is set up. A configured path
+      // that was tried and failed no longer lands here.
       no_credential:
-        'No usable OFW credential. Either nothing is configured — set OFW_USERNAME + ' +
-        'OFW_PASSWORD, or install the fetchproxy extension and sign in to ourfamilywizard.com ' +
-        'in a tab (unsetting OFW_DISABLE_FETCHPROXY if you set it) — or a configured path was ' +
-        'tried and failed. `error.message` says which: a bridge that is down or a rejected ' +
-        'password reads very differently from nothing being set up at all.',
+        'No OFW credential is configured. Either set OFW_USERNAME + OFW_PASSWORD, or install ' +
+        'the fetchproxy extension and sign in to ourfamilywizard.com in a tab (unsetting ' +
+        'OFW_DISABLE_FETCHPROXY if you set it).',
       credential_rejected:
         'OurFamilyWizard rejected the credential. If it came from `env`, the password changed or ' +
         'the account is locked; if from `fetchproxy`, the browser session expired — sign in again ' +

--- a/tests/tools/healthcheck.test.ts
+++ b/tests/tools/healthcheck.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createTestHarness, parseToolResult } from '@chrischall/mcp-utils/test';
 import { registerHealthcheckTools } from '../../src/tools/healthcheck.js';
 import type { OFWClient } from '../../src/client.js';
-import { NO_AUTH_CONFIGURED, resolveAuth, type ResolvedAuth } from '../../src/auth.js';
+import {
+  BRIDGE_DOWN_PREFIX,
+  NO_AUTH_CONFIGURED,
+  resolveAuth,
+  type ResolvedAuth,
+} from '../../src/auth.js';
 
 interface Result {
   ok: boolean;
@@ -63,20 +68,32 @@ describe('ofw_healthcheck', () => {
     expect(r.hint).toMatch(/fetchproxy/i);
   });
 
-  // A rejected password and a downed bridge are NOT "no credential". Flattening
-  // them into that arm sends someone to set variables that are already set.
-  it('keeps a real auth failure distinct from an unconfigured one', async () => {
+  // A downed bridge is NOT "no credential". Flattening it into that arm sends
+  // someone to set variables that are already set — and since mcp-utils
+  // 0.19.3 classifies resolver throws, it no longer has to.
+  it('classifies a downed bridge as transport, not as a missing credential', async () => {
     const r = await call(async () => {
-      throw new Error('OFW auth: fetchproxy bridge is down (extension service worker unreachable after retry).');
+      throw new Error(`${BRIDGE_DOWN_PREFIX} (unreachable after retry). Click the toolbar icon.`);
     });
     expect(r.ok).toBe(false);
-    expect(r.credential.source).toBeNull();
-    // The real cause has to survive into the payload — this is the half the
-    // shared helper preserves. The hint cannot claim which case it is (the
-    // helper gives one static string to both), so it must point at the thing
-    // that can: error.message.
+    expect(r.error?.kind).toBe('transport');
+    // The real cause, and the extension-specific fix, survive into the payload.
     expect(r.error?.message).toMatch(/bridge is down/);
-    expect(r.hint).toMatch(/error\.message/);
+    expect(r.error?.message).toMatch(/toolbar icon/);
+    // The hint names ONE cause now, instead of hedging across two.
+    expect(r.hint).toMatch(/bridge is down/i);
+    expect(r.hint).not.toMatch(/set OFW_USERNAME/);
+  });
+
+  // The other side of the same split: the unconfigured hint may now say
+  // plainly that nothing is set up, because a failed path no longer lands here.
+  it('gives the unconfigured case advice that no longer hedges', async () => {
+    const r = await call(async () => {
+      throw new Error(NO_AUTH_CONFIGURED);
+    });
+    expect(r.error?.kind).toBe('no_credential');
+    expect(r.hint).toMatch(/OFW_USERNAME/);
+    expect(r.hint).not.toMatch(/error\.message/);
   });
 
   it('reports a probe failure without blaming the credential', async () => {


### PR DESCRIPTION
Retires the workaround #264 shipped under protest, now that mcp-utils 0.19.3 is published.

## What changes

The shared helper used to collapse **every** `resolveCredential` throw into `no_credential` with one static hint — so "nothing is configured" and "the fetchproxy bridge is down" got the same answer, and the only honest copy hedged across both and pointed the reader at `error.message`.

`classifyThrown` is now consulted on that path (mcp-utils#172), so each case names one cause and one fix:

- **bridge down** → `transport`, with a hint saying the credential was never reached. The extension-specific remedy rides along in `error.message`, which is the only place that knows it.
- **nothing configured** → `no_credential`, and the copy drops its hedge, because a configured path that was tried and failed no longer lands there.

## The predicate

`BRIDGE_DOWN_PREFIX` + `isBridgeDown` are exported from `auth.ts`, mirroring `NO_AUTH_CONFIGURED`, so the throw and the reader share one source of truth. A **prefix** rather than a whole constant, because the upstream `.hint` is appended per failure.

Matching a copy of that text in the healthcheck is exactly what the review on #264 objected to — and the failure it hides is real: a reader with a stale copy reports a downed bridge as an unconfigured server, sending someone to set variables that are already set.

## Verification

Removing the classifier fails exactly the new row. Both sides of the split are asserted — the bridge case must not say "set OFW_USERNAME", the unconfigured case must no longer point at `error.message`.

894/894, coverage 100% on all four metrics, typecheck clean.