### PR TITLE
ci: sync the dependabot stub from chrischall/workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,19 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    # Dependabot INFERS a commit prefix from recent history when this is unset,
+    # which is why the fleet drifted into `chore(deps)`, `build(deps-dev)` and
+    # `fix(deps)` with no config anywhere. Setting it makes the release
+    # behaviour deterministic instead of a property of a repo's git log.
+    #
+    # `fix` for runtime dependencies, so a bump that changes what SHIPS cuts a
+    # patch release and reaches consumers. `chore` for dev dependencies, which
+    # ship nothing and stay out of the changelog. release-please reads the
+    # squash subject, and the squash subject is this.
+    commit-message:
+      prefix: "fix"
+      prefix-development: "chore"
+      include: "scope"
     groups:
       # Dependabot does NOT hand a dependency to the first group that matches
       # it. `PatternSpecificityCalculator` scores every matching group and the
@@ -56,6 +69,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # `ci`, not `fix`: an action version ships nothing to a consumer, so it
+    # belongs in the hidden CI section rather than cutting a patch release.
+    commit-message:
+      prefix: "ci"
+      include: "scope"
     groups:
       actions:
         update-types:


### PR DESCRIPTION
Single-stub sync: regenerates `.github/dependabot.yml` from fleet.json and the current template. Other files are untouched.

## Why this change

Dependabot had no `commit-message` config, so it INFERRED a commit prefix from each repo's recent history. That is why the fleet was running `chore(deps)`, `build(deps-dev)` and `fix(deps)` simultaneously with no config anywhere — unset was never neutral.

It also meant a bump to a RUNTIME dependency never reached a consumer: dependabot titled it `chore(deps)`, `chore` is a hidden type, release-please cut nothing, and the fix sat on main looking done. The squash subject is the release decision, and on a dependabot PR the squash subject is its title.

Now explicit, per ecosystem:

  npm / gradle    prefix: fix           a runtime bump cuts a PATCH RELEASE
                  prefix-development: chore — dev deps ship nothing, stay hidden
  github-actions  prefix: ci            an action version ships nothing to a
                                        consumer, so it stays hidden rather than
                                        cutting a release

Tested in chrischall/workflows (case DD), including the contract that every prefix chosen is a type `release-please-config.json` actually declares — a prefix outside that list is invisible to release-please rather than merely hidden (chrischall/workflows#259).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
