### PR TITLE
fix(tools): one sender key per rung, and a projector keeps only its own columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,13 @@ something already looks wrong. `ofw_get_unread_sent` has no `view` either: it
 emits a verdict list (`{id, subject, sentAt, unreadBy}`), already narrower than
 the projection.
 
+**One tool names the sender the same way on every path.** `ofw_get_message`'s
+draft-routing branch emits `from: null` on compact (a draft is unsent, so there
+is no sender — and `''` would read as one we failed to find), not the
+`fromUser: ''` the `full` rung keeps. A tool whose compact rung used two
+different sender keys depending on whether the id happened to be a draft would
+be worse than either name.
+
 **A projection that trips returns the rows WHOLE** (`projectOrRaw`), warns on
 stderr, and does so for the entire array rather than per row — a hole in the
 middle of a 50-message page is worse than a fat page and is indistinguishable

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -481,7 +481,13 @@ export function registerMessageTools(
         id: draftRow.id,
         folder: 'drafts',
         subject: draftRow.subject,
-        fromUser: '',
+        // One tool, one sender key per rung. `compact` names the sender `from`
+        // everywhere else, so emitting `fromUser` here would mean the same
+        // tool's compact rung used two different key names depending on
+        // whether the id happened to be a draft. `null` rather than '' because
+        // a draft has no sender yet — it is unsent, and an empty string reads
+        // as a sender whose name we failed to find.
+        ...(view === 'compact' ? { from: null } : { fromUser: '' }),
         sentAt: draftRow.modifiedAt,
         recipients: draftRow.recipients,
         body: draftRow.body,

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -113,19 +113,31 @@ export function compactMessage(row: MessageRow & { read?: boolean }): Record<str
     // wholesale. Those are this server's own answers, never OFW's echo, and a
     // projection that dropped one would be removing the thing the caller
     // asked for rather than the thing they got twice.
-    ...omitKnown(rest as Record<string, unknown>),
+    ...omitKnown(rest as Record<string, unknown>, MESSAGE_ROW_KEYS),
   });
 }
 
-/** The row's own columns, so the spread above adds only tool-supplied extras. */
-const ROW_KEYS = new Set([
+/**
+ * Each projector's OWN columns — the ones it names explicitly above — so the
+ * spread adds only what a tool supplied on top of the cache row.
+ *
+ * Two sets rather than one union. A shared set is the union of `MessageRow` and
+ * `DraftRow`, so each projector would silently swallow any tool-supplied extra
+ * that happened to be named after the OTHER shape's column: a message carrying
+ * a `modifiedAt`, a draft carrying a `folder`. Nothing supplies those today,
+ * which is exactly what makes it the kind of trap that is only found once
+ * something does — and it would have quietly contradicted the "kept wholesale"
+ * promise below.
+ */
+const MESSAGE_ROW_KEYS = new Set([
   'id', 'folder', 'subject', 'sentAt', 'recipients', 'read', 'replyToId', 'chainRootId', 'body', 'fetchedBodyAt',
-  'modifiedAt',
 ]);
 
-function omitKnown(rest: Record<string, unknown>): Record<string, unknown> {
+const DRAFT_ROW_KEYS = new Set(['id', 'subject', 'recipients', 'replyToId', 'modifiedAt', 'body']);
+
+function omitKnown(rest: Record<string, unknown>, own: ReadonlySet<string>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(rest)) if (!ROW_KEYS.has(key)) out[key] = value;
+  for (const [key, value] of Object.entries(rest)) if (!own.has(key)) out[key] = value;
   return out;
 }
 
@@ -147,7 +159,7 @@ export function compactDraft(row: DraftRow): Record<string, unknown> {
     replyToId: rest.replyToId,
     modifiedAt: rest.modifiedAt,
     body: rest.body,
-    ...omitKnown(rest as Record<string, unknown>),
+    ...omitKnown(rest as Record<string, unknown>, DRAFT_ROW_KEYS),
   });
 }
 

--- a/tests/tools/messages.test.ts
+++ b/tests/tools/messages.test.ts
@@ -599,7 +599,10 @@ describe('ofw_get_message (cache-first)', () => {
     expect(parsed.folder).toBe('drafts');
     expect(parsed.body).toBe('NEW body');
     expect(parsed.subject).toBe('Fresh subject');
-    expect(parsed.fromUser).toBe('');
+    // A draft has no sender — it is unsent — and compact names the sender
+    // `from` on every rung of this tool, drafts included.
+    expect(parsed).not.toHaveProperty('fromUser');
+    expect(parsed.from).toBeNull();
     expect(parsed.sentAt).toBe('2026-05-04T08:00:00-04:00');
     expect(parsed.fetchedBodyAt).toBe('2026-05-04T08:00:00-04:00');
     expect(parsed.chainRootId).toBeNull();

--- a/tests/tools/project.test.ts
+++ b/tests/tools/project.test.ts
@@ -153,6 +153,26 @@ describe('compactDraft', () => {
   });
 });
 
+describe('each projector keeps only ITS OWN columns out of the extras spread', () => {
+  it('a message carrying a tool-supplied `modifiedAt` keeps it', async () => {
+    // `modifiedAt` is a DRAFT column. With one shared key set it was swallowed
+    // here, silently contradicting the "kept wholesale" promise for anything a
+    // tool adds on top of the row.
+    const out = compactMessage({ ...row(), modifiedAt: '2026-01-01T00:00:00Z' } as never);
+    expect(out.modifiedAt).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('a draft carrying a tool-supplied `folder` keeps it', () => {
+    const draft = {
+      id: 1, subject: 's', body: 'b', recipients: [], replyToId: null, modifiedAt: 'x',
+      listData: {}, folder: 'drafts', sentAt: 'y',
+    } as never;
+    const out = compactDraft(draft);
+    expect(out.folder).toBe('drafts');
+    expect(out.sentAt).toBe('y');
+  });
+});
+
 describe('the view selector', () => {
   it('offers compact and full, and NOT raw', () => {
     // A message row is assembled from the list endpoint and the detail GET,


### PR DESCRIPTION
Both nits from the auto-review of #276, which auto-merged on a `warn` verdict before they could be addressed there. Checked against `cbaea24`, the commit the checklist was generated from — neither was already fixed.

## 1. Two sender key names in one tool's compact rung

`ofw_get_message` routes draft ids through a synthesised record. That path dropped `listData` on compact but still emitted `fromUser: ''`, while every other compact record names the sender `from`. So the *same tool's* compact rung used a different key depending on whether the id happened to be a draft — the worst kind of inconsistency, because it only shows up on the branch a caller doesn't control.

It emits `from: null` there now. **Null rather than `''`** because a draft is unsent: there is no sender, and an empty string reads as a sender whose name we failed to find — which is the distinction the promotion existed to fix in the first place.

## 2. `ROW_KEYS` was the union of two shapes

One set covering `MessageRow` *and* `DraftRow` columns, shared by both projectors. The spread that adds tool-supplied extras filtered against that union, so each projector silently swallowed anything named after the **other** shape's column — a message carrying `modifiedAt`, a draft carrying `folder` or `sentAt`.

Nothing supplies those today, which is exactly what makes it the kind of trap only found once something does. It also quietly contradicted the docstring's promise that tool-supplied fields — `attachments`, `revision`, `cacheStatus`, `serverConfirmed`, `freshness` — are "kept wholesale", which is load-bearing: `revision` and `draftKey` are the concurrency token and the stable identity, and a projector that can drop one breaks every guarded write.

Two sets now, `MESSAGE_ROW_KEYS` and `DRAFT_ROW_KEYS`, each listing only the columns its own projector names explicitly, with a test each.

## Tests

920 passing, 100% statements / branches / functions / lines. Three tests touched: two new (a message keeping a tool-supplied `modifiedAt`, a draft keeping `folder`/`sentAt`), and the draft-routing test now asserts `from: null` with no `fromUser` key.

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiLLBREAJYF1DCDeg8Kuw7