### PR TITLE
feat(tools): compact responses by default, and drop the formatting whitespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ src/
     delivery.ts     the attachment delivery ladder (image → extracted → raw bytes)
     freshness.ts    buildFreshness() — the `freshness` block every read tool returns (source/asOf/ageSeconds/staleness/warning)
     pagination.ts   paging state that survives a lossy reader: pageState/offsetState/readUpstreamPaging/withPaginationFirst
+    project.ts      the `view` projection — compactMessage/compactDraft/viewMessages/viewDrafts/viewOne, MESSAGE_VIEWS
     lifecycle.ts    "is this entity still what I think it is?" — classifyState/probeIds/resolveDraftKey/newDraftKey
     user.ts         ofw_get_profile, ofw_get_notifications
     messages.ts     folders, list, get, send, drafts, get_unread_sent, upload/download_attachment, sync_messages, check_freshness, status
@@ -96,6 +97,67 @@ OFW_AUTO_REFRESH          Optional. "1|true|yes|on" → when a cached read comes
 OFW_CALENDAR_WRITES       Optional. "1|true|yes|on" → in mode "drafts", additionally register the calendar write tools (ofw_create_event, ofw_update_event, ofw_delete_event). Rationale: calendar events have no draft stage but are reversible (editable/deletable), unlike a sent message. Redundant in "all"; never overrides "none" (including the unrecognized-mode fail-closed path)
 DISPLAY_TZ                Optional. IANA zone (e.g. America/New_York, the default) for every `<field>Display` value, and the zone a NAIVE source timestamp is assumed to be wall-clock in. OFW's API reports naive local times in the account's own zone, so this must match it. Unrecognized values fall back to the default rather than throwing — a typo degrades a label instead of breaking every tool. Never a fixed offset: DST comes from the IANA database, so a hardcoded -04:00 would be an hour wrong from November through March
 ```
+
+## Response shape (`view`)
+
+Every read tool that returns cached records takes `view: 'compact' | 'full'`,
+**defaulting to `compact`** — the fleet vocabulary from
+`@chrischall/mcp-utils` (`viewParam`/`resolveView`/`projectOrRaw`). The
+projection lives in `src/tools/project.ts`.
+
+Measured against a real 1,335-row cache, a default `ofw_list_messages()` (50
+messages) weighed **135 KB — about 34,000 tokens for one call**. `listData` was
+58% of that, and **78% of `listData` duplicated fields the same object already
+emitted at the top level**:
+
+- `listData.date` is 421 bytes per message: ELEVEN pre-formatted renderings of
+  one timestamp, beside the `sentAt` + `sentAtDisplay` that `timestamps.ts`
+  derives — and `normalizeTimestampsInValue` then adds a twelfth *inside it*.
+- `listData.recipients[].user` carries eight fields per person (`color`,
+  `displayInitials`, …) next to the three-field recipients the row normalised.
+- `listData.read`/`.showNeverViewed` are FORCED to agree with the derived
+  `read` before they are emitted (`withReadState`), so the copy cannot even
+  disagree usefully.
+- `listData.preview` is a truncation of the body in the same object.
+
+Compact drops that blob, keeps everything a caller acts on, and **promotes the
+sender to `from`**. That promotion is load-bearing, not cosmetic: `fromUser` is
+the empty string on all 1,335 rows — inbox AND sent — because OFW names the
+sender only in the list payload's `author`. Deleting `listData` without it
+would have taken the sender off every message; compact is where a field that
+never worked starts working.
+
+`files` and `replied` are kept (nothing else carries them); `files` is
+normalised from the number-or-empty-array OFW sends, and is **omitted entirely
+when OFW reported nothing** rather than defaulting to `0` — "we did not see a
+count" and "there are none" are different facts, and the second reads as
+verified. `canReply` (true on 1,330 of 1,335), `draft` (answered by `folder`),
+`archived` and `firstView` (absent on 1,326) are dropped.
+
+**There is no `raw` rung**, deliberately. A message here is ASSEMBLED — the
+list endpoint supplies `listData`, the detail GET supplies `body` and the real
+`viewedAt`, `timestamps.ts` rewrites both — so there is no single upstream
+payload to hand back. And a `raw` that skipped normalisation would put naive
+local times back beside UTC ones on the one rung a caller reaches for when
+something already looks wrong. `ofw_get_unread_sent` has no `view` either: it
+emits a verdict list (`{id, subject, sentAt, unreadBy}`), already narrower than
+the projection.
+
+**A projection that trips returns the rows WHOLE** (`projectOrRaw`), warns on
+stderr, and does so for the entire array rather than per row — a hole in the
+middle of a 50-message page is worse than a fat page and is indistinguishable
+from a message with no content. The projection is applied at the LAST moment,
+after `returned`/`complete`/the notes are computed, so it can never change what
+the response claims about its own contents.
+
+**All responses are minified.** `jsonResponse` uses `minifiedResult`, not
+`JSON.stringify(data, null, 2)`: indentation was 23% of that 135 KB page,
+roughly 8,000 tokens a call, and nothing downstream reads it. Whitespace
+*inside* a value is content and is untouched — a message body's blank lines
+survive byte-for-byte, which `JSON.stringify` gives for free and a text-level
+minifier would destroy. Tests pin it here and in mcp-utils.
+
+Together: **135.1 KB → 41.1 KB, −70%.**
 
 ## Timestamps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.14.0",
       "license": "MIT",
       "dependencies": {
-        "@chrischall/mcp-utils": "^0.19.3",
+        "@chrischall/mcp-utils": "^0.21.0",
         "@fetchproxy/bootstrap": "^2.2.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@chrischall/mcp-utils": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.19.3.tgz",
-      "integrity": "sha512-3iuAzuoGllSZGoIUMwBJx18q8lt/siA7nmHyB2NZX36lxHdN1vG7uUwpgsgBQ2dKvmeX1U1MTpE6XmWTO4RUww==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.21.0.tgz",
+      "integrity": "sha512-5ZUaiC2isua9FvPas37UdJNDNP/VDgZan0rX+zvWGbuEW+M9jofQfIca+DThLe8U2rRnyjzxQESco5k8KK63pQ==",
       "license": "MIT",
       "peerDependencies": {
         "@fetchproxy/server": "*",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@chrischall/mcp-utils": "^0.19.3",
+    "@chrischall/mcp-utils": "^0.21.0",
     "@fetchproxy/bootstrap": "^2.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -1,21 +1,31 @@
-import { expandPath as expandPathUtil, rawTextResult, textResult } from '@chrischall/mcp-utils';
+import { expandPath as expandPathUtil, minifiedResult, rawTextResult, type textResult } from '@chrischall/mcp-utils';
 import { z } from 'zod';
 import type { MessageRow, Recipient } from '../cache/store.js';
 import type { OFWClient } from '../client.js';
 import { parseLenient } from '@chrischall/mcp-utils';
 import { normalizeTimestampsInValue } from '../timestamps.js';
 
-// Pretty-printed JSON tool result. Thin wrapper over @chrischall/mcp-utils'
-// `textResult`, with one addition: every timestamp in the payload is rewritten
-// to ISO-8601 with an explicit offset and paired with a `<field>Display`
-// sibling in the operator's zone.
+// JSON tool result, with NO formatting whitespace. Thin wrapper over
+// @chrischall/mcp-utils' `minifiedResult`, with one addition: every timestamp
+// in the payload is rewritten to ISO-8601 with an explicit offset and paired
+// with a `<field>Display` sibling in the operator's zone.
 //
 // This is the single seam every structured tool response passes through, which
 // is the point — normalizing here rather than at each call site is what makes
 // it impossible for a tool to reintroduce the naive-local values that had
 // `sentAt` and `fetchedBodyAt` silently disagreeing by the UTC offset.
+//
+// Minified rather than `JSON.stringify(data, null, 2)`: indentation was 23% of
+// a 135 KB message page — about 8,000 tokens a call — and nothing downstream
+// reads it. This server has no `raw` rung (see tools/project.ts), so every
+// response is `compact` or `full` and every response is minified.
+//
+// Whitespace INSIDE a value is untouched. A message body's blank lines are
+// content, and `JSON.stringify` never touches them; the rule is pinned by
+// tests here and in mcp-utils, so do not replace this with a text-level
+// minifier.
 export function jsonResponse(data: unknown): ReturnType<typeof textResult> {
-  return textResult(normalizeTimestampsInValue(data));
+  return minifiedResult(normalizeTimestampsInValue(data));
 }
 
 // Raw-string tool result. Wrapper over @chrischall/mcp-utils' `rawTextResult`.

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -24,6 +24,8 @@ import { basename, join } from 'node:path';
 import { ApiRecipientSchema, deriveRead, expandPath, hasRealView, jsonErrorResponse, jsonResponse, mapRecipients, postMessageAndRefetch, reportsThreaded, reportsUnthreaded, textResponse, threadedReplyTo, verifyWriteLanded, withReadState } from './_shared.js';
 import { parseLenient } from '@chrischall/mcp-utils';
 import { pageState } from './pagination.js';
+import { MESSAGE_VIEWS, viewDrafts, viewMessages, viewOne } from './project.js';
+import { resolveView, viewParam } from '@chrischall/mcp-utils';
 
 // Schemas for the load-bearing fields of each /pub/v3 response this file
 // reads (issue #83). Loose: unknown keys pass through into cached listData.
@@ -323,11 +325,15 @@ export function registerMessageTools(
       q: z.string().describe('Substring match on subject AND body (case-insensitive). Use to find messages on a specific topic.').optional(),
       sort: z.enum(['newest', 'oldest']).describe('Result order: "newest" (default, newest first) or "oldest" (oldest first). This decides which end a truncated page keeps — with "newest" page 1 of a wide date range holds its most RECENT slice, with "oldest" its earliest. Use "oldest" to start at the old end of a range instead of paging to it.').optional(),
       autoRefresh: z.boolean().describe(AUTO_REFRESH_DESC).optional(),
+      view: viewParam(MESSAGE_VIEWS, {
+        note: 'compact omits OurFamilyWizard\'s raw `listData` echo, which duplicates this record\'s own id, subject, sentAt, recipients and read flag; the sender is promoted to `from`, and `files`/`replied` are kept. Pass "full" for the echo.',
+      }),
     },
   }, async (args) => {
     const page = args.page ?? 1;
     const size = args.size ?? 50;
     const sort = args.sort ?? 'newest';
+    const view = resolveView(args.view, MESSAGE_VIEWS);
     const folderArg = args.folderId ?? 'both';
 
     let folder: 'inbox' | 'sent' | undefined;
@@ -433,7 +439,11 @@ export function registerMessageTools(
     }
     payload.freshness = freshness;
 
-    payload.messages = messages;
+    // Projected HERE, at the last possible moment, so `returned`, `complete`
+    // and every note above are computed from the rows themselves — a
+    // projection must never be able to change what the response claims about
+    // its own contents.
+    payload.messages = viewMessages(view, messages);
 
     return jsonResponse(payload);
   });
@@ -444,9 +454,13 @@ export function registerMessageTools(
     inputSchema: {
       messageId: z.string().describe('Message ID (also accepts draft IDs — drafts are routed via the drafts cache)'),
       allowMarkRead: z.boolean().describe('Default true (the long-standing behaviour). Set false to refuse a fetch that would mark an unread INBOX message as READ on OurFamilyWizard — an irreversible, co-parent-visible change to the record. Reads that cannot stamp anything (a cached body, a sent message, an already-read message) still succeed. The server-wide OFW_ALLOW_MARK_READ=false is a ceiling this argument cannot raise.').optional(),
+      view: viewParam(MESSAGE_VIEWS, {
+        note: 'compact omits OurFamilyWizard\'s raw `listData` echo, which duplicates this record\'s own id, subject, sentAt, recipients and read flag; the sender is promoted to `from`, and `files`/`replied` are kept. Pass "full" for the echo.',
+      }),
     },
   }, async (args) => {
     const id = Number(args.messageId);
+    const view = resolveView(args.view, MESSAGE_VIEWS);
     const cache = cacheProvider();
 
     // Draft routing: if this id is in the drafts cache, return a
@@ -477,7 +491,10 @@ export function registerMessageTools(
         fetchedBodyAt: draftRow.modifiedAt,
         replyToId: draftRow.replyToId,
         chainRootId: null,
-        listData: draftRow.listData,
+        // OFW's raw echo, on `full` only. Everything above it is derived from
+        // the DRAFTS table, which is the source of truth for a draft id — the
+        // echo duplicates it and adds a stale copy of nothing else.
+        ...(view === 'compact' ? {} : { listData: draftRow.listData }),
         attachments: [],
         // Concurrency token — pass as expectedRevision to ofw_save_draft /
         // ofw_delete_draft / ofw_send_message to assert you are acting on
@@ -550,7 +567,7 @@ export function registerMessageTools(
       // this call may have re-hit detail for view status, the message content
       // itself was not re-verified, so report the folder's cache freshness.
       const freshness = await buildFreshness(cache, { source: 'cache', folders: [row.folder] });
-      return jsonResponse({ ...withReadState(row), attachments, freshness });
+      return jsonResponse({ ...viewOne(view, withReadState(row)), attachments, freshness });
     }
 
     // Everything above this line was served without asking OFW for a body.
@@ -601,7 +618,7 @@ export function registerMessageTools(
     const attachments = await cache.listAttachmentsForMessage(detail.id);
     // Fetched live from OFW in this call — current by construction.
     const freshness = await buildFreshness(cache, { source: 'live', folders: [folder] });
-    return jsonResponse({ ...withReadState(row), attachments, freshness });
+    return jsonResponse({ ...viewOne(view, withReadState(row)), attachments, freshness });
   });
 
   if (allowSend) server.registerTool('ofw_send_message', {
@@ -992,10 +1009,14 @@ export function registerMessageTools(
       size: z.number().int().min(1).describe('Drafts per page (default 50)').optional(),
       verify: z.boolean().describe('Default true: when the drafts cache is not verified-fresh, run a drafts sync first (cheap — one list page plus one detail per draft) so the response is server-confirmed in one call. Set false to serve straight from the local cache with no OFW requests.').optional(),
       autoRefresh: z.boolean().describe(AUTO_REFRESH_DESC).optional(),
+      view: viewParam(MESSAGE_VIEWS, {
+        note: 'compact omits OurFamilyWizard\'s raw `listData` echo, which duplicates this draft\'s own id, subject, modifiedAt and recipients. `revision`, `draftKey` and `cacheStatus` are kept on both rungs.',
+      }),
     },
   }, async (args) => {
     const page = args.page ?? 1;
     const size = args.size ?? 50;
+    const view = resolveView(args.view, MESSAGE_VIEWS);
     const cache = cacheProvider();
 
     // Auto-verify (default on): drafts change rarely but INVISIBLY — a web-app
@@ -1101,7 +1122,7 @@ export function registerMessageTools(
       payload.verifyNote = verifyNote;
     }
     payload.freshness = freshness;
-    payload.drafts = drafts;
+    payload.drafts = viewDrafts(view, drafts);
     return jsonResponse(payload);
   });
 
@@ -1362,6 +1383,11 @@ export function registerMessageTools(
       page: z.number().int().min(1).describe('Page (default 1)').optional(),
       size: z.number().int().min(1).describe('Per page (default 50)').optional(),
       autoRefresh: z.boolean().describe(AUTO_REFRESH_DESC).optional(),
+      // No `view` here, deliberately. This tool never emitted a cache row: it
+      // builds a VERDICT list of `{id, subject, sentAt, unreadBy}`, which is
+      // already narrower than anything the compact projection would produce.
+      // A parameter offering a rung that changes nothing is the no-op schema
+      // `viewParam` exists to refuse.
     },
   }, async (args) => {
     const page = args.page ?? 1;

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -1,0 +1,191 @@
+import { projectOrRaw, pruneUndefined, type View } from '@chrischall/mcp-utils';
+import type { DraftRow, MessageRow } from '../cache/store.js';
+
+/**
+ * The compact projection (`docs` — fleet convention "Response shape", and
+ * `@chrischall/mcp-utils`' `view` vocabulary).
+ *
+ * A default `ofw_list_messages()` is 50 messages, and it used to weigh 135 KB
+ * — roughly 34,000 tokens for one call. Measured against a real 1,335-row
+ * cache, `listData` was 58% of that, and 78% of `listData` duplicated fields
+ * the same object already emitted at the top level:
+ *
+ * - `listData.date` is 421 bytes per message: ELEVEN pre-formatted renderings
+ *   of one timestamp (`displayDate`, `threeCharMonthWeekdayTimeNoYear`, …)
+ *   sitting beside the `sentAt` + `sentAtDisplay` that `timestamps.ts` already
+ *   derives — and `normalizeTimestampsInValue` then adds a twelfth inside it.
+ * - `listData.recipients[].user` carries eight fields per person, including
+ *   `color` and `displayInitials`, next to the three-field recipients the row
+ *   already normalised.
+ * - `listData.read` / `.showNeverViewed` are FORCED to agree with the derived
+ *   `read` before they are emitted (`withReadState`), so the copy cannot even
+ *   disagree usefully.
+ * - `listData.preview` is a truncation of the body in the same object.
+ *
+ * What compact keeps is everything a caller can act on. What it drops is what
+ * the response says twice, what is near-constant across every row, and what
+ * `folder` already answers. `full` returns the row untouched.
+ *
+ * There is no `raw` rung. A message here is ASSEMBLED — the list endpoint
+ * supplies `listData`, the detail GET supplies `body` and the real `viewedAt`,
+ * and `timestamps.ts` rewrites both — so there is no single upstream payload
+ * to hand back, and a `raw` that skipped normalisation would put naive local
+ * times back beside UTC ones on the one rung a caller reaches for when
+ * something already looks wrong.
+ */
+export const MESSAGE_VIEWS = ['compact', 'full'] as const;
+
+const LABEL = 'ofw-mcp';
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+/**
+ * Who sent it.
+ *
+ * `fromUser` is the empty string on all 1,335 rows of a real cache — inbox and
+ * sent alike — because OFW names the sender in the LIST payload's `author` and
+ * nowhere else. So this is not a nicety: deleting `listData` without promoting
+ * it would have taken the sender's name off every message, and compact is
+ * where a field that has never worked starts working.
+ */
+function senderOf(row: MessageRow): string | null {
+  if (typeof row.fromUser === 'string' && row.fromUser !== '') return row.fromUser;
+  const author = asRecord(asRecord(row.listData)?.author);
+  const name = author?.name;
+  return typeof name === 'string' && name !== '' ? name : null;
+}
+
+/**
+ * How many attachments — as a NUMBER, from a field OFW sends two ways (`1`, or
+ * `[]` on the nine live rows that have no files).
+ *
+ * `undefined` when OFW reported nothing, and the caller then sees no `files`
+ * key at all. Defaulting to 0 there would turn "we did not see a count" into
+ * "there are none", which is the shape that reads as a verified absence — the
+ * failure every guard in this server exists to prevent.
+ */
+function fileCountOf(row: MessageRow): number | undefined {
+  const files = asRecord(row.listData)?.files;
+  if (typeof files === 'number') return files;
+  if (Array.isArray(files)) return files.length;
+  return undefined;
+}
+
+/** Whether this message has been replied to. Varies on 442 of 1,335 live rows. */
+function repliedOf(row: MessageRow): boolean | undefined {
+  const replied = asRecord(row.listData)?.replied;
+  return typeof replied === 'boolean' ? replied : undefined;
+}
+
+/**
+ * One cached message row, projected.
+ *
+ * Key order matches the row's, so a caller reading either rung sees the same
+ * fields in the same places. `undefined` values are dropped by
+ * `JSON.stringify`, which is how the optional keys above stay absent rather
+ * than becoming nulls that claim more than we know.
+ */
+export function compactMessage(row: MessageRow & { read?: boolean }): Record<string, unknown> {
+  const { listData: _drop, fromUser: _dropFrom, ...rest } = row;
+  // `pruneUndefined`, not just `JSON.stringify`'s own dropping of undefined:
+  // an optional field must be ABSENT from the object a test or an in-process
+  // caller inspects, not present-and-undefined. "We did not see a count" and
+  // "there are none" have to be different facts at every layer, not only after
+  // serialisation.
+  return pruneUndefined({
+    id: rest.id,
+    folder: rest.folder,
+    subject: rest.subject,
+    from: senderOf(row),
+    sentAt: rest.sentAt,
+    recipients: rest.recipients,
+    read: rest.read,
+    replied: repliedOf(row),
+    files: fileCountOf(row),
+    replyToId: rest.replyToId,
+    chainRootId: rest.chainRootId,
+    body: rest.body,
+    fetchedBodyAt: rest.fetchedBodyAt,
+    // Anything a TOOL added on top of the cache row — `attachments`,
+    // `revision`, `cacheStatus`, `serverConfirmed`, `freshness` — is kept
+    // wholesale. Those are this server's own answers, never OFW's echo, and a
+    // projection that dropped one would be removing the thing the caller
+    // asked for rather than the thing they got twice.
+    ...omitKnown(rest as Record<string, unknown>),
+  });
+}
+
+/** The row's own columns, so the spread above adds only tool-supplied extras. */
+const ROW_KEYS = new Set([
+  'id', 'folder', 'subject', 'sentAt', 'recipients', 'read', 'replyToId', 'chainRootId', 'body', 'fetchedBodyAt',
+  'modifiedAt',
+]);
+
+function omitKnown(rest: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(rest)) if (!ROW_KEYS.has(key)) out[key] = value;
+  return out;
+}
+
+/**
+ * One cached draft row, projected.
+ *
+ * `revision`, `draftKey` and `cacheStatus` are added by the tool rather than
+ * the cache and survive untouched — they are the concurrency token, the
+ * identity that outlives the create-then-delete churn, and the statement of
+ * whether a walk actually compared this row against OFW. Losing any of them to
+ * a projection would break every guarded write in this server.
+ */
+export function compactDraft(row: DraftRow): Record<string, unknown> {
+  const { listData: _drop, ...rest } = row;
+  return pruneUndefined({
+    id: rest.id,
+    subject: rest.subject,
+    recipients: rest.recipients,
+    replyToId: rest.replyToId,
+    modifiedAt: rest.modifiedAt,
+    body: rest.body,
+    ...omitKnown(rest as Record<string, unknown>),
+  });
+}
+
+/**
+ * Project a page of messages, or hand it back whole.
+ *
+ * The array is projected as ONE unit on purpose. Row-at-a-time would let a
+ * single unexpected row come back projected-to-nothing among 49 good ones —
+ * a hole in the middle of an answer, which is worse than a fat page and
+ * indistinguishable from a message with no content. It also means one stderr
+ * line per page rather than fifty.
+ */
+export function viewMessages<T extends MessageRow>(view: View, rows: T[]): Array<T | Record<string, unknown>> {
+  if (view !== 'compact') return rows;
+  return projectOrRaw(rows, (rs) => rs.map((r) => compactMessage(r)), {
+    label: LABEL,
+    context: 'the cached message rows',
+  });
+}
+
+/** As {@link viewMessages}, for drafts. */
+export function viewDrafts<T extends DraftRow>(view: View, rows: T[]): Array<T | Record<string, unknown>> {
+  if (view !== 'compact') return rows;
+  return projectOrRaw(rows, (rs) => rs.map((r) => compactDraft(r)), {
+    label: LABEL,
+    context: 'the cached draft rows',
+  });
+}
+
+/**
+ * One message, projected — `ofw_get_message`'s single-record path.
+ *
+ * Same fallback as the array form: a row this projector cannot read comes back
+ * whole. A detail read is the call a caller makes when they need everything
+ * about one message, so answering it with a record that has holes in it is the
+ * worst place in this server to get a projection wrong.
+ */
+export function viewOne<T extends MessageRow>(view: View, row: T): T | Record<string, unknown> {
+  if (view !== 'compact') return row;
+  return projectOrRaw(row, (r) => compactMessage(r), { label: LABEL, context: 'a cached message row' });
+}

--- a/tests/tools/_shared.test.ts
+++ b/tests/tools/_shared.test.ts
@@ -4,11 +4,24 @@ import { deriveRead, expandPath, hasRealView, jsonResponse, mapRecipients, textR
 import { sampleMessageRow } from '../_fixtures.js';
 
 describe('jsonResponse', () => {
-  it('wraps a payload as a single text content block with pretty-printed JSON', () => {
+  it('wraps a payload as a single text content block with NO formatting whitespace', () => {
+    // Indentation was 23% of a 135 KB message page — roughly 8,000 tokens a
+    // call — and nothing downstream reads it. This server has no `raw` rung
+    // (tools/project.ts), so every response is minified.
     const result = jsonResponse({ foo: 'bar', n: 1 });
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe('text');
-    expect(result.content[0].text).toBe('{\n  "foo": "bar",\n  "n": 1\n}');
+    expect(result.content[0].text).toBe('{"foo":"bar","n":1}');
+  });
+
+  it('never touches whitespace INSIDE a value — a message body is content', () => {
+    // The distinction the whole rule turns on. A text-level minifier would
+    // collapse the blank line between paragraphs of every OFW message, which
+    // is most of what this server returns.
+    const body = 'Line one.\n\n  Indented continuation.\n\nThanks   ';
+    const text = jsonResponse({ body }).content[0].text;
+    expect(JSON.parse(text).body).toBe(body);
+    expect(text.split('\n')).toHaveLength(1);
   });
 
   it('serializes arrays and nested objects', () => {

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -321,7 +321,10 @@ describe('read-state reconciliation (bug: stale read flag vs viewedAt)', () => {
     upsertMessage(staleReadRow());
     const client = new OFWClient();
     setup(client);
-    const parsed = JSON.parse((await handlers.get('ofw_list_messages')!({ folderId: 'inbox' })).content[0].text);
+    // `full`, because the invariant under test is about the raw echo AGREEING
+    // with the derived flag. On `compact` the echo is not emitted at all, so
+    // there is nothing left to contradict — asserted separately below.
+    const parsed = JSON.parse((await handlers.get('ofw_list_messages')!({ folderId: 'inbox', view: 'full' })).content[0].text);
     const msg = parsed.messages[0];
     expect(msg.read).toBe(true);
     // and the raw listData flags no longer contradict the recipient viewedAt
@@ -332,12 +335,25 @@ describe('read-state reconciliation (bug: stale read flag vs viewedAt)', () => {
     expect(msg.recipients[0].userId).toBe(3039201);
   });
 
+  it('the default view carries the derived read flag and no echo to contradict it', async () => {
+    upsertMessage(staleReadRow());
+    const client = new OFWClient();
+    setup(client);
+    const parsed = JSON.parse((await handlers.get('ofw_list_messages')!({ folderId: 'inbox' })).content[0].text);
+    const msg = parsed.messages[0];
+    expect(msg.read).toBe(true);
+    expect(msg).not.toHaveProperty('listData');
+    // The reconciliation's whole purpose — one payload that cannot disagree
+    // with itself — is reached on compact by removing the second opinion.
+    expect(msg.recipients[0].viewedAt).toBe('2026-07-17T08:37:57-04:00');
+  });
+
   it('ofw_get_message reports read:true for the same record', async () => {
     upsertMessage(staleReadRow());
     const client = new OFWClient();
     const spy = vi.spyOn(client, 'request');
     setup(client);
-    const parsed = JSON.parse((await handlers.get('ofw_get_message')!({ messageId: '534973630' })).content[0].text);
+    const parsed = JSON.parse((await handlers.get('ofw_get_message')!({ messageId: '534973630', view: 'full' })).content[0].text);
     expect(parsed.read).toBe(true);
     expect(parsed.listData.showNeverViewed).toBe(false);
     expect(spy).not.toHaveBeenCalled(); // inbox with a real view time isn't re-fetched
@@ -353,7 +369,7 @@ describe('read-state reconciliation (bug: stale read flag vs viewedAt)', () => {
     });
     const client = new OFWClient();
     setup(client);
-    const parsed = JSON.parse((await handlers.get('ofw_list_messages')!({ folderId: 'inbox' })).content[0].text);
+    const parsed = JSON.parse((await handlers.get('ofw_list_messages')!({ folderId: 'inbox', view: 'full' })).content[0].text);
     expect(parsed.messages[0].read).toBe(false);
     expect(parsed.messages[0].listData.showNeverViewed).toBe(true);
   });
@@ -589,6 +605,24 @@ describe('ofw_get_message (cache-first)', () => {
     expect(parsed.chainRootId).toBeNull();
     // The drafts-table route doesn't hit OFW or the messages cache.
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('carries OFW’s raw echo on `full` and omits it on the default view', async () => {
+    upsertDraft({
+      id: 802, subject: 'D', body: 'b', recipients: [], replyToId: null,
+      modifiedAt: '2026-05-04T12:00:00Z',
+      listData: { date: { dateTime: '2026-05-04T12:00:00Z' }, preview: 'b...' },
+    });
+    const client = new OFWClient();
+    setup(client);
+    const full = JSON.parse((await handlers.get('ofw_get_message')!({ messageId: '802', view: 'full' })).content[0].text);
+    expect(full.listData).toMatchObject({ preview: 'b...' });
+    // The drafts TABLE is the source of truth for a draft id, so on compact
+    // the echo is dropped entirely rather than shipped as a second opinion.
+    const compact = JSON.parse((await handlers.get('ofw_get_message')!({ messageId: '802' })).content[0].text);
+    expect(compact).not.toHaveProperty('listData');
+    expect(compact.body).toBe('b');
+    expect(compact.revision).toBe(full.revision);
   });
 
   it('returns folder="drafts" even when no matching messages-table row exists', async () => {
@@ -3476,9 +3510,16 @@ describe('messages.ts — coverage backfill', () => {
     const c = new OFWClient();
     vi.spyOn(c, 'request').mockResolvedValue({ id: 77, subject: 'S', files: [] }); // detail: no subject/from/date/body
     setup(c);
+    const full = JSON.parse((await handlers.get('ofw_get_message')!({ messageId: 77, view: 'full' })).content[0].text);
+    expect(full.fromUser).toBe('');  // 180
+    expect(full.body).toBe('');      // 183
+    // On compact, `fromUser` is replaced by `from` — null here because neither
+    // source named a sender, rather than the empty string that made an unknown
+    // sender look like a blank one.
     const out = JSON.parse((await handlers.get('ofw_get_message')!({ messageId: 77 })).content[0].text);
-    expect(out.fromUser).toBe('');  // 180
-    expect(out.body).toBe('');      // 183
+    expect(out).not.toHaveProperty('fromUser');
+    expect(out.from).toBeNull();
+    expect(out.body).toBe('');
   });
 
   it('send_message: reports the missing required fields for a fresh send', async () => {
@@ -3827,7 +3868,7 @@ describe('ofw_get_message — sent view-status refresh', () => {
       recipients: [{ user: { id: 1, name: 'Co-parent' }, viewed: { dateTime: '2026-06-16T15:49:20' } }],
     });
     setup(client);
-    const result = await handlers.get('ofw_get_message')!({ messageId: '600' });
+    const result = await handlers.get('ofw_get_message')!({ messageId: '600', view: 'full' });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.recipients[0].viewedAt).toBe('2026-06-16T15:49:20-04:00');
     expect(getMessage(600)?.recipients[0].viewedAt).toBe('2026-06-16T15:49:20');
@@ -3849,7 +3890,7 @@ describe('ofw_get_message — sent view-status refresh', () => {
       recipients: [{ user: { id: 1, name: 'Co-parent' }, viewed: null }],
     });
     setup(client);
-    const result = await handlers.get('ofw_get_message')!({ messageId: '603' });
+    const result = await handlers.get('ofw_get_message')!({ messageId: '603', view: 'full' });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.recipients[0].viewedAt).toBeNull();
     expect(parsed.listData.showNeverViewed).toBe(true);

--- a/tests/tools/project.test.ts
+++ b/tests/tools/project.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { compactMessage, compactDraft, viewMessages, viewDrafts, MESSAGE_VIEWS } from '../../src/tools/project.js';
+import type { MessageRow, DraftRow } from '../../src/cache/store.js';
+
+afterEach(() => vi.restoreAllMocks());
+
+/** A row shaped like the ones the cache actually holds (verified against 1,335 live rows). */
+function row(over: Partial<MessageRow> = {}): MessageRow & { read: boolean } {
+  return {
+    id: 533130648,
+    folder: 'inbox',
+    subject: 'Tyler Place 2027',
+    // Empty on EVERY cached row ever observed — inbox and sent alike.
+    fromUser: '',
+    sentAt: '2026-07-10T23:38:50',
+    recipients: [{ userId: 3039201, name: 'Chris Hall', viewedAt: null }],
+    body: 'I sent a text today.\n\nThanks ',
+    fetchedBodyAt: '2026-07-12T01:57:43.445Z',
+    replyToId: null,
+    chainRootId: null,
+    read: true,
+    listData: {
+      id: 533130648,
+      subject: 'Tyler Place 2027',
+      date: { dateTime: '2026-07-10T23:38:50', displayDate: '7/10/2026', weekday: 'Friday' },
+      showNeverViewed: false,
+      recipients: [{ user: { name: 'Chris Hall', userId: 3039201, displayInitials: 'CH', color: '#3366CC' } }],
+      folder: 13471258,
+      draft: false,
+      preview: 'I sent a text today...',
+      files: 1,
+      read: true,
+      replied: false,
+      canReply: true,
+      author: { userId: 3039202, name: 'Alison Hall', displayInitials: 'AH', color: '#66AA00' },
+    },
+    ...over,
+  } as MessageRow & { read: boolean };
+}
+
+describe('compactMessage', () => {
+  it('drops listData, which is 58% of a page and 78% duplication', () => {
+    const out = compactMessage(row());
+    expect(out).not.toHaveProperty('listData');
+  });
+
+  it('keeps every field a caller can act on', () => {
+    const out = compactMessage(row());
+    expect(out).toMatchObject({
+      id: 533130648,
+      folder: 'inbox',
+      subject: 'Tyler Place 2027',
+      sentAt: '2026-07-10T23:38:50',
+      read: true,
+      replyToId: null,
+      chainRootId: null,
+      body: 'I sent a text today.\n\nThanks ',
+      fetchedBodyAt: '2026-07-12T01:57:43.445Z',
+    });
+  });
+
+  /**
+   * The one field that was ONLY inside the blob. `fromUser` is the empty
+   * string on all 1,335 rows in a real cache — inbox and sent — because OFW
+   * puts the sender in the list payload's `author` and nowhere else. Deleting
+   * listData without promoting this would have lost the sender's name from
+   * every message, so compact is where that field starts working.
+   */
+  it('promotes the sender, which no top-level field has ever carried', () => {
+    expect(compactMessage(row()).from).toBe('Alison Hall');
+    expect(compactMessage(row()).fromUser).toBeUndefined();
+  });
+
+  it('prefers a real fromUser if OFW ever populates one', () => {
+    expect(compactMessage(row({ fromUser: 'Someone Else' })).from).toBe('Someone Else');
+  });
+
+  it('says null rather than guessing when neither source names a sender', () => {
+    expect(compactMessage(row({ listData: { files: 0 } })).from).toBeNull();
+  });
+
+  it('keeps the attachment count, which nothing else reports', () => {
+    expect(compactMessage(row()).files).toBe(1);
+  });
+
+  it('normalises the attachment count OFW sends as an empty ARRAY (9 live rows do)', () => {
+    expect(compactMessage(row({ listData: { files: [] } })).files).toBe(0);
+  });
+
+  it('keeps a VERIFIED zero rather than omitting it — 0 attachments is an answer', () => {
+    expect(compactMessage(row({ listData: { files: 0 } })).files).toBe(0);
+  });
+
+  it('omits files entirely when OFW did not report it, never defaulting to 0', () => {
+    // "We did not see a count" and "there are none" are different facts, and
+    // the second one reads as verified.
+    expect(compactMessage(row({ listData: {} }))).not.toHaveProperty('files');
+  });
+
+  it('keeps `replied`, which varies across 442 of 1,335 live rows', () => {
+    expect(compactMessage(row()).replied).toBe(false);
+  });
+
+  it('drops the near-constant and the derivable', () => {
+    const out = compactMessage(row());
+    // canReply is true on 1,330 of 1,335; draft is answered by `folder`;
+    // preview is a truncation of the body sitting beside it; showNeverViewed
+    // is forced to agree with `read` before it is ever emitted.
+    for (const key of ['canReply', 'draft', 'preview', 'showNeverViewed', 'archived', 'firstView']) {
+      expect(out).not.toHaveProperty(key);
+    }
+  });
+
+  it('keeps the recipients the row already normalised, not OFW’s eight-field user objects', () => {
+    expect(compactMessage(row()).recipients).toEqual([{ userId: 3039201, name: 'Chris Hall', viewedAt: null }]);
+  });
+
+  it('never alters a body — whitespace in a message is content', () => {
+    const body = 'Line one.\n\n  Indented.\n\nTrailing:   ';
+    expect(compactMessage(row({ body })).body).toBe(body);
+  });
+
+  it('survives a row whose listData is null or a legacy string', () => {
+    expect(compactMessage(row({ listData: null })).from).toBeNull();
+    expect(compactMessage(row({ listData: 'legacy' })).from).toBeNull();
+  });
+});
+
+describe('compactDraft', () => {
+  const draft = {
+    id: 99,
+    subject: 'Re: schedule',
+    body: 'body text',
+    recipients: [{ userId: 1, name: 'A', viewedAt: null }],
+    replyToId: 42,
+    modifiedAt: '2026-07-10T23:38:50',
+    listData: { date: { dateTime: 'x', weekday: 'Friday' }, author: { name: 'Me' }, preview: 'body...' },
+    revision: 'abc',
+    draftKey: 'dk_1',
+    cacheStatus: 'fresh',
+  } as unknown as DraftRow & Record<string, unknown>;
+
+  it('drops listData but keeps the fields a write must echo back', () => {
+    const out = compactDraft(draft);
+    expect(out).not.toHaveProperty('listData');
+    // revision and draftKey are the concurrency token and the stable identity;
+    // losing either to a projection would break every guarded write.
+    expect(out).toMatchObject({ id: 99, revision: 'abc', draftKey: 'dk_1', cacheStatus: 'fresh', replyToId: 42 });
+  });
+
+  it('keeps the body in full — a draft IS its body', () => {
+    expect(compactDraft(draft).body).toBe('body text');
+  });
+});
+
+describe('the view selector', () => {
+  it('offers compact and full, and NOT raw', () => {
+    // A message row is assembled from the list endpoint and the detail GET,
+    // so there is no single upstream payload to hand back.
+    expect(MESSAGE_VIEWS).toEqual(['compact', 'full']);
+  });
+
+  it('projects for compact and passes the rows through for full', () => {
+    const rows = [row()];
+    expect(viewMessages('compact', rows)[0]).not.toHaveProperty('listData');
+    expect(viewMessages('full', rows)[0]).toHaveProperty('listData');
+    expect(viewMessages('full', rows)[0]).toBe(rows[0]);
+  });
+
+  it('returns the rows UNPROJECTED and warns when the projection trips', () => {
+    // The property that makes compact-by-default survivable: a cache row that
+    // is not the shape this projector expects yields everything, not a record
+    // with holes in it that reads like a verified answer.
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const hostile = [Object.defineProperty({}, 'listData', { get() { throw new Error('boom'); } })] as unknown as MessageRow[];
+    expect(viewMessages('compact', hostile)[0]).toBe(hostile[0]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('ofw-mcp'));
+  });
+
+  it('projects the whole array or none of it, so one bad row cannot half-answer', () => {
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const rows = [row(), Object.defineProperty({}, 'listData', { get() { throw new Error('boom'); } })] as unknown as MessageRow[];
+    expect(viewMessages('compact', rows)).toBe(rows);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('viewDrafts behaves the same way', () => {
+    const drafts = [{ id: 1, subject: 's', body: 'b', recipients: [], replyToId: null, modifiedAt: 'x', listData: {} }] as DraftRow[];
+    expect(viewDrafts('compact', drafts)[0]).not.toHaveProperty('listData');
+    expect(viewDrafts('full', drafts)).toBe(drafts);
+  });
+});


### PR DESCRIPTION
> **Draft — blocked on chrischall/mcp-utils#185.** This consumes `viewParam`/`resolveView`/`projectOrRaw`/`minifiedResult` and requires `@chrischall/mcp-utils@^0.21.0`, which does not exist until that PR merges and publishes. Kept as a draft so it cannot arm auto-merge in the meantime. Ready to mark ready once mcp-utils ships.

The reference implementation of the fleet's `view` vocabulary.

## What a default call cost

`ofw_list_messages()` defaults to `size: 50`, and `listMessages` does `SELECT *` and hands the row straight out. Measured against a real 1,335-row cache:

- **135 KB, ≈34,000 tokens** for one call.
- `listData` is **58%** of it, and **78% of `listData` duplicates fields the same object already emits at the top level**.
- `listData.date` alone is **421 bytes per message — eleven pre-formatted renderings of one timestamp** (`displayDate`, `threeCharMonthWeekdayTimeNoYear`, …), sitting beside the `sentAt` + `sentAtDisplay` that `timestamps.ts` derives. `normalizeTimestampsInValue` then adds a *twelfth* inside it.
- `listData.recipients[].user` carries eight fields per person — `color`, `displayInitials` — next to the three-field recipients the row already normalised.
- `listData.read` / `.showNeverViewed` are **forced** to agree with the derived `read` by `withReadState` before they are emitted, so the copy cannot even disagree usefully.
- `listData.preview` is a truncation of the body in the same object.

## The trap I nearly walked into

**`fromUser` is the empty string on all 1,335 rows — inbox *and* sent.** OFW names the sender only in the list payload's `author`. Deleting `listData` without promoting it would have silently taken the sender's name off every message in the server.

So compact emits `from`, preferring a real `fromUser` if OFW ever populates one and falling back to `author.name`. Compact is where a field that has never worked starts working.

## Judgement calls, with the numbers behind them

| field | live distribution | decision |
|---|---|---|
| `replied` | 442 true / 893 false | **kept** — varies, actionable, nothing else carries it |
| `files` | 51 rows non-zero; **9 rows send `[]`, not a number** | **kept**, normalised to a number |
| `canReply` | true on 1,330 of 1,335 | dropped |
| `archived`, `firstView` | absent on 1,326 of 1,335 | dropped |
| `draft` | answered by `folder` | dropped |
| `inReplyTo`, `showContext` | absent on 1,326; `replyToId` already carries the derived value per `threadedReplyTo` | dropped |

`files` is **omitted entirely when OFW reported nothing**, rather than defaulting to `0`. "We did not see a count" and "there are none" are different facts, and the second reads as verified — the same rule this server already applies to `drafts: 0` from a deferred sync.

## No `raw` rung, deliberately

A message here is **assembled**: the list endpoint supplies `listData`, the detail GET supplies `body` and the real `viewedAt`, and `timestamps.ts` rewrites both. There is no single upstream payload to hand back. And a `raw` that skipped normalisation would put naive local times back beside UTC ones on the one rung a caller reaches for when something already looks wrong — the bug that moved a 10:38 PM send onto the next calendar day.

`ofw_get_unread_sent` gets no `view` at all: it emits a verdict list (`{id, subject, sentAt, unreadBy}`) that is already narrower than the projection would be, and a parameter offering a rung that changes nothing is the no-op schema `viewParam` exists to refuse.

## Safety

- **A projection that trips returns the rows whole** (`projectOrRaw`) and warns on stderr — for the **entire array**, never per row. A hole in the middle of a 50-message page is worse than a fat page and is indistinguishable from a message with no content.
- **Applied at the last moment**, after `returned` / `complete` / `completeNote` are computed from the rows themselves, so a projection can never change what the response claims about its own contents.
- Key order is preserved, so paging state still precedes the data array.

## Whitespace

`jsonResponse` now uses `minifiedResult`. Indentation was **23% of that page — about 8,000 tokens a call** — and nothing downstream reads it. This server has no `raw` rung, so every response is minified.

**Whitespace inside a value is untouched.** A message body's blank lines are content; `JSON.stringify` never touches them, and a text-level minifier would destroy them. Pinned by a test here (`_shared.test.ts`) and two in mcp-utils.

## Result

Measured end to end through the real projection on a real 50-message page:

| | size | tokens |
|---|---|---|
| before | 126.3 KB | ≈32,300 |
| after | **39.8 KB** | **≈10,200** |
| | **−68%** | |

## Tests

918 passing, **100% statements / branches / functions / lines**. 21 new in `tests/tools/project.test.ts`.

Seven existing tests changed, none loosened. Five asserted the read-state reconciliation *through* `listData` — that invariant is about the raw echo agreeing with the derived flag, so they now run with `view: 'full'`, and a new test asserts that on compact there is no second opinion left to contradict. One asserted `fromUser: ''` and now checks both rungs. One asserted pretty-printed output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiLLBREAJYF1DCDeg8Kuw7