### PR TITLE
ci: sync the release-please stub from chrischall/workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,10 +40,16 @@ jobs:
           manifest-file: .release-please-manifest.json
 
       # A changelog line names the change and the PR, never the person. This
-      # amends the release PR's CHANGELOG so a contribution from outside the
-      # org reads "(thanks @user)". Runs after release-please and re-applies
-      # every run, because release-please regenerates the changelog and
-      # force-pushes its branch each time.
+      # amends BOTH the release PR's CHANGELOG and its own description, so a
+      # contribution from outside the org reads "(thanks @user)" everywhere a
+      # person actually looks — the release PR, and the GitHub Release notes
+      # cut from it. The body needs its own pass because release-please writes
+      # the description from its own notes and never re-reads the branch.
+      #
+      # Runs after release-please and re-applies every run, because
+      # release-please regenerates the changelog and force-pushes its branch
+      # each time. The PAT below is load-bearing twice over: contents:write to
+      # commit the changelog, pull-requests:write to push the body back.
       - uses: actions/checkout@v7
         if: steps.release.outputs.pr != ''
         with:


### PR DESCRIPTION
Single-stub sync: regenerates `.github/workflows/release-please.yml` from fleet.json and the current template. Other workflow files are untouched.

## Why this change

chrischall/workflows#202 taught the credit-contributors step to amend the release PR's DESCRIPTION as well as CHANGELOG.md — release-please writes the body from its own notes and never re-reads the branch, so a credit committed to the file was invisible in the release PR and in the GitHub Release notes cut from it. This syncs the stub's comment to match, and names what each half of the PAT scope is for. Comment-only; no behaviour change in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
