### PR TITLE
ci: sync the ci-fork-status stub from chrischall/workflows

### DIFF
--- a/.github/workflows/ci-fork-status.yml
+++ b/.github/workflows/ci-fork-status.yml
@@ -32,8 +32,10 @@ name: CI fork status
 #   1. GitHub holds fork workflow runs at `action_required` until a maintainer
 #      approves them, so CI never runs on unreviewed external code — and this
 #      workflow only ever reports a run that a human already approved.
-#   2. `pr-auto-review` SKIPS fork PRs, so `ready-to-merge` is never applied
-#      automatically to one. A human must arm it.
+#   2. a fork is armed only when a maintainer types `/auto-review` on it. No
+#      event reviews a fork on its own, the command's author_association is
+#      checked before anything runs, and auto-merge excludes forks by head
+#      repo — so arming a fork starts its CI, never its merge.
 #
 # This reports CI; it does not vouch for it. But note that the run's conclusion
 # alone does NOT say whether CI ran: an un-armed fork PR defers the build and


### PR DESCRIPTION
Single-stub sync: regenerates `.github/workflows/ci-fork-status.yml` from fleet.json and the current template. Other workflow files are untouched.

## Why this change

The ci-gated security note named 'pr-auto-review SKIPS fork PRs' as one of the two human gates the workflow_run reporter rests on. That is no longer how it works: chrischall/workflows#198 lets a maintainer's /auto-review arm a fork PR, so the gate is now the command itself (author_association checked, no event arms a fork on its own), plus auto-merge's own fork exclusion — arming a fork starts its CI, never its merge. Comment-only sync of the corrected rationale; no behaviour change in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
