### PR TITLE
ci: sync the ci-fork-status stub from chrischall/workflows

### DIFF
--- a/.github/workflows/ci-fork-status.yml
+++ b/.github/workflows/ci-fork-status.yml
@@ -17,12 +17,13 @@ name: CI fork status
 # footgun: it has a write token and is triggered by an untrusted fork. This
 # workflow is safe ONLY because it never fetches, checks out, builds or
 # executes anything from the head repository. It reads five scalars off the
-# event payload and nothing else — `event` and `head_repository.full_name` to
-# gate the job, then `head_sha`, `conclusion` and `html_url` to post the
-# status. Do NOT add `actions/checkout` here, and do not pass any
-# fork-controlled string into a shell: `head_sha` and `head_repository` are
-# named by the fork, which is why they reach the composite action through an
-# `env:` block rather than the script body.
+# event payload and nothing else: `event` and `head_repository.full_name` gate
+# the job below and go no further, while `head_sha`, `conclusion` and
+# `html_url` are handed to the composite action through `with:`. Do NOT add
+# `actions/checkout` here. Of the three that travel onward only `head_sha` is
+# named by the fork, and inside the action every input is bound to an `env:`
+# var and referenced as "$SHA" rather than interpolated into the script body —
+# keep it that way.
 #
 # What this DOES weaken, stated plainly: a fork PR can now satisfy `ci-gated`,
 # so the merge no longer waits for a maintainer to post one by hand. Two human


### PR DESCRIPTION
Single-stub sync: regenerates `.github/workflows/ci-fork-status.yml` from fleet.json and the current template. Other workflow files are untouched.

## Why this change

chrischall/workflows#192 corrected two claims in the `ci-fork-status.yml` SECURITY note that #191 got wrong: it said `head_repository` reaches the composite action (it appears only in the job `if:` and never leaves the stub), and that fork-named values arrive through an `env:` block (they arrive through `with:`; the `env:` block is inside action.yml, binding `inputs.*` to `$SHA`).

Every clause now maps to something checkable in the file or in action.yml: which two fields gate the job, which three are handed on and how, that only `head_sha` among them is fork-named, and that the injection guard is the action's env binding. A security note whose specifics do not survive being checked is worse than a vague one, because it gets trusted.

Comment-only: no rendered behaviour changes, and the posture itself was correct throughout — only its description was wrong. Rolled to every standard-CI repo because `rollout.sh --check` compares bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
