### PR TITLE
ci: sync the ci-fork-status stub from chrischall/workflows

### DIFF
--- a/.github/workflows/ci-fork-status.yml
+++ b/.github/workflows/ci-fork-status.yml
@@ -16,9 +16,13 @@ name: CI fork status
 # SECURITY — read before editing. `workflow_run` is the classic "pwn request"
 # footgun: it has a write token and is triggered by an untrusted fork. This
 # workflow is safe ONLY because it never fetches, checks out, builds or
-# executes anything from the head repository. It reads two fields off the
-# event payload and posts a status. Do NOT add `actions/checkout` here, and do
-# not pass any fork-controlled string into a shell.
+# executes anything from the head repository. It reads five scalars off the
+# event payload and nothing else — `event` and `head_repository.full_name` to
+# gate the job, then `head_sha`, `conclusion` and `html_url` to post the
+# status. Do NOT add `actions/checkout` here, and do not pass any
+# fork-controlled string into a shell: `head_sha` and `head_repository` are
+# named by the fork, which is why they reach the composite action through an
+# `env:` block rather than the script body.
 #
 # What this DOES weaken, stated plainly: a fork PR can now satisfy `ci-gated`,
 # so the merge no longer waits for a maintainer to post one by hand. Two human


### PR DESCRIPTION
Single-stub sync: regenerates `.github/workflows/ci-fork-status.yml` from fleet.json and the current template. Other workflow files are untouched.

## Why this change

chrischall/workflows#191 corrected the SECURITY note in `ci-fork-status.yml`. It claimed the workflow "reads two fields off the event payload"; it reads five — `event` and `head_repository.full_name` gate the job, and `head_sha`, `conclusion` and `html_url` are passed to the composite action.

Comment-only: no rendered behaviour changes, and the posture the note describes was already correct (no `actions/checkout`, no head-repo content fetched or executed, every value reaching the action arrives as a scalar in an `env:` block). The paragraph exists so a future editor can judge whether a change keeps the "pwn request" surface closed, and one that under-counts its own reads by three cannot serve that purpose.

Rolled to every repo because `rollout.sh --check` compares bytes — leaving this unsynced would drift the whole fleet on the next daily sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
