### PR TITLE
fix(deps): @chrischall/mcp-utils 0.26.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.16.0",
       "license": "MIT",
       "dependencies": {
-        "@chrischall/mcp-utils": "^0.23.3",
+        "@chrischall/mcp-utils": "^0.26.1",
         "@fetchproxy/bootstrap": "^2.2.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
@@ -90,16 +90,16 @@
       }
     },
     "node_modules/@chrischall/mcp-utils": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.23.3.tgz",
-      "integrity": "sha512-gmcfsJmRYOTVzutAm6hZ/d92qaZGcviRD9JHg8BxuaUfNUES7U+DNZhGh0NKiLu3uv6AZ2USvultIBfz/PR4cw==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@chrischall/mcp-utils/-/mcp-utils-0.26.1.tgz",
+      "integrity": "sha512-Hvaoq8ncaqFMnF4OW0qVDovXoNk8embgV/MoG8ktc4d8rRWJPAZbjm3z+vciQJn+9U5eTpnLswrmo/0bYr5vqQ==",
       "license": "MIT",
       "peerDependencies": {
         "@fetchproxy/server": "*",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "node-html-parser": "*",
         "vitest": "*",
-        "zod": "^4.4.0"
+        "zod": "^4.5.4"
       },
       "peerDependenciesMeta": {
         "@fetchproxy/server": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@chrischall/mcp-utils": "^0.23.3",
+    "@chrischall/mcp-utils": "^0.26.1",
     "@fetchproxy/bootstrap": "^2.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
Part of a fleet-wide first-party dependency rollout.

## @chrischall/mcp-utils 0.26.1

0.26.1 fixes a healthcheck that could contradict itself: `classifyThrown` set `error.kind`, but the hint printed beside it still came from the arm derived from the HTTP status, which never moved. A connector whose client throws without a status reported `kind: "credential_rejected"` next to "Unexpected failure — see error.message", leaving its own copy unreachable.

0.24–0.26 also stopped the fetchproxy boot banner claiming to listen on a port nothing had bound yet, and added `sessionProbe` / `sessionClassifier` for connectors whose upstream answers a dead session with a login page served 200. Neither helper is adopted here.



## Verified

Cut fresh off `origin/main`, then this repo's own typecheck and full suite run against the real published versions before the commit was made. A branch that passed when it was cut is not evidence it still passes on today's main, so anything that moved was re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVs1XcfAyERqJSXnoBQZBq