### PR TITLE
fix(manifest): three registered tools were missing from the mcpb roster

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -190,6 +190,18 @@
     {
       "name": "ofw_create_journal_entry",
       "description": "Create a journal entry"
+    },
+    {
+      "name": "ofw_healthcheck",
+      "description": "Report whether the OFW credential resolved and the API accepted it, and what to fix if not"
+    },
+    {
+      "name": "ofw_check_freshness",
+      "description": "Cheaply re-verify message/draft ids against OFW — live lifecycle state and content-hash comparison, no bodies fetched"
+    },
+    {
+      "name": "ofw_status",
+      "description": "Server-verified draft inventory and live lifecycle state for given ids or draft keys, in one round trip"
     }
   ],
   "compatibility": {

--- a/tests/manifest-roster.test.ts
+++ b/tests/manifest-roster.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerHealthcheckTools } from '../src/tools/healthcheck.js';
+import { registerUserTools } from '../src/tools/user.js';
+import { registerMessageTools } from '../src/tools/messages.js';
+import { registerCalendarTools } from '../src/tools/calendar.js';
+import { registerExpenseTools } from '../src/tools/expenses.js';
+import { registerJournalTools } from '../src/tools/journal.js';
+import { NodeAttachmentIO } from '../src/tools/attachments.js';
+import type { CacheStore } from '../src/cache/store.js';
+import type { OFWClient } from '../src/client.js';
+
+/**
+ * `manifest.json`'s tool roster must equal the REGISTERED roster, both ways.
+ *
+ * This is the file an mcpb host reads to decide what to show. A tool missing
+ * from it is callable by name and invisible in the UI; a tool listed but not
+ * registered is advertised and then fails. Neither breaks a test, breaks the
+ * build, or breaks the server — nothing else in this repo reads the file — so
+ * the drift is silent in both directions and only a user notices.
+ *
+ * It had drifted: `ofw_check_freshness` and `ofw_status` were registered and
+ * absent from the manifest. `ofw_status` is the call the whole "verify rather
+ * than recite" design rests on (see CLAUDE.md), so it was exactly the wrong
+ * one to hide.
+ *
+ * The roster is read by REGISTERING, not by scanning source. A grep for
+ * `registerTool('name'` misses a name on a continuation line, a name that is a
+ * loop variable, and a tool registered through a shared helper — all three
+ * occur across this fleet.
+ */
+const manifest = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../manifest.json', import.meta.url)), 'utf8'),
+) as { tools: { name: string; description?: string }[] };
+
+function registeredToolNames(): string[] {
+  const names: string[] = [];
+  const server = { registerTool: (name: string) => void names.push(name) } as unknown as McpServer;
+  const client = {} as OFWClient;
+  // Neither the cache nor the attachment IO is touched by registration — the
+  // handlers are never invoked here — so a stub keeps the test off the disk.
+  const cacheProvider = (): CacheStore => ({}) as CacheStore;
+  registerHealthcheckTools(server, client);
+  registerUserTools(server, client);
+  registerMessageTools(server, client, cacheProvider, new NodeAttachmentIO());
+  registerCalendarTools(server, client);
+  registerExpenseTools(server, client);
+  registerJournalTools(server, client);
+  return names;
+}
+
+describe('manifest.json tool roster', () => {
+  // Registration is gated by OFW_WRITE_MODE, and the manifest describes the
+  // full surface — so the comparison has to be made in the mode that registers
+  // everything, or the test would "pass" by hiding the write tools too.
+  const saved = process.env.OFW_WRITE_MODE;
+  beforeAll(() => {
+    process.env.OFW_WRITE_MODE = 'all';
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env.OFW_WRITE_MODE;
+    else process.env.OFW_WRITE_MODE = saved;
+  });
+
+  it('lists every registered tool', () => {
+    const registered = registeredToolNames().sort();
+    const listed = manifest.tools.map((t) => t.name).sort();
+    expect(registered.filter((n) => !listed.includes(n))).toEqual([]);
+  });
+
+  it('lists no tool that is not registered', () => {
+    const registered = registeredToolNames();
+    const listed = manifest.tools.map((t) => t.name).sort();
+    expect(listed.filter((n) => !registered.includes(n))).toEqual([]);
+  });
+
+  it('gives every entry a non-blank description', () => {
+    expect(manifest.tools.filter((t) => !t.description?.trim()).map((t) => t.name)).toEqual([]);
+  });
+});


### PR DESCRIPTION
`manifest.json` is the file an mcpb host reads to decide what to show. It listed **22** tools; the server registers **25**.

Missing: `ofw_check_freshness`, `ofw_healthcheck`, `ofw_status` — callable by name, invisible in the UI.

`ofw_status` is the worst one to have hidden. It is the call the whole "verify rather than recite" design rests on: it exists so that confirming a draft summary costs one round trip and returns an unambiguous answer, removing the incentive to narrate remembered state. A host that never showed it left the cheaper path unavailable.

**Nothing caught this because nothing else reads the file.** The drift breaks no test, no build and no server — in either direction. A tool listed but *not* registered would be advertised and then fail on call, just as quietly.

## The guard

`tests/manifest-roster.test.ts` asserts the two rosters match **both ways**, plus no blank descriptions.

It reads the registered roster by **registering** — a stub server recording names — not by scanning source. That is not incidental: **writing the test found a third missing tool my grep had not.** `ofw_healthcheck` registers through a shared `@chrischall/mcp-utils` helper, so its name never appears as a literal in this repo and `grep "registerTool('ofw_"` cannot see it. A name on a continuation line, and a name that is a loop variable, are invisible the same way — all three shapes occur across this fleet.

Registration is gated by `OFW_WRITE_MODE`, so the test pins it to `all`. The manifest describes the full surface, and comparing in a narrower mode would have "passed" by hiding the write tools too.

## Scope

Found while re-sweeping the fleet skills. **This is not unique to ofw-mcp** — a first pass suggests the same drift in a number of sibling repos, `compass-mcp` confirmed by name-level diff (9 registered tools absent from its manifest, and one listed tool, `compass_get_market_report`, that does not exist in `src/` at all). I have not fixed those here and have not put a number on the fleet-wide total, because the only trustworthy way to count is the registration method above and I have run it on three repos, not sixty.

## Verification

- `npm test` — **923 passed** (was 920; three added). Typecheck runs first and is clean.
- `manifest.json` still parses; `server.json` description length unchanged at 83, inside the registry's 100-char cap.
- No source change — the server's behaviour is identical; only what a host is told about it changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiLLBREAJYF1DCDeg8Kuw7
