### PR TITLE
ci: sync the ci-fork-status stub from chrischall/workflows

### DIFF
--- a/.github/workflows/ci-fork-status.yml
+++ b/.github/workflows/ci-fork-status.yml
@@ -35,8 +35,13 @@ name: CI fork status
 #   2. `pr-auto-review` SKIPS fork PRs, so `ready-to-merge` is never applied
 #      automatically to one. A human must arm it.
 #
-# The status posted is exactly the conclusion of the run: this reports CI, it
-# does not vouch for it.
+# This reports CI; it does not vouch for it. But note that the run's conclusion
+# alone does NOT say whether CI ran: an un-armed fork PR defers the build and
+# the run still concludes `success`, which is how this workflow once posted a
+# green `ci-gated` for a commit nothing had compiled (skylight-mcp#148). The
+# action therefore re-derives the gate's arming decision from the PR's labels
+# and mirrors a conclusion only for a run that was armed; everything else is
+# reported `pending`, the same block the gate gives a same-repo un-armed PR.
 
 on:
   workflow_run:
@@ -46,6 +51,11 @@ on:
 permissions:
   contents: read
   statuses: write
+  # Read-only, and load-bearing: the action decides whether CI actually RAN by
+  # reading the PR's `ready-to-merge` label. Without this grant the lookup
+  # fails and every fork PR is reported blocked rather than green — safe, but
+  # unmergeable, so this must ship together with the action.
+  pull-requests: read
 
 jobs:
   report:


### PR DESCRIPTION
Single-stub sync: regenerates `.github/workflows/ci-fork-status.yml` from fleet.json and the current template. Other workflow files are untouched.

## Why this change

Grants `pull-requests: read` to the fork-CI reporter stub.

The `ci-gated` required status is posted for fork PRs by `.github/workflows/ci-fork-status.yml`, which calls a shared action in chrischall/workflows. That action mirrored the CI run's *conclusion* into the status — but an un-armed fork PR DEFERS CI (the `ci` job is skipped, or its build steps are guarded off in bespoke shapes) and the run still concludes `success`. So the required check went GREEN for a commit where nothing was built and no test ran, leaving an untested fork PR one click from merge. skylight-mcp#148 is the live instance: `ci / ci` skipped, `ci-gated: success — "CI passed (fork run)"`, and the branch actually fails CI on its coverage threshold.

The fix (chrischall/workflows#194) re-derives the gate's arming decision from the PR's `ready-to-merge` label instead of trusting the run conclusion. Reading labels needs `pull-requests: read`, which this PR grants. It is a read-only scope and changes nothing on its own — the permission must be in place across the fleet BEFORE #194 merges, or the reporter's lookup 403s and every fork PR reports blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
