### PR TITLE
ci: sync the dependabot, release and release-please-config stubs from chrischall/workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# Thin config — the fleet-wide shape lives in chrischall/workflows.
+# Renders to: .github/dependabot.yml
+# Regenerate with: scripts/rollout.sh <owner/repo> --execute --only dependabot
 version: 2
 updates:
   - package-ecosystem: npm
@@ -6,9 +9,32 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
+      # Dependabot does NOT hand a dependency to the first group that matches
+      # it. `PatternSpecificityCalculator` scores every matching group and the
+      # highest score wins:
+      #
+      #   exact `pattern == name`      1000   (EXACT_MATCH_SCORE)
+      #   group with NO `patterns` key  500   (NO_PATTERNS_SCORE)
+      #   pattern with no wildcard      500
+      #   wildcard   100 - 10*wildcards + max(len-5, 0)
+      #
+      # so "@vitest/*" scores 94 and loses @vitest/coverage-v8 to the
+      # dev-dependencies group below, which declares no patterns at all and
+      # therefore scores 500. On a MAJOR bump dev-dependencies cannot take it
+      # either (minor/patch only), so it falls out of every group into a PR of
+      # its own — and since vitest and its coverage provider peer-depend on
+      # each other at an EXACT version, the two halves apart are unsatisfiable:
+      # both PRs die on `npm ci` ERESOLVE and sit red with auto-merge armed
+      # until someone pushes the pair by hand. That cost 19 repos on
+      # 2026-09-07 and vibo-mcp #110/#113 the day after.
+      #
+      # Listing the exact name scores 1000, which is >= EXPLICIT_MEMBER_SCORE
+      # and short-circuits the comparison, so nothing can outbid it. The
+      # wildcard stays for any future @vitest/… package.
       vitest:
         patterns:
           - "vitest"
+          - "@vitest/coverage-v8"
           - "@vitest/*"
         update-types:
           - major

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,65 @@
+# Thin config — the fleet-wide shape lives in chrischall/workflows.
+# Renders to: .github/release.yml
+# Regenerate with: scripts/rollout.sh <owner/repo> --execute --only release
+# (--only names the DESTINATION basename, `.github/release.yml` -> `release`,
+#  not this template's filename.)
+#
+# Configuration for GitHub's auto-generated release notes. Honored by
+# softprops/action-gh-release when generate_release_notes: true, and by the
+# GitHub web UI when drafting release notes.
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes/automatically-generated-release-notes#configuration-options
+#
+# Only PRs merged into the default branch appear in release notes — direct
+# pushes to main are not listed. Apply one of the labels below to every PR so
+# it lands in the right section.
+#
+# This is the LABEL-driven view of a release, and it is a different axis from
+# release-please-config.json's `changelog-sections`, which is COMMIT-TYPE
+# driven and decides the version bump. A dependency bump on a package we own
+# ships a real fix or feature through us, so it belongs under Features or Bug
+# Fixes with `enhancement`/`bug` — not under Dependencies, which is for
+# third-party bumps that ship nothing.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+      - dependabot[bot]
+      - github-actions
+      - github-actions[bot]
+  categories:
+    # `enhancement` and `bug` only: `feature`/`fix` were aliases for them and
+    # existed in 2 of 81 repos, so the categories they fed matched almost
+    # nothing. Two names for one meaning is a choice point with no benefit,
+    # and a first-party dependency bump belongs here under `enhancement`/`bug`
+    # rather than under Dependencies, which is for third-party bumps that ship
+    # nothing.
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Security
+      labels:
+        - security
+    - title: Refactor
+      labels:
+        - refactor
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Tests
+      labels:
+        - test
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: CI & Build
+      labels:
+        - ci
+        - github_actions
+    - title: Other Changes
+      labels:
+        - "*"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,29 +4,87 @@
     ".": {
       "package-name": "ofw-mcp",
       "release-type": "node",
-      "include-v-in-tag": true,
-      "include-component-in-tag": false,
       "changelog-sections": [
-        { "type": "feat", "section": "Features" },
-        { "type": "fix", "section": "Bug Fixes" },
-        { "type": "perf", "section": "Performance" },
-        { "type": "revert", "section": "Reverts" },
-        { "type": "refactor", "section": "Refactor" },
-        { "type": "docs", "section": "Documentation" },
-        { "type": "test", "section": "Tests", "hidden": true },
-        { "type": "build", "section": "Build", "hidden": true },
-        { "type": "ci", "section": "CI", "hidden": true },
-        { "type": "chore", "section": "Chores", "hidden": true }
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "refactor",
+          "section": "Refactor"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "test",
+          "section": "Tests",
+          "hidden": true
+        },
+        {
+          "type": "build",
+          "section": "Build",
+          "hidden": true
+        },
+        {
+          "type": "ci",
+          "section": "CI",
+          "hidden": true
+        },
+        {
+          "type": "chore",
+          "section": "Chores",
+          "hidden": true
+        }
       ],
       "extra-files": [
-        { "type": "json", "path": "manifest.json", "jsonpath": "$.version" },
-        { "type": "json", "path": "server.json", "jsonpath": "$.version" },
-        { "type": "json", "path": "server.json", "jsonpath": "$.packages[*].version" },
-        { "type": "json", "path": ".claude-plugin/plugin.json", "jsonpath": "$.version" },
-        { "type": "json", "path": ".claude-plugin/marketplace.json", "jsonpath": "$.plugins[*].version" },
-        { "type": "json", "path": ".claude-plugin/marketplace.json", "jsonpath": "$.metadata.version" },
+        {
+          "type": "json",
+          "path": "manifest.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[*].version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/marketplace.json",
+          "jsonpath": "$.plugins[*].version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/marketplace.json",
+          "jsonpath": "$.metadata.version"
+        },
         "src/index.ts"
-      ]
+      ],
+      "include-v-in-tag": true,
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
Multi-stub sync: regenerates these from fleet.json and the current templates. Other files are untouched.

- `.github/dependabot.yml`
- `.github/release.yml`
- `release-please-config.json`

## Why this change

Dependabot does not hand a dependency to the first group that matches it — `PatternSpecificityCalculator` scores every matching group and the highest wins. `"@vitest/*"` scores 94 and loses `@vitest/coverage-v8` to the pattern-less `dev-dependencies` group (500); on a MAJOR bump that group cannot take it either, so it escapes into its own PR. vitest and its coverage provider peer-depend at an exact version, so the halves apart are unsatisfiable: both PRs fail `npm ci` with ERESOLVE and sit red with auto-merge armed until someone pushes the pair by hand. That cost 19 repos on 2026-09-07 and vibo-mcp #110/#113 the day after.

These three files were previously untemplated, so nothing rendered them and `--check` never saw them: `.github/dependabot.yml` had drifted into 17 variants across 72 repos, `release-please-config.json` into 78 unique copies among 79 (8 with no `changelog-sections` at all), and `.github/release.yml` was missing from 45 repos entirely.

Verified before rolling (chrischall/workflows#236, #239, #241): across the fleet the only semantic `dependabot.yml` change is the added `@vitest/coverage-v8` line, with zero `ignore` entries lost; `release-please-config.json` renders semantically identical for 57 of 60 repos and the other three only gain a `revert` changelog section. The canonical labels `.github/release.yml` categorises by were applied to all 81 repos first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
