### PR TITLE
fix(deps): declare the peer floors mcp-utils 0.26.1 requires

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@chrischall/mcp-utils": "^0.26.1",
         "@fetchproxy/bootstrap": "^2.2.0",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "dotenv": "^17.4.2",
-        "zod": "^4.4.3"
+        "zod": "^4.5.4"
       },
       "bin": {
         "ofw-mcp": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "dependencies": {
     "@chrischall/mcp-utils": "^0.26.1",
     "@fetchproxy/bootstrap": "^2.2.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "dotenv": "^17.4.2",
-    "zod": "^4.4.3"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@types/node": "^26.0.0",


### PR DESCRIPTION
Follow-up to the mcp-utils 0.26.1 bump, which moved the dependency without moving the peers it asks for.

`@chrischall/mcp-utils@0.26.1` peers on `@modelcontextprotocol/sdk ^1.30.0` and `zod ^4.5.4`. This repo declared `^1.29.0` and `^4.4.3`.

## Why the bump passed anyway

npm resolved versions satisfying BOTH the stale caret and the peer, so the installed tree was correct, the typecheck passed and the suite passed. Only the **declared floor** was wrong, and nothing that runs code can see that — `^1.29.0` admits 1.29.4, which mcp-utils refuses, and today's resolve picking 1.30.0 is luck a fresh resolve need not repeat.

Twelve auto-reviews across the fleet caught this; forty-nine repos, this one included, merged it silently. The verdicts were right.

## Not just this repo

Every repo depending on mcp-utils had it — 61 of them. There is now a `fleet-peers.mjs` checker that tests SUBSET (every version a declaration admits must be one the peer accepts) rather than the obvious "does the installed version satisfy the peer?", which would have passed all 61 on the day this happened.

Typecheck and the full suite pass on the corrected floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVs1XcfAyERqJSXnoBQZBq