### PR TITLE
feat(security): allowlist outbound requests to the OFW host

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ whole suite, so no test can reach the developer's real `~/.ofw-mcp`.
 ```
 src/
   index.ts          MCP server entry — SQLite-warning shim, then runMcp() from @chrischall/mcp-utils (builds McpServer, applies registrars with client as deps, prints banner, wires shutdown + stdio transport)
-  protocol.ts       Wire-level constants (BASE_URL, OFW_PROTOCOL_HEADERS, token TTL). Leaf module to break the client→auth→auth-password import cycle
+  protocol.ts       Wire-level constants (BASE_URL, OFW_PROTOCOL_HEADERS, token TTL) + assertOfwUrl() egress allowlist. Leaf module to break the client→auth→auth-password import cycle
   client.ts         OFWClient (Bearer token, 401/429 retry, JSON + binary). Delegates auth to ./auth.ts
   auth.ts           resolveAuth(): three-path priority (env vars → fetchproxy fallback → error). Template for sibling MCPs
   auth-password.ts  loginWithPassword(): legacy OFW Spring Security form login (kept as own module so auth.ts can mock it cleanly)

--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ By default nothing changes: reads behave exactly as they always have. Two contro
 
 Calendar events sit between the two message tiers: they have no draft stage (a created event is immediately visible on the shared record), but unlike a sent message they are reversible — an event can be edited or deleted afterward. If you run in `drafts` mode but are comfortable with direct calendar writes, set `OFW_CALENDAR_WRITES=true` to additionally register `ofw_create_event`, `ofw_update_event`, and `ofw_delete_event`. The flag is redundant in `all` mode and never overrides `none`.
 
+### Egress allowlist
+
+Every outbound request passes its constructed URL through a host check before `fetch` — the server refuses to contact any host other than `ofw.ourfamilywizard.com`. Today it always passes, and that is the point: it makes "this server only ever talks to OFW" a structural invariant rather than a code-review promise, so a later refactor or a compromised dependency that pointed a request elsewhere throws instead of carrying your bearer token or messages off-host. It is a pre-flight check on the URL we build, not a redirect-following egress filter.
+
 ## Troubleshooting
 
 **"0 messages"** — Claude may have read the notification counts rather than the actual messages. Ask explicitly: *"List the messages in my OFW inbox"* or *"Use ofw_list_message_folders then ofw_list_messages"*.
@@ -271,6 +275,7 @@ Calendar events sit between the two message tiers: they have no draft stage (a c
 - They are passed to the server as environment variables and never logged
 - The server authenticates with OFW using the same login flow as the web app
 - Use a strong, unique OFW password
+- Outbound requests are host-allowlisted to `ofw.ourfamilywizard.com` (see [Egress allowlist](#egress-allowlist))
 
 ## Development
 

--- a/src/auth-password.ts
+++ b/src/auth-password.ts
@@ -10,7 +10,7 @@
 // `resolveAuth()` in `./auth.ts` can call it without a Client instance, and
 // so tests can mock it at the module boundary.
 
-import { BASE_URL, OFW_PROTOCOL_HEADERS, OFW_TOKEN_TTL_MS } from './protocol.js';
+import { BASE_URL, OFW_PROTOCOL_HEADERS, OFW_TOKEN_TTL_MS, assertOfwUrl } from './protocol.js';
 
 interface LoginResponse {
   auth: string;
@@ -27,7 +27,9 @@ export async function loginWithPassword(
   password: string,
 ): Promise<PasswordLoginResult> {
   // Step 1: get a SESSION cookie (Spring Security refuses the POST without it).
-  const initResponse = await fetch(`${BASE_URL}/ofw/login.form`, {
+  const initUrl = `${BASE_URL}/ofw/login.form`;
+  assertOfwUrl(initUrl);
+  const initResponse = await fetch(initUrl, {
     headers: { ...OFW_PROTOCOL_HEADERS },
     redirect: 'manual',
   });
@@ -40,7 +42,9 @@ export async function loginWithPassword(
     .join('; ');
 
   // Step 2: submit the form.
-  const response = await fetch(`${BASE_URL}/ofw/login`, {
+  const loginUrl = `${BASE_URL}/ofw/login`;
+  assertOfwUrl(loginUrl);
+  const response = await fetch(loginUrl, {
     method: 'POST',
     headers: {
       ...OFW_PROTOCOL_HEADERS,

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { resolveAuth, type ResolvedAuth } from './auth.js';
 import { createSessionCache, reportCacheWriteFailure } from './session-cache.js';
-import { BASE_URL, OFW_PROTOCOL_HEADERS, OFW_TOKEN_TTL_MS, OFW_TOKEN_EXPIRY_SKEW_MS } from './protocol.js';
+import { BASE_URL, OFW_PROTOCOL_HEADERS, OFW_TOKEN_TTL_MS, OFW_TOKEN_EXPIRY_SKEW_MS, assertOfwUrl } from './protocol.js';
 
 // Load .env for local dev; silently skip if dotenv is unavailable (e.g. mcpb
 // bundle). loadDotenvSafely applies override:false + quiet:true and swallows a
@@ -196,6 +196,9 @@ export class OFWClient {
     if (body !== undefined && !isFormData) headers['Content-Type'] = 'application/json';
 
     const url = `${BASE_URL}${path}`;
+    // Egress allowlist — checked before the debug log, so a URL we refuse is
+    // never announced as outgoing.
+    assertOfwUrl(url);
     if (debugLogEnabled()) {
       const bodyPreview = body === undefined
         ? '<none>'

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -19,3 +19,41 @@ export const OFW_TOKEN_TTL_MS = 6 * 60 * 60 * 1000;
 // How early we treat a token as expiring. Re-auth before this skew so a
 // long-running request doesn't get a stale token mid-flight.
 export const OFW_TOKEN_EXPIRY_SKEW_MS = 5 * 60 * 1000;
+
+// The only host this server is ever allowed to contact. Derived from BASE_URL
+// so the two cannot drift.
+const ALLOWED_HOST = new URL(BASE_URL).host;
+
+/**
+ * Enforced egress allowlist: every outbound request passes its
+ * fully-constructed URL through here before `fetch` (API calls in client.ts,
+ * the form login in auth-password.ts).
+ *
+ * Today this always passes, and that is the point. Every URL is
+ * `${BASE_URL}${path}` with a path that begins with '/', so no id or query
+ * value interpolated into a path can move the host — an '@' can never land in
+ * the authority component when a '/' already precedes it. The check exists so
+ * that stays true after a future refactor: a code change (or a compromised
+ * dependency) that pointed `fetch` somewhere else would throw here instead of
+ * carrying the bearer token or a message body off-host. It makes "this server
+ * only ever talks to OFW" a structural invariant rather than a code-review
+ * promise.
+ *
+ * Scope, stated honestly: this is a PRE-FLIGHT check on the URL we construct.
+ * It does not follow redirects, so it is not a complete egress control — an
+ * OFW-served 3xx to another host is still followed by `fetch` (which does at
+ * least drop Authorization on a cross-origin redirect, per the fetch spec).
+ */
+export function assertOfwUrl(rawUrl: string): void {
+  let host: string;
+  try {
+    host = new URL(rawUrl).host;
+  } catch {
+    throw new Error(`ofw-mcp: refusing malformed request URL "${rawUrl}"`);
+  }
+  if (host !== ALLOWED_HOST) {
+    throw new Error(
+      `ofw-mcp: refusing request to non-OFW host "${host}" — only ${ALLOWED_HOST} is allowed.`,
+    );
+  }
+}

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { assertOfwUrl, BASE_URL } from '../src/protocol.js';
+
+describe('assertOfwUrl (egress allowlist)', () => {
+  it('allows URLs on the OFW host', () => {
+    expect(() => assertOfwUrl(`${BASE_URL}/pub/v3/messages`)).not.toThrow();
+    expect(() => assertOfwUrl(`${BASE_URL}/ofw/login`)).not.toThrow();
+  });
+
+  it('rejects any other host', () => {
+    expect(() => assertOfwUrl('https://evil.com/steal')).toThrow(/non-OFW host "evil\.com"/);
+  });
+
+  it('rejects an authority that only looks like OFW', () => {
+    // `…ourfamilywizard.com@evil.com` parses with host evil.com. The current
+    // call sites cannot produce this — every path begins with '/', so the '@'
+    // can never reach the authority — which is exactly the invariant this
+    // guard is here to keep true through a later refactor.
+    expect(() => assertOfwUrl('https://ofw.ourfamilywizard.com@evil.com/x'))
+      .toThrow(/non-OFW host "evil\.com"/);
+    expect(() => assertOfwUrl('https://ofw.ourfamilywizard.com.evil.com/x'))
+      .toThrow(/non-OFW host "ofw\.ourfamilywizard\.com\.evil\.com"/);
+  });
+
+  it('rejects a malformed URL', () => {
+    expect(() => assertOfwUrl('not a url')).toThrow(/malformed request URL/);
+  });
+});


### PR DESCRIPTION
Ports the egress-allowlist half of #175 onto current `main`, with credit to @Cache8063 (`Co-authored-by` on the commit). #175 bundled it with a breaking flip of the `OFW_WRITE_MODE` default; that half isn't being taken (reasoning on that PR). This is the half worth keeping, and nothing equivalent exists in `src/` today.

## What lands

`assertOfwUrl()` in `src/protocol.ts` — derived from `BASE_URL` so the two can't drift — wired into all three outbound `fetch` sites:

- `src/client.ts` — every API call, checked **before** the `OFW_DEBUG_LOG` line so a URL we refuse is never announced as outgoing.
- `src/auth-password.ts` — both legs of the Spring Security form login.

Any host other than `ofw.ourfamilywizard.com` throws, as does a URL that won't parse.

## Why, stated honestly

Today the check always passes. Every URL is `${BASE_URL}${path}` with a path that begins with `/`, so no interpolated id can move the host — an `@` can never reach the authority component when a `/` already precedes it. **That is the point**: the guard makes "this server only ever talks to OFW" a structural invariant rather than a code-review promise, so a later refactor or a compromised dependency that pointed `fetch` elsewhere throws instead of carrying the bearer token or a message body off-host.

Two claims from #175 I deliberately did **not** carry into the docs:

- The userinfo-splice attack it described can't arise from the current call sites (see above). The test for it stays, framed as the invariant it protects rather than a live hole.
- This is a **pre-flight check on the URL we construct, not a redirect-following egress filter**. `fetch` still follows an OFW-served 3xx to another host (it does at least drop `Authorization` cross-origin, per the fetch spec). The docstring and README both say so.

## Verification

- `npm test` — 927/927, typecheck clean.
- `npm run test:coverage` — 100% statements/branches/functions/lines, gate intact.
- `npm run build` — clean.

## Docs

README gets an **Egress allowlist** section plus a Security bullet; `CLAUDE.md`'s architecture line for `protocol.ts` names the export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pxFAy1Jq8hbYrk8XaoWhe