### PR TITLE
ci: sync the auto-merge stub from chrischall/workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,5 +18,12 @@ concurrency:
 jobs:
   arm:
     uses: chrischall/workflows/.github/workflows/reusable-auto-merge.yml@main
+    with:
+      # Empty renders as false: the reusable declares `default: false`, and an
+      # empty string is not `true`. So every repo that has not opted in keeps
+      # today's behaviour, and the line is inert until fleet.json says
+      # otherwise. Recorded there rather than hand-edited into a stub, because
+      # a hand-edit is silently reverted by the next `--execute` (#76).
+      sanitize_release_message: true
     secrets:
       release_pat: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
Single-stub sync: regenerates `.github/workflows/auto-merge.yml` from fleet.json and the current template. Other files are untouched.

## Why this change

Enable sanitize_release_message (#266) before the @fetchproxy/bootstrap 2.11.2 fix(deps) bumps land, so an unparseable dependabot body cannot silently drop the bump from the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
